### PR TITLE
Fixed GUI s.t. it doesnt enable collision detection during initialization

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
@@ -56,7 +56,6 @@ public class Simulation {
 	public Grid grid;
 	public Detector detector;
 	public CollisionAlgorithm collisionalgorithm;
-	public boolean collisionBoolean = false;
 
 	/**
 	 * We can turn on or off the effect of the grid on particles by
@@ -204,10 +203,10 @@ public class Simulation {
 	 */
 	public void step() {
 		particlePush();
-		if(collisionBoolean) {
-			detector.run();
-			collisionalgorithm.collide(detector.getOverlappedPairs(), f, mover.getSolver(), tstep);
-		}
+
+		detector.run();
+		collisionalgorithm.collide(detector.getOverlappedPairs(), f, mover.getSolver(), tstep);
+
 		interpolation.interpolateToGrid(particles, grid, tstep);
 		grid.updateGrid(tstep);
 		interpolation.interpolateToParticle(particles, grid);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
@@ -82,7 +82,6 @@ public class MainControlApplet extends JApplet {
 	private JComboBox algorithmComboBox;
 	private JCheckBox traceCheck;
 	private JComboBox collisionComboBox;
-	private JComboBox collisionDetector;
 	private JComboBox collisionAlgorithm;
 
 	private JRadioButton hardBoundaries;
@@ -125,10 +124,6 @@ public class MainControlApplet extends JApplet {
 
 	String[] collisionsString = {
 			"No collisions",
-			"Elastic collisions"
-	};
-
-	String[] collisiondetectorString = {
 			"All particles",
 			"Sweep & Prune"
 	};
@@ -213,32 +208,33 @@ public class MainControlApplet extends JApplet {
 			int i = cbox.getSelectedIndex();
 			particlePanel.collisionChange(i);
 			if(i == 0) {
-				collisionDetector.setEnabled(false);
 				collisionAlgorithm.setEnabled(false);
+				collisionAlgorithm.addItem("Enable collisions first");
+				collisionAlgorithm.setSelectedItem("Enable collisions first");
 			} else {
-				collisionDetector.setEnabled(true);
 				collisionAlgorithm.setEnabled(true);
+				//setSelectedIndex() automatically calls collisionAlgorithm.actionPerformed()!
+				collisionAlgorithm.setSelectedIndex(0);
+				collisionAlgorithm.removeItem("Enable collisions first");
 			}
 		}
 	}
 
-	class CollisionDetector implements ActionListener {
-		public void actionPerformed(ActionEvent eve) {
-			JComboBox cbox = (JComboBox) eve.getSource();
-			int i = cbox.getSelectedIndex();
-			particlePanel.detectorChange(i);
-		}
-	}
-
 	class CollisionAlgorithm implements ActionListener {
+		
 		public void actionPerformed(ActionEvent eve) {
 			JComboBox cbox = (JComboBox) eve.getSource();
 			int i = cbox.getSelectedIndex();
-			particlePanel.algorithmCollisionChange(i);
+			int j = collisionComboBox.getSelectedIndex();
+			if (j == 0) {
+				collisionAlgorithm.setSelectedItem("Enable collisions first");
+			} else {
+				particlePanel.algorithmCollisionChange(i);
+			}
 		}
 	}
 
-
+ 
 	/**
 	 * Listener for start button.
 	 */
@@ -584,11 +580,6 @@ public class MainControlApplet extends JApplet {
 		//collisionComboBox.setPreferredSize(new Dimension(collisionComboBox.getPreferredSize().width, 5));
 		JLabel collisionsLabel = new JLabel("Collisions");
 
-		collisionDetector = new JComboBox(collisiondetectorString);
-		collisionDetector.setSelectedIndex(0);
-		collisionDetector.addActionListener(new CollisionDetector());
-		JLabel colDetectorLabel = new JLabel("Detection method");
-
 		collisionAlgorithm = new JComboBox(collisionalgorithmString);
 		collisionAlgorithm.setSelectedIndex(0);
 		collisionAlgorithm.addActionListener(new CollisionAlgorithm());
@@ -597,9 +588,6 @@ public class MainControlApplet extends JApplet {
 		Box collisionBox = Box.createVerticalBox();
 		collisionBox.add(collisionsLabel);
 		collisionBox.add(collisionComboBox);
-		collisionBox.add(Box.createVerticalGlue());
-		collisionBox.add(colDetectorLabel);
-		collisionBox.add(collisionDetector);
 		collisionBox.add(Box.createVerticalGlue());
 		collisionBox.add(colAlgorithmLabel);
 		collisionBox.add(collisionAlgorithm);
@@ -819,10 +807,9 @@ public class MainControlApplet extends JApplet {
 			hardBoundaries.setSelected(false);
 			periodicBoundaries.setSelected(true);
 		}
-		//particlePanel.s.collision.alg = new CollisionAlgorithm();
-		//particlePanel.s.detector = new Detector();
+		
+		//ordering of these two is important!
 		collisionComboBox.setSelectedIndex(0);
-		collisionDetector.setSelectedIndex(0);
 		collisionAlgorithm.setSelectedIndex(0);
 
 		// Set algorithm UI according to current setting

--- a/pixi/src/main/java/org/openpixi/pixi/ui/Particle2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/Particle2DPanel.java
@@ -320,24 +320,13 @@ public class Particle2DPanel extends JPanel {
 	public void collisionChange(int i) {
 		switch(i) {
 		case 0:
-			s.collisionBoolean = false;
 			s.detector = new Detector();
 			s.collisionalgorithm = new CollisionAlgorithm();
 			break;
 		case 1:
-			s.collisionBoolean = true;
-			s.detector = new AllParticles(s.particles);
-			s.collisionalgorithm = new SimpleCollision();
-			break;
-		}
-	}
-
-	public void detectorChange(int i) {
-		switch(i) {
-		case 0:
 			s.detector = new AllParticles(s.particles);
 			break;
-		case 1:
+		case 2:
 			s.detector = new SweepAndPrune(s.particles);
 			break;
 		}


### PR DESCRIPTION
Previously we had a boolean variable in the Simulation class that enabled and disabled collision detection (even though we actually have empty detector classes for that). That also meant that setting a non-empy detector algorithm in the Settings class (for the non-gui version for example) wouldnt actually enable collisions. The boolean in the Simulation class would have had to be changed too.

The boolean was a workaround because without it the GUI always enabled collision detection during initialization. I have fixed it now. The problem was that detectorChange() and algorithmCollisionChange() from Particle2DPanel were called during initialization and these two methods could only set non-empty detector classes.

Furthermore I have combined the enabling and disabling of collisions with the selection of the collision detection method into one dropdown menu.
