### PR TITLE
Bugfix: use correct types in YAML parser.

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlParticleStream.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlParticleStream.java
@@ -7,7 +7,7 @@ public class YamlParticleStream {
 	public YamlParticle particle;
 	public Double dx;
 	public Double dy;
-	public Double number;
+	public Integer number;
 
 	/**
 	 * Creates a stream of particles. The particle is copied

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlSettings.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlSettings.java
@@ -14,7 +14,7 @@ import org.openpixi.pixi.physics.grid.ChargeConservingCIC;
 public class YamlSettings {
 	public Double timeStep;
 	public Double speedOfLight;
-	public Integer gridStep;
+	public Double gridStep;
 	public Integer gridCellsX;
 	public Integer gridCellsY;
 	public List<YamlParticle> particles;


### PR DESCRIPTION
Now "gridStep: 0.5" is allowed in the YAML input file.
