### PR TITLE
Bug fix in the XML parser: set simulation properties correctly.

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/Parser.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/Parser.java
@@ -307,7 +307,7 @@ public class Parser extends DefaultHandler {
 			System.out.println("Error: simulation width is not a positive value! Setting it to 100.");
 			w = 100;
 		}
-		settings.setTimeStep(w);
+		settings.setSimulationWidth(w);
 	}
 
 	private void setSimulationHeight(char ch[], int start, int length) {
@@ -321,7 +321,7 @@ public class Parser extends DefaultHandler {
 			System.out.println("Error: simulation height is not a positive value! Setting it to 100.");
 			h = 100;
 		}
-		settings.setTimeStep(h);
+		settings.setSimulationHeight(h);
 	}
 
 	private void setInterpolator(char ch[], int start, int length) {


### PR DESCRIPTION
Set simulation width and height instead of timestep.
