### PR TITLE
Decoupling of display-resize and simulation-resize

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/physics/InitialConditions.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/InitialConditions.java
@@ -60,15 +60,15 @@ public class InitialConditions {
 		return s;
 	}
 	
-	public static Simulation initRandomParticles(int count, int radius) {
+	public static Simulation initRandomParticles(int count, double radius) {
 		
 		Simulation s = new Simulation();
 		
 		//basic simulation parameters
 		s.tstep = 1;
 		s.c = 3;
-		s.width = 700;
-		s.height = 500;
+		s.width = 100;
+		s.height = 100;
 		
 		//external forces
 		s.f.clear();
@@ -87,7 +87,7 @@ public class InitialConditions {
 		return s;
 	}
 	
-	public static Simulation initGravity(int count, int radius) {
+	public static Simulation initGravity(int count, double radius) {
 
 		Simulation s = new Simulation();
 		
@@ -115,7 +115,7 @@ public class InitialConditions {
 		return s;
 	}
 
-	public static Simulation initElectric(int count, int radius) {
+	public static Simulation initElectric(int count, double radius) {
 
 		Simulation s = new Simulation();
 		
@@ -143,7 +143,7 @@ public class InitialConditions {
 		return s;
 	}
 
-	public static Simulation initMagnetic(int count, int radius) {
+	public static Simulation initMagnetic(int count, double radius) {
 
 		Simulation s = new Simulation();
 		
@@ -171,7 +171,7 @@ public class InitialConditions {
 		return s;
 	}
 
-	public static Simulation initSpring(int count, int radius) {
+	public static Simulation initSpring(int count, double radius) {
 		
 		Simulation s = new Simulation();
 		

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
@@ -443,9 +443,6 @@ public class MainControlApplet extends JApplet {
 		particlePanel = new Particle2DPanel();
 		linkConstantForce();
 
-		this.setVisible(true);
-		this.setSize(1000, 500);
-
 		startButton = new JButton("start");
 		stopButton = new JButton("stop");
 		resetButton = new JButton("reset");
@@ -822,6 +819,7 @@ public class MainControlApplet extends JApplet {
 		web.pack();
 		web.setVisible(true);
 		web.setSize(1000, 500);
+		web.setResizable(true);
 
 		applet.init();
 	}


### PR DESCRIPTION
This decouples the resize of the gui-window from the resize of the simulation by introducing scaling variables sx and sy.

Previously the particle radius was used directly to display the particles, therefore this quantity needed to be set accordingly to the window size and the number of particles. This has been removed, the simulation now determines automatically what size should be displayed according to the total number of particles.

I have not thought much about performance or functionality because obviously we will have to rewrite big parts of the display method (look at all those ifs and the arrow display, all of this is also not compatible with the actual arrangment of fields on the grid) anyway.
