### PR TITLE
Revert "Initial conditions grid step independent."

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/physics/InitialConditions.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/InitialConditions.java
@@ -26,7 +26,6 @@ import org.openpixi.pixi.physics.particles.ParticleFull;
 import org.openpixi.pixi.physics.solver.EulerRichardson;
 import org.openpixi.pixi.physics.solver.relativistic.BorisRelativistic;
 import org.openpixi.pixi.physics.fields.PoissonSolverFFTPeriodic;
-import org.openpixi.pixi.physics.fields.EmptyPoissonSolver;
 import org.openpixi.pixi.physics.fields.SimpleSolver;
 import org.openpixi.pixi.physics.grid.ChargeConservingCIC;
 
@@ -197,14 +196,14 @@ public class InitialConditions {
     public static Simulation initPair(double charge, double radius) {
 	Settings stt = new Settings();
 
-	stt.setTimeStep(0.1);
+	stt.setTimeStep(1);
 	stt.setSpeedOfLight(1);
 	stt.setRelativistic(true);
 	/*stt.setSimulationWidth(100);
 	stt.setSimulationHeight(100);*/
-	stt.setGridStep(0.5);
-	stt.setGridCellsX(200);
-	stt.setGridCellsY(200);
+	stt.setGridStep(10);
+	stt.setGridCellsX(10);
+	stt.setGridCellsY(10);
             stt.setNumOfParticles(2);
 
 	stt.addForce(new ConstantForce());
@@ -215,7 +214,7 @@ public class InitialConditions {
 	for (int k = 0; k < 2; k++) {
 		Particle par = new ParticleFull();
 		par.setX(stt.getSimulationWidth() * 1/9.0*(k+4));
-		par.setY(stt.getSimulationHeight() * 1/2 + stt.getGridStep()*2/4);
+		par.setY(stt.getSimulationHeight() * 1/2 + stt.getGridStep()*0/4);
 		par.setRadius(radius);
 		par.setVx(0);
 		par.setVy(0);

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
@@ -61,8 +61,8 @@ public class Settings {
 	private double speedOfLight = 1;
 	private double timeStep = 1;
 	private double gridStep = 1;
-	private double tMax = 1000;
-	private int spectrumStep = 300;
+	private double tMax = 25000;
+	private int spectrumStep = 100;
 	private GeneralBoundaryType boundaryType = GeneralBoundaryType.Periodic;
 	private InterpolatorAlgorithm interpolator = new ChargeConservingCIC();
 	//private InterpolatorAlgorithm interpolator = new CloudInCell();

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
@@ -205,8 +205,6 @@ public class Simulation {
 		collisionalgorithm = settings.getCollisionAlgorithm();
 
 		prepareAllParticles();
-		
-		clearFile();
 	}
 
 	public void turnGridForceOn() {
@@ -255,13 +253,13 @@ public class Simulation {
 	 * Checks if the files are already existent and deletes them.
 	 */
 	public void clearFile() {
-		File particlesfile = new File("output/particles_seq.txt");
+		File particlesfile = new File("particles_seq.txt");
 		boolean fileExists1 = particlesfile.exists();
 		if(fileExists1 == true) {
 			particlesfile.delete();
 		}
 		
-		File gridfile = new File("output/cells_seq.txt");
+		File gridfile = new File("cells_seq.txt");
 		boolean fileExists2 = gridfile.exists();
 		if(fileExists2 == true) {
 			gridfile.delete();
@@ -328,10 +326,9 @@ public class Simulation {
 		double SumJx = 0;
 		double SumJy = 0;
 		double fieldEnergy = 0;
-		//int NumPoints = grid.getNumCellsX()*grid.getNumCellsY();
 		
-		for (int i = 0; i < grid.getNumCellsX(); i++) {
-			for (int j = 0; j < grid.getNumCellsY(); j++) {
+		for (int i = 0; i < grid.getNumCellsXTotal(); i++) {
+			for (int j = 0; j < grid.getNumCellsYTotal(); j++) {
 				
 				SumRho += grid.getCells()[i][j].getRho();
 				SumJx += grid.getCells()[i][j].getJx();
@@ -357,7 +354,6 @@ public class Simulation {
 		pw.write("\n");
 		
 		pw.close();
-		
 	}
 
 	public void writeSpecFile(int time) throws FileNotFoundException {
@@ -377,23 +373,7 @@ public class Simulation {
 		}
 		
 		sw.close();
-		
-		PrintWriter snap = new PrintWriter(new File("output/snapshot" + time + ".txt"));
 
-		for (int i = 0; i < grid.getNumCellsXTotal(); i++) {
-			for (int j = 0; j < grid.getNumCellsYTotal(); j++) {
-				
-				snap.write(i + "\t");
-				snap.write(j + "\t");
-				snap.write(grid.getCells()[i][j].getEx() + "\t");
-				//snap.write(grid.getCells()[i][j].getPhi() + "\t");
-				snap.write("\n");
-				
-			}
-		}
-		
-		snap.close();
-		
 	}
 	
 	public void particlePush() {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/PoissonSolverFFTPeriodic.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/PoissonSolverFFTPeriodic.java
@@ -36,7 +36,7 @@ public class PoissonSolverFFTPeriodic implements PoissonSolver {
 		//prepare input for fft
 		for(int i = 0; i < columns; i++) {
 			for(int j = 0; j < rows; j++) {
-				trho[i][2*j] = g.getRho(i,j)/cellArea;
+				trho[i][2*j] = g.getRho(i,j);
 				trho[i][2*j+1] = 0;
 			}
 		}
@@ -59,7 +59,7 @@ public class PoissonSolverFFTPeriodic implements PoissonSolver {
 		}
                 phi[0][0] = 0;
                 phi[0][1] = 0;
-
+		
 		//perform inverse Fourier transform
 		fft.complexInverse(phi, true);
                 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
@@ -68,8 +68,7 @@ public class MainBatch {
 		if (settings.getSimulationType() == 0) {
 			// Creates the actual physics simulation that can be run iteratively.
 			simulation = new Simulation(settings);
-			//simulation = InitialConditions.initTwoStream(0.01,1,50);
-			simulation = InitialConditions.initPair(0.01,1);
+			simulation = InitialConditions.initTwoStream(0.01,1,50);
 			
 			// Reads out the settings that are needed for this UI.
 			// This must be placed after the parsing process.
@@ -80,7 +79,7 @@ public class MainBatch {
 			for (int i = 0; i <= iterations;) {
 				// advance the simulation by one step
 				simulation.step(i);
-				//System.out.println("MainBatch test: " + i);
+				System.out.println(i);
 				i++;
 
 			}


### PR DESCRIPTION
Reverts openpixi/openpixi#78

There was some compilation failure:
[INFO] Compilation failure
openpixi/pixi/src/main/java/org/openpixi/pixi/physics/InitialConditions.java:[29,39] cannot find symbol
symbol  : class EmptyPoissonSolver
location: package org.openpixi.pixi.physics.fields
