### PR TITLE
Repaired hardwall boundaries.

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/physics/movement/BoundingBox.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/movement/BoundingBox.java
@@ -7,10 +7,7 @@ public class BoundingBox {
 	private double ymax;
 
 	public BoundingBox(double xmin, double xmax, double ymin, double ymax) {
-		this.xmin = xmin;
-		this.xmax = xmax;
-		this.ymin = ymin;
-		this.ymax = ymax;
+		set(xmin, xmax, ymin, ymax);
 	}
 
 	public double xmin() {
@@ -35,5 +32,12 @@ public class BoundingBox {
 
 	public double ysize() {
 		return ymax - ymin;
+	}
+
+	public void set(double xmin, double xmax, double ymin, double ymax) {
+		this.xmin = xmin;
+		this.xmax = xmax;
+		this.ymin = ymin;
+		this.ymax = ymax;
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/movement/boundary/BoundaryRegionDecomposition.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/movement/boundary/BoundaryRegionDecomposition.java
@@ -26,21 +26,27 @@ public class BoundaryRegionDecomposition {
 		this.simulationArea = simulationArea;
 	}
 
-	public int getRegion(double x, double y) {
+
+	/**
+	 * We do not get the region based on position but a whole box.
+	 * This way we are more flexible
+	 * - we can check particle's circumference to be in a boundary region.
+	 */
+	public int getRegion(BoundingBox particleBox) {
 		int xidx;
 		int yidx;
 
-		if (x < simulationArea.xmin()) {
+		if (particleBox.xmin() < simulationArea.xmin()) {
 			xidx  = XMIN;
-		} else if (x >= simulationArea.xmax()) {
+		} else if (particleBox.xmax() >= simulationArea.xmax()) {
 			xidx = XMAX;
 		} else {
 			xidx = XCENTER;
 		}
 
-		if (y < simulationArea.ymin()) {
+		if (particleBox.ymin() < simulationArea.ymin()) {
 			yidx = YMIN;
-		} else if (y >= simulationArea.ymax()) {
+		} else if (particleBox.ymax() >= simulationArea.ymax()) {
 			yidx = YMAX;
 		} else {
 			yidx = YCENTER;

--- a/pixi/src/main/java/org/openpixi/pixi/physics/movement/boundary/ParticleBoundaryType.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/movement/boundary/ParticleBoundaryType.java
@@ -1,5 +1,8 @@
 package org.openpixi.pixi.physics.movement.boundary;
 
+import org.openpixi.pixi.physics.Particle;
+import org.openpixi.pixi.physics.movement.BoundingBox;
+
 /**
  * Determines the type of particle boundary.
  */
@@ -10,6 +13,14 @@ public enum ParticleBoundaryType {
 		public ParticleBoundary createBoundary(double xoffset, double yoffset) {
 			return new HardwallBoundary(xoffset, yoffset);
 		}
+
+		@Override
+		public BoundingBox getParticleBoundingBox(Particle p, BoundingBox pbb) {
+			pbb.set(
+					p.getX() - p.getRadius(), p.getX() + p.getRadius(),
+					p.getY() - p.getRadius(), p.getY() + p.getRadius());
+			return pbb;
+		}
 	},
 
 	Periodic {
@@ -17,7 +28,20 @@ public enum ParticleBoundaryType {
 		public ParticleBoundary createBoundary(double xoffset, double yoffset) {
 			return new PeriodicBoundary(xoffset, yoffset);
 		}
+
+		@Override
+		public BoundingBox getParticleBoundingBox(Particle p, BoundingBox pbb) {
+			pbb.set(p.getX(), p.getX(), p.getY(), p.getY());
+			return pbb;
+		}
 	};
 
 	public abstract ParticleBoundary createBoundary(double xoffset, double yoffset);
+
+	/**
+	 * Determines a bounding box around the particle.
+	 * For the determination of whether the particle is outside of the simulation area
+	 * we use the particle's bounding box.
+	 */
+	public abstract BoundingBox getParticleBoundingBox(Particle p, BoundingBox pbb);
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/movement/boundary/RegionBoundaryMap2D.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/movement/boundary/RegionBoundaryMap2D.java
@@ -11,9 +11,12 @@ public class RegionBoundaryMap2D {
 
 	private BoundaryRegionDecomposition boundaryRegions;
 	private ParticleBoundary[] regionBoundaryMap = new ParticleBoundary[NUM_OF_2D_REGIONS];
+	private ParticleBoundaryType boundaryType;
 
+	private BoundingBox particleBoundingBox = new BoundingBox(0,0,0,0);
 
 	public RegionBoundaryMap2D(BoundingBox sa, ParticleBoundaryType boundaryType) {
+		this.boundaryType = boundaryType;
 		boundaryRegions = new BoundaryRegionDecomposition(sa);
 
 		regionBoundaryMap[BoundaryRegionDecomposition.XMIN + BoundaryRegionDecomposition.YMIN] =
@@ -38,7 +41,15 @@ public class RegionBoundaryMap2D {
 
 
 	public void apply(Particle p) {
-		int region = boundaryRegions.getRegion(p.getX(), p.getY());
+
+		/*
+		 * Since there can be a large number of particles,
+		 * it is costly to create new bounding box for each particle in each time step;
+		 * thus, we reuse single bounding box.
+		 */
+		boundaryType.getParticleBoundingBox(p, particleBoundingBox);
+
+		int region = boundaryRegions.getRegion(particleBoundingBox);
 		regionBoundaryMap[region].apply(p);
 	}
 }


### PR DESCRIPTION
Hardwall boundaries react now on particle's circumference outside of the simulation area (not on the particle's center being outside).
