### PR TITLE
Small bug fixes

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/FieldGenerators/SU2PlanePulse.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/FieldGenerators/SU2PlanePulse.java
@@ -14,7 +14,7 @@ public class SU2PlanePulse implements IFieldGenerator {
 	private double sigma;
 
 	private Simulation s;
-	private Grid g;
+	private Grid grid;
 	private double timeStep;
 
 	public SU2PlanePulse(double[] direction,
@@ -40,9 +40,12 @@ public class SU2PlanePulse implements IFieldGenerator {
 
 	public void applyFieldConfiguration(Simulation s) {
 		this.s = s;
-		this.g = s.grid;
+		this.grid = s.grid;
 		this.timeStep = s.getTimeStep();
 		double c = s.getSpeedOfLight();
+
+		double as = grid.getLatticeSpacing();
+		double g = s.getCouplingConstant();
 
 		/*
 			Setup the field amplitude for the plane pulse.
@@ -60,7 +63,7 @@ public class SU2PlanePulse implements IFieldGenerator {
 		 */
 		int numberOfCells = 1;
 		for (int i = 0; i < this.numberOfDimensions; i++) {
-			numberOfCells *= g.getNumCells(i);
+			numberOfCells *= grid.getNumCells(i);
 		}
 
 
@@ -69,7 +72,7 @@ public class SU2PlanePulse implements IFieldGenerator {
 		 */
 		for (int ci = 0; ci < numberOfCells; ci++)
 		{
-			int[] cellPosition = g.getCellPos(ci);
+			int[] cellPosition = grid.getCellPos(ci);
 			double[] currentPosition =  getPosition(cellPosition);
 
 			/*
@@ -83,24 +86,24 @@ public class SU2PlanePulse implements IFieldGenerator {
 
 			//Multiplicative factor for the plane pulse at t = - dt/2 (for electric fields)
 			double phaseE = scalarProduct + c*timeStep/2.0;
-			double factorForE =  c * phaseE / Math.pow(sigma, 2.0) *
+			double electricFieldFactor =  g * as * c * phaseE / Math.pow(sigma, 2.0) *
 					Math.exp(- Math.pow(phaseE / this.sigma, 2.0) / 2.0);
 			//Multiplicative factor for the plane pulse at t = 0 (for links)
 			double phaseU = scalarProduct;
-			double factorForU = Math.exp(- Math.pow(phaseU / this.sigma, 2.0) / 2.0);
+			double gaugeFieldFactor = g* as * Math.exp(- Math.pow(phaseU / this.sigma, 2.0) / 2.0);
 
 
 
-			Cell currentCell = g.getCell(cellPosition);
+			Cell currentCell = grid.getCell(cellPosition);
 
 			for(int i = 0; i < this.numberOfDimensions; i++)
 			{
 				//Setup the gauge links
-				SU2Matrix U = (SU2Matrix) currentCell.getU(i).mult(amplitudeYMField[i].mult(factorForU).getLinkExact());
+				SU2Matrix U = (SU2Matrix) currentCell.getU(i).mult(amplitudeYMField[i].mult(gaugeFieldFactor).getLinkExact());
 				currentCell.setU(i, U);
 
 				//Setup the electric fields
-				currentCell.addE(i, amplitudeYMField[i].mult(factorForE));
+				currentCell.addE(i, amplitudeYMField[i].mult(electricFieldFactor));
 			}
 		}
 
@@ -127,7 +130,7 @@ public class SU2PlanePulse implements IFieldGenerator {
 		double[] position =  new double[this.numberOfDimensions];
 		for(int i = 0; i < this.numberOfDimensions; i++)
 		{
-			position[i] =  cellPosition[i] * g.getLatticeSpacing();
+			position[i] =  cellPosition[i] * grid.getLatticeSpacing();
 		}
 		return position;
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/FieldGenerators/SU2PlaneWave.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/FieldGenerators/SU2PlaneWave.java
@@ -11,7 +11,7 @@ public class SU2PlaneWave implements IFieldGenerator {
     private double[] amplitudeColorDirection;
     private double amplitudeMagnitude;
     private Simulation s;
-    private Grid g;
+    private Grid grid;
     private double timeStep;
 
     public SU2PlaneWave(double[] k, double[] amplitudeSpatialDirection, double[] amplitudeColorDirection, double amplitudeMagnitude)
@@ -32,8 +32,12 @@ public class SU2PlaneWave implements IFieldGenerator {
 
     public void applyFieldConfiguration(Simulation s) {
         this.s = s;
-        this.g = s.grid;
+        this.grid = s.grid;
         this.timeStep = s.getTimeStep();
+
+
+		double as = grid.getLatticeSpacing();
+		double g = s.getCouplingConstant();
 
 		/*
 			Setup the field amplitude for the plane wave.
@@ -51,7 +55,7 @@ public class SU2PlaneWave implements IFieldGenerator {
 		 */
         int numberOfCells = 1;
         for (int i = 0; i < this.numberOfDimensions; i++) {
-            numberOfCells *= g.getNumCells(i);
+            numberOfCells *= grid.getNumCells(i);
         }
 
 
@@ -60,7 +64,7 @@ public class SU2PlaneWave implements IFieldGenerator {
 		 */
         for (int c = 0; c < numberOfCells; c++)
         {
-            int[] cellPosition = g.getCellPos(c);
+            int[] cellPosition = grid.getCellPos(c);
             double[] position =  getPosition(cellPosition);
 
 			/*
@@ -76,13 +80,13 @@ public class SU2PlaneWave implements IFieldGenerator {
             omega = s.getSpeedOfLight() * Math.sqrt(omega);
 
             //Factor of the plane wave at t = - dt/2 (for electric fields)
-            double factorForE = omega * Math.sin(omega * (this.timeStep / 2.0) + kx);
+            double factorForE = g * as * omega * Math.sin(omega * (this.timeStep / 2.0) + kx);
             //Phase of the plane wave at t = 0 (for links)
-            double factorForU = Math.cos(kx);
+            double factorForU = g * as * Math.cos(kx);
 
 
 
-            Cell currentCell = g.getCell(cellPosition);
+            Cell currentCell = grid.getCell(cellPosition);
 
             for(int i = 0; i < this.numberOfDimensions; i++)
             {
@@ -119,7 +123,7 @@ public class SU2PlaneWave implements IFieldGenerator {
         double[] position =  new double[this.numberOfDimensions];
         for(int i = 0; i < this.numberOfDimensions; i++)
         {
-            position[i] =  cellPosition[i] * g.getLatticeSpacing();
+            position[i] =  cellPosition[i] * grid.getLatticeSpacing();
         }
         return position;
     }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -24,6 +24,14 @@ public class ElectricFieldPanel extends AnimationPanel {
 	public void paintComponent(Graphics graph1) {
 		Graphics2D graph = (Graphics2D) graph1;
 		setBackground(Color.white);
+
+		/*
+			Note:
+			These two commands set the origin of the coordinate system to the lower-left corner of the panel and flip
+			the y-axis. The system is now as follows:
+			Let (x,y0 denote a point on the panel. (0,0) is the lower-left corner. The x-component increases to the
+			right. The y-component increases downwards.
+		 */
 		graph.translate(0, this.getHeight());
 		graph.scale(1, -1);
 
@@ -36,6 +44,10 @@ public class ElectricFieldPanel extends AnimationPanel {
 		double sy = getHeight() / s.getHeight();
 
 		double panelHeight = getHeight();
+
+		// Lattice spacing and coupling constant
+		double as = s.grid.getLatticeSpacing();
+		double g = s.getCouplingConstant();
 
 		// Draw particles on a central line:
 		for (int i = 0; i < s.particles.size(); i++) {
@@ -55,17 +67,12 @@ public class ElectricFieldPanel extends AnimationPanel {
 		int colorIndex = getSimulationAnimation().getColorIndex();
 		int dirIndex = getSimulationAnimation().getDirectionIndex();
 
-
-		/*
-			Note: The Java 2D API coordinate system is as follows:
-			Let (x,y) denote a point. (0,0) is in the upper-left corner of the drawing area.
-			The x component increases to the right, the y component increases downward.
-		 */
-
 		// Draw electric field:
 		graph.setColor(Color.black);
 		// Scale factor for electric field
 		double scaleE = 1;
+		// Scale factor for gauge field
+		double scaleA = 1;
 		
 		int[] pos = new int[s.getNumberOfDimensions()];
 		for(int w = 2; w < s.getNumberOfDimensions(); w++) {
@@ -87,9 +94,13 @@ public class ElectricFieldPanel extends AnimationPanel {
 				// Electric fields are placed at the lattice points.
 				newPosition = (int) (s.grid.getLatticeSpacing() * (i) * sx);
 
-				// The y-component in the Java 2D API increases downward. Positive field components should point upward.
-				double electricField = s.grid.getE(pos, dirIndex).get(colorIndex);
-				newValue = (int) (((0.5 - scaleE * electricField) * panelHeight));
+				/*
+					Expectation: Positive fields should point upwards.
+					In the flipped and translated coordinate system defined above we have to add the fields to the
+					center of the panel in order to get the expected result.
+				*/
+				double electricField = s.grid.getE(pos, dirIndex).get(colorIndex) / (as * g);
+				newValue = (int) (((0.5 + scaleE * electricField) * panelHeight));
 
 				if (i > 0) {
 					graph.drawLine(oldPosition, oldValue,newPosition, newValue);
@@ -115,9 +126,13 @@ public class ElectricFieldPanel extends AnimationPanel {
 				// Gauge fields are placed at the lattice points.
 				newPosition = (int) (s.grid.getLatticeSpacing() * i * sx);
 
-				// The y-component in the Java 2D API increases downward. Positive fields should point upward.
-				double gaugeField = s.grid.getU(pos, dirIndex).getLinearizedAlgebraElement().get(colorIndex);
-				newValue = (int) (((0.5 - scaleE * gaugeField) * panelHeight));
+				/*
+					Expectation: Positive fields should point upwards.
+					In the flipped and translated coordinate system defined above we have to add the fields to the
+					center of the panel in order to get the expected result.
+				*/
+				double gaugeField = s.grid.getU(pos, dirIndex).getLinearizedAlgebraElement().get(colorIndex) / (as * g);
+				newValue = (int) (((0.5 + scaleA * gaugeField) * panelHeight));
 
 				if (i > 0) {
 					graph.drawLine(oldPosition, oldValue,newPosition, newValue);


### PR DESCRIPTION
Fixed the display errors in ElectricFieldPanel. The gauge fields and electric fields should now point in the correct direction. Since we are using lattice units for the gauge fields and electric fields the relevant factors of grid step and coupling constants are now used in the display.

The SU2PlanePulse and SU2PlaneWave FieldGenerators now properly use lattice units as well.
