### PR TITLE
Fixed GUI s.t. it doesnt enable collision detection during initialization

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
@@ -56,7 +56,6 @@ public class Simulation {
 	public Grid grid;
 	public Detector detector;
 	public CollisionAlgorithm collisionalgorithm;
-	public boolean collisionBoolean = false;
 
 	/**
 	 * We can turn on or off the effect of the grid on particles by
@@ -204,10 +203,10 @@ public class Simulation {
 	 */
 	public void step() {
 		particlePush();
-		if(collisionBoolean) {
-			detector.run();
-			collisionalgorithm.collide(detector.getOverlappedPairs(), f, mover.getSolver(), tstep);
-		}
+			
+		detector.run();
+		collisionalgorithm.collide(detector.getOverlappedPairs(), f, mover.getSolver(), tstep);
+
 		interpolation.interpolateToGrid(particles, grid, tstep);
 		grid.updateGrid(tstep);
 		interpolation.interpolateToParticle(particles, grid);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
@@ -129,11 +129,13 @@ public class MainControlApplet extends JApplet {
 	};
 
 	String[] collisiondetectorString = {
+			"Enable collisions first",
 			"All particles",
 			"Sweep & Prune"
 	};
 
 	String[] collisionalgorithmString = {
+			"Enable collisions first",
 			"Simple collision",
 			"With vectors",
 			"With matrices"
@@ -214,10 +216,17 @@ public class MainControlApplet extends JApplet {
 			particlePanel.collisionChange(i);
 			if(i == 0) {
 				collisionDetector.setEnabled(false);
+				collisionDetector.setSelectedIndex(0);
 				collisionAlgorithm.setEnabled(false);
+				collisionAlgorithm.setSelectedIndex(0);
 			} else {
 				collisionDetector.setEnabled(true);
+				//Index is set to 1 because Particle2DPanel enables AllParticles Detector and
+				//SimpleCollision Algorithm which correspond to index 1 in the list
+				//ALWAYS KEEP THIS IN SYNC WITH THE collisionChange() method in Particle2DPanel
+				collisionDetector.setSelectedIndex(1);
 				collisionAlgorithm.setEnabled(true);
+				collisionAlgorithm.setSelectedIndex(1);
 			}
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/Particle2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/Particle2DPanel.java
@@ -320,12 +320,10 @@ public class Particle2DPanel extends JPanel {
 	public void collisionChange(int i) {
 		switch(i) {
 		case 0:
-			s.collisionBoolean = false;
 			s.detector = new Detector();
 			s.collisionalgorithm = new CollisionAlgorithm();
 			break;
 		case 1:
-			s.collisionBoolean = true;
 			s.detector = new AllParticles(s.particles);
 			s.collisionalgorithm = new SimpleCollision();
 			break;
@@ -335,9 +333,11 @@ public class Particle2DPanel extends JPanel {
 	public void detectorChange(int i) {
 		switch(i) {
 		case 0:
-			s.detector = new AllParticles(s.particles);
 			break;
 		case 1:
+			s.detector = new AllParticles(s.particles);
+			break;
+		case 2:
 			s.detector = new SweepAndPrune(s.particles);
 			break;
 		}
@@ -346,12 +346,14 @@ public class Particle2DPanel extends JPanel {
 	public void algorithmCollisionChange(int i) {
 		switch(i) {
 		case 0:
-			s.collisionalgorithm = new SimpleCollision();
 			break;
 		case 1:
-			s.collisionalgorithm = new VectorTransformation();
+			s.collisionalgorithm = new SimpleCollision();
 			break;
 		case 2:
+			s.collisionalgorithm = new VectorTransformation();
+			break;
+		case 3:
 			s.collisionalgorithm = new MatrixTransformation();
 			break;
 		}


### PR DESCRIPTION
Previously we had a boolean variable in the Simulation class that enabled and disabled collision detection (even though we actually have empty detector classes for that). That also meant that setting a non-empy detector algorithm in the Settings class (for the non-gui version for example) wouldnt actually enable collisions. The boolean in the Simulation class would have had to be changed too.

The boolean was a workaround because without it the GUI always enabled collision detection during initialization. I have fixed it now. The problem was that detectorChange() and algorithmCollisionChange() from Particle2DPanel were called during initialization and these two methods could only set non-empty detector classes.
