### PR TITLE
Fix test failure on Jenkins server

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/physics/util/ClassCopier.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/util/ClassCopier.java
@@ -36,6 +36,14 @@ public class ClassCopier {
 
 	public static <T> void copy(T source, T destination) {
 		for (Field sourceField: source.getClass().getDeclaredFields()) {
+			if (sourceField.getName().equals("serialVersionUID")
+				|| sourceField.getName().equals("$VRc"))
+			{
+				// The fields '$VRc' and 'serialVersionUID'
+				// are added by the EMMA instrumentation framework
+				// and are therefore ignored.
+				break;
+			};
 			try {
 				Field destinationField = destination.getClass().getDeclaredField(sourceField.getName());
 
@@ -45,9 +53,9 @@ public class ClassCopier {
 
 				destinationField.set(destination, sourceField.get(source));
 			} catch (Exception e) {
-			//	e.printStackTrace();
-			//	throw new RuntimeException(e);
-				System.out.println("Skipping field " + sourceField.getName());
+				System.out.println("Exception for field: " + sourceField.getName());
+				e.printStackTrace();
+				throw new RuntimeException(e);
 			}
 		}
 	}


### PR DESCRIPTION
The fields '$VRc' and 'serialVersionUID' are added by the EMMA instrumentation framework.

They cause an java.lang.IllegalAccessException: Can not set static final field org.openpixi.pixi.physics.Settings.$VRc

Therefore, these fields are skipped in the copy routine.
