### PR TITLE
Read (write) panel layout from (to) YAML file

### DIFF
--- a/pixi/input/Dual_Pulse.yaml
+++ b/pixi/input/Dual_Pulse.yaml
@@ -23,3 +23,16 @@ fields:
       aColor: [0.0, 1.0, 0.0]
       a: 1
       sigma: 8
+
+panels:
+  orientation: 0
+  leftPanel:
+    electricFieldPanel:
+      colorIndex: 0
+      directionIndex: 1
+      scaleFactor: 0.5
+  rightPanel:
+    electricFieldPanel:
+      colorIndex: 1
+      directionIndex: 1
+      scaleFactor: 0.5

--- a/pixi/input/Dual_Pulse_2D.yaml
+++ b/pixi/input/Dual_Pulse_2D.yaml
@@ -1,0 +1,65 @@
+# Dual pulse test
+
+gridStep: 1
+numberOfDimensions: 3
+numberOfColors: 2
+gridCells: [32, 32, 1]
+poissonsolver: empty
+timeStep: 0.1
+duration: 1000
+
+fields:
+  SU2PlanePulses:
+    - dir: [1.0, 0., 0.]
+      pos: [8, 0.0, 0.0]
+      aSpatial: [0.0, 1.0, 0.0]
+      aColor: [1.0, 0.0, 0.0]
+      a: 1
+      sigma: 2
+
+    - dir: [-1.0, 0.0, 0.0]
+      pos: [24, 0.0, 0.0]
+      aSpatial: [0.0,1.0, 0.0]
+      aColor: [0.0, 1.0, 0.0]
+      a: 1
+      sigma: 2
+
+panels:
+  dividerLocation: 236
+  leftPanel:
+    dividerLocation: 226
+    leftPanel:
+      particle3DPanel:
+        colorIndex: 0
+        directionIndex: 1
+        drawCurrent: false
+        drawFields: true
+        phi: 0.0
+        showInfo: false
+        theta: 0.9
+    orientation: 1
+    rightPanel:
+      particle3DPanel:
+        colorIndex: 1
+        directionIndex: 1
+        drawCurrent: false
+        drawFields: true
+        phi: 0.0
+        showInfo: false
+        theta: 0.9
+  orientation: 0
+  rightPanel:
+    dividerLocation: 226
+    leftPanel:
+      electricFieldPanel:
+        automaticScaling: false
+        colorIndex: 0
+        directionIndex: 1
+        scaleFactor: 0.5
+    orientation: 1
+    rightPanel:
+      electricFieldPanel:
+        automaticScaling: false
+        colorIndex: 1
+        directionIndex: 1
+        scaleFactor: 0.5

--- a/pixi/input/Single_Pulse.yaml
+++ b/pixi/input/Single_Pulse.yaml
@@ -15,4 +15,11 @@ fields:
       aSpatial: [0.0, 1.0, 0.0]
       aColor: [1.0, 0.0, 0.0]
       a: 1
-      sigma: 2
+      sigma: 4
+
+panels:
+  electricFieldPanel:
+    automaticScaling: false
+    colorIndex: 0
+    directionIndex: 1
+    scaleFactor: 1.0

--- a/pixi/input/Wave_Test.yaml
+++ b/pixi/input/Wave_Test.yaml
@@ -29,3 +29,9 @@ output:
 
       # Measurement interval
       interval: 1.0
+
+panels:
+  electricFieldPanel:
+    colorIndex: 0
+    directionIndex: 1
+    scaleFactor: 2

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
@@ -10,6 +10,7 @@ import org.openpixi.pixi.physics.grid.*;
 import org.openpixi.pixi.physics.particles.*;
 import org.openpixi.pixi.physics.solver.*;
 import org.openpixi.pixi.physics.solver.relativistic.LeapFrogRelativistic;
+import org.openpixi.pixi.ui.util.yaml.YamlPanels;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -85,6 +86,9 @@ public class Settings {
 	 * simulation we use ExecutorService which is maintaining a fixed number of threads running
 	 * all the time and assigns work to the threads on the fly according to demand. */
 	private ExecutorService threadsExecutor;
+
+	// Panel management
+	private YamlPanels yamlPanels;
 
 	//----------------------------------------------------------------------------------------------
 	// SIMPLE GETTERS
@@ -208,6 +212,10 @@ public class Settings {
     {
         return this.fieldGenerators;
     }
+
+	public YamlPanels getYamlPanels() {
+		return yamlPanels;
+	}
 
 	//----------------------------------------------------------------------------------------------
 	// MORE COMPLEX GETTERS / BUILDERS
@@ -421,6 +429,10 @@ public class Settings {
     {
         this.fieldGenerators.add(generator);
     }
+
+	public void setYamlPanels(YamlPanels yamlPanels) {
+		this.yamlPanels = yamlPanels;
+	}
 
 	//----------------------------------------------------------------------------------------------
 	// VARIOUS

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
@@ -231,7 +231,7 @@ public class MainControlApplet extends JApplet
 		tabs = new JTabbedPane();
 
 		this.propertiesTab = new PropertiesTab(MainControlApplet.this, panelManager);
-		this.fileTab = new FileTab(MainControlApplet.this, simulationAnimation);
+		this.fileTab = new FileTab(MainControlApplet.this, simulationAnimation, panelManager);
 
 		settingControls.setPreferredSize(new Dimension (300, 100));
 
@@ -245,6 +245,8 @@ public class MainControlApplet extends JApplet
 		this.add(controlPanel, BorderLayout.SOUTH);
 		this.add(mainPanel, BorderLayout.CENTER);
 		this.add(tabs, BorderLayout.EAST);
+
+		panelManager.replaceMainPanel(mainPanel);
 
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
@@ -2,6 +2,7 @@ package org.openpixi.pixi.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
+import java.awt.LayoutManager;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -36,6 +37,8 @@ public class PanelManager {
 	private AnimationPanel lastFocusPanel;
 	private PropertiesTab propertiesTab;
 
+	private Component previousMainComponent;
+
 	PopupClickListener popupClickListener;
 
 	JMenuItem itemSplitHorizontally;
@@ -65,6 +68,19 @@ public class PanelManager {
 	 */
 	public void setPropertiesTab(PropertiesTab propertiesTab) {
 		this.propertiesTab = propertiesTab;
+	}
+
+	/**
+	 * Replace the main content area by a new component.
+	 * @param component
+	 */
+	public void replaceMainPanel(Component component) {
+		if (previousMainComponent != null) {
+			mainControlApplet.remove(previousMainComponent);
+		}
+		mainControlApplet.add(component, BorderLayout.CENTER);
+		mainControlApplet.validate();
+		previousMainComponent = component;
 	}
 
 	/**
@@ -200,9 +216,7 @@ public class PanelManager {
 					parentsplitpane.setDividerLocation(dividerLocation);
 				} else if (parent instanceof JPanel) {
 					// top level
-					mainControlApplet.remove(clickComponent);
-					mainControlApplet.add(component, BorderLayout.CENTER);
-					mainControlApplet.validate();
+					replaceMainPanel(component);
 				}
 			}
 			setFocus(component);
@@ -247,9 +261,7 @@ public class PanelManager {
 					s.setContinuousLayout(true);
 					s.setResizeWeight(0.5);
 
-					mainControlApplet.remove(clickComponent);
-					mainControlApplet.add(s, BorderLayout.CENTER);
-					mainControlApplet.validate();
+					replaceMainPanel(s);
 				}
 			}
 		}
@@ -279,9 +291,7 @@ public class PanelManager {
 							}
 						} else if (grandparent instanceof JPanel) {
 							parentsplitpane.removeAll();
-							mainControlApplet.remove(parentsplitpane);
-							mainControlApplet.add(othercomponent, BorderLayout.CENTER);
-							mainControlApplet.validate();
+							replaceMainPanel(othercomponent);
 						}
 						setFocus(othercomponent);
 						clickComponent.removeMouseListener(popupClickListener);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
@@ -81,11 +81,32 @@ public class PanelManager {
 	}
 
 	/**
+	 * Split current panel either horizontally or vertically
+	 *
+	 * @param orientation
+	 *            Either JSplitPane.HORIZONTAL_SPLIT or
+	 *            JSplitPane.VERTICAL_SPLIT.
+	 */
+	public Component getSplitPanel(Component leftPanel, Component rightPanel, Integer orientation, Integer dividerLocation) {
+		Component parent = clickComponent.getParent();
+
+		JSplitPane splitpane = new JSplitPane(orientation,
+				leftPanel, rightPanel);
+		splitpane.setOneTouchExpandable(true);
+		splitpane.setContinuousLayout(true);
+		splitpane.setResizeWeight(0.5);
+		if (dividerLocation != null) {
+			splitpane.setDividerLocation(dividerLocation);
+		}
+		return splitpane;
+	}
+
+	/**
 	 * Attaching the default right mouse button listener,
 	 * unless it is a split pane.
 	 * @param component
 	 */
-	void attachMouseListener(Component component) {
+	private void attachMouseListener(Component component) {
 		if (!(component instanceof JSplitPane)) {
 			// Only attache mouse listener to "real" panels.
 			// Remove listener first, so that it does not get attached twice.
@@ -249,27 +270,19 @@ public class PanelManager {
 
 					int dividerLocation = parentsplitpane.getDividerLocation();
 
-					JSplitPane s = new JSplitPane(orientation,
-								clickComponent, newcomponent);
-					s.setOneTouchExpandable(true);
-					s.setContinuousLayout(true);
-					s.setResizeWeight(0.5);
+					Component splitpane = getSplitPanel(clickComponent, newcomponent, orientation, null);
 
 					if (parentleft == clickComponent) {
-						parentsplitpane.setLeftComponent(s);
+						parentsplitpane.setLeftComponent(splitpane);
 					} else {
-						parentsplitpane.setRightComponent(s);
+						parentsplitpane.setRightComponent(splitpane);
 					}
 					parentsplitpane.setDividerLocation(dividerLocation);
 				} else if (parent instanceof JPanel) {
 					// top level
-					JSplitPane s = new JSplitPane(orientation,
-							clickComponent, newcomponent);
-					s.setOneTouchExpandable(true);
-					s.setContinuousLayout(true);
-					s.setResizeWeight(0.5);
+					Component splitpane = getSplitPanel(clickComponent, newcomponent, orientation, null);
 
-					replaceMainPanel(s);
+					replaceMainPanel(splitpane);
 				}
 			}
 		}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
@@ -31,7 +31,7 @@ public class PanelManager {
 	private AnimationPanel lastFocusPanel;
 	private PropertiesTab propertiesTab;
 
-	private Component previousMainComponent;
+	private Component mainComponent;
 
 	PopupClickListener popupClickListener = new PopupClickListener();
 
@@ -54,6 +54,10 @@ public class PanelManager {
 		return component;
 	}
 
+	public Component getMainComponent() {
+		return mainComponent;
+	}
+
 	/**
 	 * Set properties tab which should replace content upon focus.
 	 * @param propertiesTab
@@ -71,13 +75,13 @@ public class PanelManager {
 	 * @param component
 	 */
 	public void replaceMainPanel(Component component) {
-		if (previousMainComponent != null) {
-			mainControlApplet.remove(previousMainComponent);
+		if (mainComponent != null) {
+			mainControlApplet.remove(mainComponent);
 		}
 		attachMouseListener(component);
 		mainControlApplet.add(component, BorderLayout.CENTER);
 		mainControlApplet.validate();
-		previousMainComponent = component;
+		mainComponent = component;
 	}
 
 	/**

--- a/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
@@ -13,6 +13,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
 import javax.swing.JSplitPane;
 
+import org.apache.maven.project.artifact.AttachedArtifact;
 import org.openpixi.pixi.ui.panel.AnimationPanel;
 import org.openpixi.pixi.ui.panel.ElectricFieldPanel;
 import org.openpixi.pixi.ui.panel.Particle2DPanel;
@@ -88,8 +89,8 @@ public class PanelManager {
 	 *            JSplitPane.VERTICAL_SPLIT.
 	 */
 	public Component getSplitPanel(Component leftPanel, Component rightPanel, Integer orientation, Integer dividerLocation) {
-		Component parent = clickComponent.getParent();
-
+		attachMouseListener(leftPanel);
+		attachMouseListener(rightPanel);
 		JSplitPane splitpane = new JSplitPane(orientation,
 				leftPanel, rightPanel);
 		splitpane.setOneTouchExpandable(true);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
@@ -2,7 +2,6 @@ package org.openpixi.pixi.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.LayoutManager;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -29,17 +28,12 @@ public class PanelManager {
 
 	private MainControlApplet mainControlApplet;
 
-	private Particle2DPanel particlePanel;
-	private Particle3DPanel particle3DPanel;
-	private PhaseSpacePanel phaseSpacePanel;
-	private ElectricFieldPanel electricFieldPanel;
-
 	private AnimationPanel lastFocusPanel;
 	private PropertiesTab propertiesTab;
 
 	private Component previousMainComponent;
 
-	PopupClickListener popupClickListener;
+	PopupClickListener popupClickListener = new PopupClickListener();
 
 	JMenuItem itemSplitHorizontally;
 	JMenuItem itemSplitVertically;
@@ -55,11 +49,9 @@ public class PanelManager {
 
 	/* Create default panel */
 	Component getDefaultPanel() {
-		particlePanel = new Particle2DPanel(mainControlApplet.simulationAnimation);
-		popupClickListener = new PopupClickListener();
-		particlePanel.addMouseListener(popupClickListener);
-		setFocus(particlePanel);
-		return particlePanel;
+		Component component = new Particle2DPanel(mainControlApplet.simulationAnimation);
+		setFocus(component);
+		return component;
 	}
 
 	/**
@@ -70,6 +62,10 @@ public class PanelManager {
 		this.propertiesTab = propertiesTab;
 	}
 
+	public SimulationAnimation getSimulationAnimation() {
+		return mainControlApplet.simulationAnimation;
+	}
+
 	/**
 	 * Replace the main content area by a new component.
 	 * @param component
@@ -78,9 +74,24 @@ public class PanelManager {
 		if (previousMainComponent != null) {
 			mainControlApplet.remove(previousMainComponent);
 		}
+		attachMouseListener(component);
 		mainControlApplet.add(component, BorderLayout.CENTER);
 		mainControlApplet.validate();
 		previousMainComponent = component;
+	}
+
+	/**
+	 * Attaching the default right mouse button listener,
+	 * unless it is a split pane.
+	 * @param component
+	 */
+	void attachMouseListener(Component component) {
+		if (!(component instanceof JSplitPane)) {
+			// Only attache mouse listener to "real" panels.
+			// Remove listener first, so that it does not get attached twice.
+			component.removeMouseListener(popupClickListener);
+			component.addMouseListener(popupClickListener);
+		}
 	}
 
 	/**
@@ -182,17 +193,13 @@ public class PanelManager {
 			} else if (event.getSource() == itemClosePanel) {
 				closePanel();
 			} else if (event.getSource() == itemParticle2DPanel) {
-				particlePanel = new Particle2DPanel(mainControlApplet.simulationAnimation);
-				component = particlePanel;
+				component = new Particle2DPanel(mainControlApplet.simulationAnimation);
 			} else if (event.getSource() == itemParticle3DPanel) {
-				particle3DPanel = new Particle3DPanel(mainControlApplet.simulationAnimation);
-				component = particle3DPanel;
+				component = new Particle3DPanel(mainControlApplet.simulationAnimation);
 			} else if (event.getSource() == itemPhaseSpacePanel) {
-				phaseSpacePanel = new PhaseSpacePanel(mainControlApplet.simulationAnimation);
-				component = phaseSpacePanel;
+				component = new PhaseSpacePanel(mainControlApplet.simulationAnimation);
 			} else if (event.getSource() == itemElectricFieldPanel) {
-				electricFieldPanel = new ElectricFieldPanel(mainControlApplet.simulationAnimation);
-				component = electricFieldPanel;
+				component = new ElectricFieldPanel(mainControlApplet.simulationAnimation);
 			}
 			if (component != null) {
 				replacePanel(component);
@@ -200,7 +207,7 @@ public class PanelManager {
 		}
 
 		private void replacePanel(Component component) {
-			component.addMouseListener(popupClickListener);
+			attachMouseListener(component);
 			Component parent = clickComponent.getParent();
 			if (parent != null) {
 				if (parent instanceof JSplitPane) {
@@ -233,6 +240,7 @@ public class PanelManager {
 			Component parent = clickComponent.getParent();
 
 			Component newcomponent = getDefaultPanel();
+			attachMouseListener(newcomponent);
 
 			if (parent != null) {
 				if (parent instanceof JSplitPane) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
@@ -120,8 +120,13 @@ public class PanelManager {
 	 * previously focused panel.
 	 * @param component
 	 */
-	private void setFocus(Component component) {
-		if (component instanceof AnimationPanel) {
+	public void setFocus(Component component) {
+		if (component instanceof JSplitPane) {
+			// Set focus on left descendant:
+			JSplitPane splitpanel = (JSplitPane) component;
+			Component leftComponent = splitpanel.getLeftComponent();
+			setFocus(leftComponent);
+		} else if (component instanceof AnimationPanel) {
 			AnimationPanel panel = (AnimationPanel) component;
 			if (!panel.isFocused()) {
 				if (lastFocusPanel != null) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
@@ -13,7 +13,6 @@ import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
 import javax.swing.JSplitPane;
 
-import org.apache.maven.project.artifact.AttachedArtifact;
 import org.openpixi.pixi.ui.panel.AnimationPanel;
 import org.openpixi.pixi.ui.panel.ElectricFieldPanel;
 import org.openpixi.pixi.ui.panel.Particle2DPanel;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -158,4 +158,12 @@ public class ElectricFieldPanel extends AnimationPanel {
 		colorProperties.addComponents(box);
 		scaleProperties.addComponents(box);
 	}
+
+	public ColorProperties getColorProperties() {
+		return colorProperties;
+	}
+
+	public ScaleProperties getScaleProperties() {
+		return scaleProperties;
+	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle2DPanel.java
@@ -81,7 +81,7 @@ public class Particle2DPanel extends AnimationPanel {
 			double radius = par.getRadius();//double radius = par.getRadius()*(2 - 1.9*par.getZ()/s.getDepth());
 			int width = (int) (2*sx*radius);
 			int height = (int) (2*sy*radius);
-			if(width > 2 && height > 2 && !traceProperties.getPaintTrace()) {
+			if(width > 2 && height > 2 && !traceProperties.isShowTrace()) {
 				graph.fillOval((int) (par.getPosition(0)*sx) - width/2, (int) (par.getPosition(1)*sy) - height/2,  width,  height);
 			}
 			else {
@@ -97,7 +97,7 @@ public class Particle2DPanel extends AnimationPanel {
 		int colorIndex = colorProperties.getColorIndex();
 		int directionIndex = colorProperties.getDirectionIndex();
 		
-		if(fieldProperties.getDrawCurrentGrid())
+		if(fieldProperties.isDrawCurrent())
 		{
 			graph.setColor(Color.black);
 			
@@ -120,7 +120,7 @@ public class Particle2DPanel extends AnimationPanel {
 			//return;
 		}
 
-		if(fieldProperties.getDrawFields())
+		if(fieldProperties.isDrawFields())
 		{
 			graph.setColor(Color.black);
 			for(int i = 0; i < s.grid.getNumCells(0); i++)

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle2DPanel.java
@@ -63,7 +63,7 @@ public class Particle2DPanel extends AnimationPanel {
 		graph.scale(1, -1);
 		double scale = 10;
 
-		if (traceProperties.getCallSuper()) {
+		if (traceProperties.isCallSuper()) {
 			super.paintComponent(graph1);
 		}
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle2DPanel.java
@@ -180,4 +180,20 @@ public class Particle2DPanel extends AnimationPanel {
 		infoProperties.addComponents(box);
 		traceProperties.addComponents(box);
 	}
+
+	public ColorProperties getColorProperties() {
+		return colorProperties;
+	}
+
+	public FieldProperties getFieldProperties() {
+		return fieldProperties;
+	}
+
+	public InfoProperties getInfoProperties() {
+		return infoProperties;
+	}
+
+	public TraceProperties getTraceProperties() {
+		return traceProperties;
+	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
@@ -56,6 +56,7 @@ public class Particle3DPanel extends AnimationPanel {
 	private long currentrendertime = 0;
 
 	private Projection projection = new Projection();
+
 	private LineObject cuboid = new LineObject();
 	private LineObject fields = new LineObject();
 	private SphereObject spheres = new SphereObject();
@@ -297,5 +298,9 @@ public class Particle3DPanel extends AnimationPanel {
 
 	public InfoProperties getInfoProperties() {
 		return infoProperties;
+	}
+
+	public Projection getProjection() {
+		return projection;
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
@@ -70,7 +70,6 @@ public class Particle3DPanel extends AnimationPanel {
 	public Particle3DPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
 
-		Simulation s = simulationAnimation.getSimulation();
 		projection.phi = 0;
 		projection.theta = 0;
 
@@ -310,4 +309,15 @@ public class Particle3DPanel extends AnimationPanel {
 		infoProperties.addComponents(box);
 	}
 
+	public ColorProperties getColorProperties() {
+		return colorProperties;
+	}
+
+	public FieldProperties getFieldProperties() {
+		return fieldProperties;
+	}
+
+	public InfoProperties getInfoProperties() {
+		return infoProperties;
+	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
@@ -182,7 +182,7 @@ public class Particle3DPanel extends AnimationPanel {
 		int colorIndex = colorProperties.getColorIndex();
 		int directionIndex = colorProperties.getDirectionIndex();
 		
-		if(fieldProperties.getDrawCurrentGrid()) {
+		if(fieldProperties.isDrawCurrent()) {
 			for(int i = 0; i < s.grid.getNumCells(0); i += gridstep) {
 				for(int j = 0; j < s.grid.getNumCells(1); j += gridstep) {
 					for(int k = 0; k < s.grid.getNumCells(2); k += gridstep) {
@@ -223,7 +223,7 @@ public class Particle3DPanel extends AnimationPanel {
 			}
 		}
 
-		if(fieldProperties.getDrawFields())
+		if(fieldProperties.isDrawFields())
 		{
 			graph.setColor(Color.black);
 			for(int i = 0; i < s.grid.getNumCells(0); i += gridstep) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
@@ -51,11 +51,6 @@ public class Particle3DPanel extends AnimationPanel {
 	 * or whether to keep them separate. */
 	private boolean combinefields = true;
 
-	/** A state for the trace */
-	public boolean paint_trace = false;
-
-	private boolean reset_trace;
-
 	private int gridstep = 1;
 	private int gridstepadjusted = 0;
 	private long currentrendertime = 0;
@@ -82,15 +77,6 @@ public class Particle3DPanel extends AnimationPanel {
 		addMouseMotionListener(l);
 	}
 
-	public void clear() {
-		reset_trace = true;
-	}
-
-	public void checkTrace() {
-		paint_trace =! paint_trace;
-		//startAnimation();
-	}
-
 	/** Display the particles */
 	public void paintComponent(Graphics graph1) {
 		Graphics2D graph = (Graphics2D) graph1;
@@ -99,15 +85,7 @@ public class Particle3DPanel extends AnimationPanel {
 		graph.scale(1, -1);
 		double scale = 10;
 
-		if(!paint_trace)
-		{
-			super.paintComponent(graph1);
-		}
-		if(reset_trace)
-		{
-			super.paintComponent(graph1);
-			reset_trace = false;
-		}
+		super.paintComponent(graph1);
 
 		Simulation s = getSimulationAnimation().getSimulation();
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/PhaseSpacePanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/PhaseSpacePanel.java
@@ -9,11 +9,14 @@ import javax.swing.Box;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.particles.IParticle;
 import org.openpixi.pixi.ui.SimulationAnimation;
+import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
 
 /**
  * This panel shows the one-dimensional phase space (x vs. vx).
  */
 public class PhaseSpacePanel extends AnimationPanel {
+
+	ScaleProperties scaleProperties = new ScaleProperties();
 
 	/** Constructor */
 	public PhaseSpacePanel(SimulationAnimation simulationAnimation) {
@@ -30,7 +33,7 @@ public class PhaseSpacePanel extends AnimationPanel {
 		super.paintComponent(graph1);
 
 		// scale factor for velocity
-		double scaleV = .5;
+		double scaleV = scaleProperties.getScale();
 
 		Simulation s = getSimulationAnimation().getSimulation();
 		/** Scaling factor for the displayed panel in x-direction*/
@@ -40,13 +43,17 @@ public class PhaseSpacePanel extends AnimationPanel {
 
 		double panelHeight = getHeight();
 
+		scaleProperties.resetAutomaticScale();
+
 		for (int i = 0; i < s.particles.size(); i++) {
 			IParticle par = (IParticle) s.particles.get(i);
 			graph.setColor(par.getColor());
 			double radius = par.getRadius();
 			int width = (int) (2*sx*radius);
 			int height = (int) (2*sx*radius);
-			double position = (0.5 + scaleV * par.getVelocity(0) ) * panelHeight;
+			double velocity = par.getVelocity(0);
+			scaleProperties.putValue(velocity);
+			double position = (0.5 + scaleV * velocity) * panelHeight;
 			if(width > 2 && height > 2) {
 				graph.fillOval((int) (par.getPosition(0)*sx) - width/2, (int) position - height/2,  width,  height);
 			}
@@ -54,11 +61,16 @@ public class PhaseSpacePanel extends AnimationPanel {
 				graph.drawRect((int) (par.getPosition(0)*sx), (int) position, 0, 0);
 			}
 		}
+		scaleProperties.calculateAutomaticScale(0.5);
 
 	}
 
 	public void addComponents(Box box) {
 		addLabel(box, "Phase space panel");
+		scaleProperties.addComponents(box);
 	}
 
+	public ScaleProperties getScaleProperties() {
+		return scaleProperties;
+	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ColorProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ColorProperties.java
@@ -36,12 +36,12 @@ public class ColorProperties {
 		return directionIndex;
 	}
 
-	public void colorIndexSet(int id)
+	public void setColorIndex(int id)
 	{
 		this.colorIndex = id;
 	}
 
-	public void directionSet(int id)
+	public void setDirectionIndex(int id)
 	{
 		this.directionIndex = id;
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/FieldProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/FieldProperties.java
@@ -8,25 +8,31 @@ import javax.swing.JCheckBox;
 
 public class FieldProperties {
 
-	private boolean drawCurrentGrid = false;
-
+	private boolean drawCurrent = false;
 	private boolean drawFields = false;
 
-	public boolean getDrawCurrentGrid() {
-		return drawCurrentGrid;
+	public boolean isDrawCurrent() {
+		return drawCurrent;
 	}
 
-	public boolean getDrawFields() {
+	public boolean isDrawFields() {
 		return drawFields;
 	}
 
+	public void setDrawCurrent(boolean drawCurrent) {
+		this.drawCurrent = drawCurrent;
+	}
+
+	public void setDrawFields(boolean drawFields) {
+		this.drawFields = drawFields;
+	}
 
 	public void addComponents(Box box) {
 
 		JCheckBox currentgridCheck;
 		currentgridCheck = new JCheckBox("Current");
-		currentgridCheck.addItemListener(new DrawCurrentGridListener());
-		currentgridCheck.setSelected(drawCurrentGrid);
+		currentgridCheck.addItemListener(new DrawCurrentListener());
+		currentgridCheck.setSelected(drawCurrent);
 
 		JCheckBox drawFieldsCheck;
 		drawFieldsCheck = new JCheckBox("Draw fields");
@@ -42,9 +48,9 @@ public class FieldProperties {
 		box.add(cellSettings);
 	}
 
-	class DrawCurrentGridListener implements ItemListener {
+	class DrawCurrentListener implements ItemListener {
 		public void itemStateChanged(ItemEvent event){
-			FieldProperties.this.drawCurrentGrid = 
+			FieldProperties.this.drawCurrent = 
 					(event.getStateChange() == ItemEvent.SELECTED);
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/InfoProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/InfoProperties.java
@@ -14,9 +14,17 @@ import org.openpixi.pixi.ui.util.FrameRateDetector;
 
 public class InfoProperties {
 
-	public boolean showinfo = false;
+	public boolean showInfo = false;
 
 	Color darkGreen = new Color(0x00, 0x80, 0x00);
+
+	public boolean isShowInfo() {
+		return showInfo;
+	}
+
+	public void setShowInfo(boolean showInfo) {
+		this.showInfo = showInfo;
+	}
 
 	public void addComponents(Box box) {
 		Box settingControls = Box.createVerticalBox();
@@ -24,7 +32,7 @@ public class InfoProperties {
 		JCheckBox framerateCheck;
 		framerateCheck = new JCheckBox("Info");
 		framerateCheck.addItemListener(new FrameListener());
-		framerateCheck.setSelected(showinfo);
+		framerateCheck.setSelected(showInfo);
 
 		settingControls.add(framerateCheck);
 		settingControls.add(Box.createVerticalGlue());
@@ -34,14 +42,14 @@ public class InfoProperties {
 
 	class FrameListener implements ItemListener {
 		public void itemStateChanged(ItemEvent event) {
-			InfoProperties.this.showinfo = 
+			InfoProperties.this.showInfo =
 					(event.getStateChange() == ItemEvent.SELECTED);
 		}
 	}
 
 	public void showInfo(Graphics2D graph, AnimationPanel panel) {
 
-		if (showinfo) {
+		if (showInfo) {
 			FrameRateDetector frameratedetector = panel.getSimulationAnimation().getFrameRateDetector();
 			Simulation s = panel.getSimulationAnimation().getSimulation();
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ScaleProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ScaleProperties.java
@@ -22,6 +22,22 @@ public class ScaleProperties {
 	private JLabel label;
 	private JTextField textField;
 
+	public double getScaleFactor() {
+		return scaleFactor;
+	}
+
+	public boolean getAutomaticScaling() {
+		return automaticScaling;
+	}
+
+	public void setScaleFactor(double scaleFactor) {
+		this.scaleFactor = scaleFactor;
+	}
+
+	public void setAutomaticScaling(boolean automaticScaling) {
+		this.automaticScaling = automaticScaling;
+	}
+
 	public double getScale() {
 		if (automaticScaling) {
 			return automaticScaleFactor;
@@ -46,7 +62,9 @@ public class ScaleProperties {
 	public void calculateAutomaticScale(double maxsize) {
 		if (automaticScaling && currentMaxValue > 0) {
 			automaticScaleFactor = maxsize / currentMaxValue;
-			textField.setText(Double.toString(automaticScaleFactor));
+			if (textField != null) {
+				textField.setText(Double.toString(automaticScaleFactor));
+			}
 		}
 	}
 
@@ -79,12 +97,14 @@ public class ScaleProperties {
 	}
 
 	void updateTextFieldStatus() {
-		textField.setEnabled(!automaticScaling);
-		label.setEnabled(!automaticScaling);
-		if (automaticScaling) {
-			textField.setText(Double.toString(automaticScaleFactor));
-		} else {
-			textField.setText(Double.toString(scaleFactor));
+		if (textField != null) {
+			textField.setEnabled(!automaticScaling);
+			label.setEnabled(!automaticScaling);
+			if (automaticScaling) {
+				textField.setText(Double.toString(automaticScaleFactor));
+			} else {
+				textField.setText(Double.toString(scaleFactor));
+			}
 		}
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/TraceProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/TraceProperties.java
@@ -10,7 +10,7 @@ import javax.swing.JCheckBox;
 public class TraceProperties {
 
 	/** A state for the trace */
-	public boolean paint_trace = false;
+	public boolean showTrace = false;
 
 	private boolean reset_trace;
 
@@ -18,8 +18,12 @@ public class TraceProperties {
 		reset_trace = true;
 	}
 
-	public boolean getPaintTrace() {
-		return paint_trace;
+	public boolean isShowTrace() {
+		return showTrace;
+	}
+
+	public void setShowTrace(boolean showTrace) {
+		this.showTrace = showTrace;
 	}
 
 	public void addComponents(Box box) {
@@ -28,7 +32,7 @@ public class TraceProperties {
 		JCheckBox traceCheck;
 		traceCheck = new JCheckBox("Trace");
 		traceCheck.addItemListener(new CheckListener());
-		traceCheck.setSelected(paint_trace);
+		traceCheck.setSelected(showTrace);
 
 		settingControls.add(traceCheck);
 		settingControls.add(Box.createVerticalGlue());
@@ -38,7 +42,7 @@ public class TraceProperties {
 
 	public boolean getCallSuper() {
 		boolean callsuper = false;
-		if(!paint_trace)
+		if(!showTrace)
 		{
 			callsuper = true;
 		}
@@ -52,7 +56,7 @@ public class TraceProperties {
 
 	class CheckListener implements ItemListener {
 		public void itemStateChanged(ItemEvent event){
-			TraceProperties.this.paint_trace = 
+			TraceProperties.this.showTrace = 
 					(event.getStateChange() == ItemEvent.SELECTED);
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/TraceProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/TraceProperties.java
@@ -1,6 +1,5 @@
 package org.openpixi.pixi.ui.panel.properties;
 
-import java.awt.Graphics;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 
@@ -12,10 +11,10 @@ public class TraceProperties {
 	/** A state for the trace */
 	public boolean showTrace = false;
 
-	private boolean reset_trace;
+	private boolean resetTrace;
 
 	public void clear() {
-		reset_trace = true;
+		resetTrace = true;
 	}
 
 	public boolean isShowTrace() {
@@ -40,16 +39,16 @@ public class TraceProperties {
 		box.add(settingControls);
 	}
 
-	public boolean getCallSuper() {
+	public boolean isCallSuper() {
 		boolean callsuper = false;
 		if(!showTrace)
 		{
 			callsuper = true;
 		}
-		if(reset_trace)
+		if(resetTrace)
 		{
 			callsuper = true;
-			reset_trace = false;
+			resetTrace = false;
 		}
 		return callsuper;
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
@@ -132,7 +132,6 @@ public class FileTab extends Box {
 	class ApplyButtonListener implements ActionListener {
 		public void actionPerformed(ActionEvent event) {
 			applyTextAreaSettings();
-			applyTextAreaPanelSettings();
 		}
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
@@ -15,24 +15,28 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 
 import org.openpixi.pixi.physics.Settings;
+import org.openpixi.pixi.ui.PanelManager;
 import org.openpixi.pixi.ui.SimulationAnimation;
 import org.openpixi.pixi.ui.util.FileIO;
+import org.openpixi.pixi.ui.util.yaml.YamlPanels;
 import org.openpixi.pixi.ui.util.yaml.YamlParser;
 
 public class FileTab extends Box {
 
 	private Component parent;
 	private SimulationAnimation simulationAnimation;
+	private PanelManager panelManager;
 	private JFileChooser fc;
 	private JButton openButton;
 	private JButton saveButton;
 	private JButton applyButton;
 	private JTextArea fileTextArea;
 
-	public FileTab(Component parent, SimulationAnimation simulationAnimation) {
+	public FileTab(Component parent, SimulationAnimation simulationAnimation, PanelManager panelManager) {
 		super(BoxLayout.PAGE_AXIS);
 		this.parent = parent;
 		this.simulationAnimation = simulationAnimation;
+		this.panelManager = panelManager;
 
 		fc = new JFileChooser();
 		File workingDirectory = new File(System.getProperty("user.dir"));
@@ -72,6 +76,7 @@ public class FileTab extends Box {
 					String content = FileIO.readFile(file);
 					fileTextArea.setText(content);
 					applyTextAreaSettings();
+					applyTextAreaPanelSettings();
 				} catch (IOException e) {
 					// TODO Error message
 				}
@@ -118,6 +123,7 @@ public class FileTab extends Box {
 	class ApplyButtonListener implements ActionListener {
 		public void actionPerformed(ActionEvent event) {
 			applyTextAreaSettings();
+			applyTextAreaPanelSettings();
 		}
 	}
 
@@ -132,6 +138,26 @@ public class FileTab extends Box {
 			YamlParser parser = new YamlParser(settings);
 			parser.parseString(string);
 			simulationAnimation.resetAnimation(settings);
+		}
+	}
+
+	/**
+	 * Apply the panel settings from the text area and restart the simulation.
+	 */
+	public void applyTextAreaPanelSettings() {
+		String string = fileTextArea.getText();
+		if(string.length() > 0)
+		{
+			Settings settings = new Settings();
+			YamlParser parser = new YamlParser(settings);
+			parser.parseString(string);
+			YamlPanels panels = settings.getYamlPanels();
+			if (panels != null) {
+				Component component = panels.inflate(simulationAnimation);
+				panelManager.replaceMainPanel(component);
+			} else {
+				// ToDo: Warning message? No panel specification provided in Yaml file.
+			}
 		}
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
@@ -156,6 +156,7 @@ public class FileTab extends Box {
 				Component component = panels.inflate(panelManager);
 				if (component != null) {
 					panelManager.replaceMainPanel(component);
+					panelManager.setFocus(component);
 				}
 			} else {
 				// ToDo: Warning message? No panel specification provided in Yaml file.

--- a/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
@@ -154,7 +154,9 @@ public class FileTab extends Box {
 			YamlPanels panels = settings.getYamlPanels();
 			if (panels != null) {
 				Component component = panels.inflate(panelManager);
-				panelManager.replaceMainPanel(component);
+				if (component != null) {
+					panelManager.replaceMainPanel(component);
+				}
 			} else {
 				// ToDo: Warning message? No panel specification provided in Yaml file.
 			}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
@@ -210,15 +210,11 @@ public class FileTab extends Box {
 	 * Append the current panel settings to the text area.
 	 */
 	public void writeTextAreaPanelSettings() {
-		String string = fileTextArea.getText();
-		if(string.length() > 0)
-		{
-			Settings settings = new Settings();
-			YamlParser parser = new YamlParser(settings);
-			YamlPanelWriter panelWriter = new YamlPanelWriter();
-			String yamlString = panelWriter.getYamlString(settings.getYamlPanels());
-			yamlString = "\n\n# Generated panel code:\n" + yamlString;
-			fileTextArea.append(yamlString);
-		}
+		Component component = panelManager.getMainComponent();
+		YamlPanels yamlPanels = new YamlPanels(component);
+		YamlPanelWriter panelWriter = new YamlPanelWriter();
+		String yamlString = panelWriter.getYamlString(yamlPanels);
+		yamlString = "\n\n# Generated panel code:\n" + yamlString;
+		fileTextArea.append(yamlString);
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
@@ -18,6 +18,7 @@ import org.openpixi.pixi.physics.Settings;
 import org.openpixi.pixi.ui.PanelManager;
 import org.openpixi.pixi.ui.SimulationAnimation;
 import org.openpixi.pixi.ui.util.FileIO;
+import org.openpixi.pixi.ui.util.yaml.YamlPanelWriter;
 import org.openpixi.pixi.ui.util.yaml.YamlPanels;
 import org.openpixi.pixi.ui.util.yaml.YamlParser;
 
@@ -161,6 +162,8 @@ public class FileTab extends Box {
 			} else {
 				// ToDo: Warning message? No panel specification provided in Yaml file.
 			}
+			YamlPanelWriter panelWriter = new YamlPanelWriter();
+			panelWriter.writeYaml(settings.getYamlPanels());
 		}
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
@@ -153,7 +153,7 @@ public class FileTab extends Box {
 			parser.parseString(string);
 			YamlPanels panels = settings.getYamlPanels();
 			if (panels != null) {
-				Component component = panels.inflate(simulationAnimation);
+				Component component = panels.inflate(panelManager);
 				panelManager.replaceMainPanel(component);
 			} else {
 				// ToDo: Warning message? No panel specification provided in Yaml file.

--- a/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
@@ -10,7 +10,9 @@ import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
+import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 
@@ -31,7 +33,10 @@ public class FileTab extends Box {
 	private JButton openButton;
 	private JButton saveButton;
 	private JButton applyButton;
+	private JButton moreButton;
 	private JTextArea fileTextArea;
+	JMenuItem itemApplyPanelSettings;
+	JMenuItem itemWritePanelSettings;
 
 	public FileTab(Component parent, SimulationAnimation simulationAnimation, PanelManager panelManager) {
 		super(BoxLayout.PAGE_AXIS);
@@ -54,6 +59,8 @@ public class FileTab extends Box {
 		saveButton.addActionListener(new SaveButtonListener());
 		applyButton = new JButton("Apply");
 		applyButton.addActionListener(new ApplyButtonListener());
+		moreButton = new JButton("More...");
+		moreButton.addActionListener(new MoreButtonListener());
 		fileTextArea = new JTextArea();
 		JScrollPane scrollpane = new JScrollPane(fileTextArea);
 
@@ -61,6 +68,7 @@ public class FileTab extends Box {
 		buttonBox.add(openButton);
 		buttonBox.add(saveButton);
 		buttonBox.add(applyButton);
+		buttonBox.add(moreButton);
 
 		this.add(buttonBox);
 		this.add(scrollpane);
@@ -128,6 +136,39 @@ public class FileTab extends Box {
 		}
 	}
 
+	class MoreButtonListener implements ActionListener {
+		public void actionPerformed(ActionEvent event) {
+			PopupMenu menu = new PopupMenu();
+			menu.show(moreButton, 0, moreButton.getHeight());
+		}
+	}
+
+	class PopupMenu extends JPopupMenu {
+
+		public PopupMenu() {
+			itemApplyPanelSettings = new JMenuItem("Apply panel settings");
+			itemApplyPanelSettings.addActionListener(new MenuSelected());
+			add(itemApplyPanelSettings);
+
+			itemWritePanelSettings = new JMenuItem("Write panel settings");
+			itemWritePanelSettings.addActionListener(new MenuSelected());
+			add(itemWritePanelSettings);
+		}
+	}
+
+	class MenuSelected implements ActionListener {
+
+		@Override
+		public void actionPerformed(ActionEvent event) {
+
+			if (event.getSource() == itemApplyPanelSettings) {
+				applyTextAreaPanelSettings();
+			} else if (event.getSource() == itemWritePanelSettings) {
+				writeTextAreaPanelSettings();
+			}
+		}
+	}
+
 	/**
 	 * Apply the settings from the text area and restart the simulation.
 	 */
@@ -162,9 +203,22 @@ public class FileTab extends Box {
 			} else {
 				// ToDo: Warning message? No panel specification provided in Yaml file.
 			}
-			YamlPanelWriter panelWriter = new YamlPanelWriter();
-			panelWriter.writeYaml(settings.getYamlPanels());
 		}
 	}
 
+	/**
+	 * Append the current panel settings to the text area.
+	 */
+	public void writeTextAreaPanelSettings() {
+		String string = fileTextArea.getText();
+		if(string.length() > 0)
+		{
+			Settings settings = new Settings();
+			YamlParser parser = new YamlParser(settings);
+			YamlPanelWriter panelWriter = new YamlPanelWriter();
+			String yamlString = panelWriter.getYamlString(settings.getYamlPanels());
+			yamlString = "\n\n# Generated panel code:\n" + yamlString;
+			fileTextArea.append(yamlString);
+		}
+	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanelWriter.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanelWriter.java
@@ -13,7 +13,6 @@ public class YamlPanelWriter {
 		PanelWrapper wrapper = new PanelWrapper(panels);
 		String output = yaml.dump(wrapper);
 		output = removeLines(output);
-		System.out.println(output);
 		return output;
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanelWriter.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanelWriter.java
@@ -31,7 +31,7 @@ public class YamlPanelWriter {
 			} else if (line.startsWith("!!org.openpixi")) {
 				// omit
 			} else {
-				result = result + line + "\r";
+				result = result + line + "\n";
 			}
 		}
 		return result;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanelWriter.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanelWriter.java
@@ -5,7 +5,7 @@ import org.yaml.snakeyaml.Yaml;
 
 public class YamlPanelWriter {
 
-	public String writeYaml(YamlPanels panels) {
+	public String getYamlString(YamlPanels panels) {
 		DumperOptions options = new DumperOptions();
 		options.setIndent(2);
 		options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
@@ -13,7 +13,6 @@ public class YamlPanelWriter {
 		PanelWrapper wrapper = new PanelWrapper(panels);
 		String output = yaml.dump(wrapper);
 		output = removeLines(output);
-		output = "# Generated code:\r" + output;
 		System.out.println(output);
 		return output;
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanelWriter.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanelWriter.java
@@ -1,0 +1,48 @@
+package org.openpixi.pixi.ui.util.yaml;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+public class YamlPanelWriter {
+
+	public String writeYaml(YamlPanels panels) {
+		DumperOptions options = new DumperOptions();
+		options.setIndent(2);
+		options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+		Yaml yaml = new Yaml(options);
+		PanelWrapper wrapper = new PanelWrapper(panels);
+		String output = yaml.dump(wrapper);
+		output = removeLines(output);
+		output = "# Generated code:\r" + output;
+		System.out.println(output);
+		return output;
+	}
+
+	/**
+	 * Workaround to remove lines that only contain "xxx: null".
+	 * @param string
+	 * @return
+	 */
+	private String removeLines(String string) {
+		String lines[] = string.split("\\r?\\n");
+		String result = "";
+		for (String line : lines) {
+			if (line.endsWith(": null")) {
+				// omit
+			} else if (line.startsWith("!!org.openpixi")) {
+				// omit
+			} else {
+				result = result + line + "\r";
+			}
+		}
+		return result;
+	}
+
+	class PanelWrapper {
+		public YamlPanels panels;
+
+		public PanelWrapper(YamlPanels panels) {
+			this.panels = panels;
+		}
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
@@ -2,7 +2,7 @@ package org.openpixi.pixi.ui.util.yaml;
 
 import java.awt.Component;
 
-import org.openpixi.pixi.ui.SimulationAnimation;
+import org.openpixi.pixi.ui.PanelManager;
 import org.openpixi.pixi.ui.panel.ElectricFieldPanel;
 import org.openpixi.pixi.ui.util.yaml.panels.YamlParticle2DPanel;
 
@@ -15,8 +15,8 @@ public class YamlPanels {
 
 	public YamlParticle2DPanel particle2DPanel;
 
-	public Component inflate(SimulationAnimation simulationAnimation) {
-		Component component = new ElectricFieldPanel(simulationAnimation);
+	public Component inflate(PanelManager panelManager) {
+		Component component = new ElectricFieldPanel(panelManager.getSimulationAnimation());
 		return component;
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
@@ -4,6 +4,7 @@ import java.awt.Component;
 
 import org.openpixi.pixi.ui.PanelManager;
 import org.openpixi.pixi.ui.panel.ElectricFieldPanel;
+import org.openpixi.pixi.ui.panel.Particle2DPanel;
 import org.openpixi.pixi.ui.util.yaml.panels.YamlParticle2DPanel;
 
 public class YamlPanels {
@@ -16,7 +17,16 @@ public class YamlPanels {
 	public YamlParticle2DPanel particle2DPanel;
 
 	public Component inflate(PanelManager panelManager) {
-		Component component = new ElectricFieldPanel(panelManager.getSimulationAnimation());
+		Component component = null;
+		if (leftPanel != null && rightPanel != null) {
+			// Create new split panel
+			Component leftComponent = leftPanel.inflate(panelManager);
+			Component rightComponent = rightPanel.inflate(panelManager);
+
+			component = panelManager.getSplitPanel(leftComponent, rightComponent, orientation, dividerLocation);
+		} else if (particle2DPanel != null) {
+			component = new Particle2DPanel(panelManager.getSimulationAnimation());
+		}
 		return component;
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
@@ -5,6 +5,8 @@ import java.awt.Component;
 import org.openpixi.pixi.ui.PanelManager;
 import org.openpixi.pixi.ui.util.yaml.panels.YamlElectricFieldPanel;
 import org.openpixi.pixi.ui.util.yaml.panels.YamlParticle2DPanel;
+import org.openpixi.pixi.ui.util.yaml.panels.YamlParticle3DPanel;
+import org.openpixi.pixi.ui.util.yaml.panels.YamlPhaseSpacePanel;
 
 public class YamlPanels {
 
@@ -13,8 +15,10 @@ public class YamlPanels {
 	public Integer orientation;
 	public Integer dividerLocation;
 
-	public YamlParticle2DPanel particle2DPanel;
 	public YamlElectricFieldPanel electricFieldPanel;
+	public YamlParticle2DPanel particle2DPanel;
+	public YamlParticle3DPanel particle3DPanel;
+	public YamlPhaseSpacePanel phaseSpacePanel;
 
 	public Component inflate(PanelManager panelManager) {
 		Component component = null;
@@ -24,10 +28,14 @@ public class YamlPanels {
 			Component rightComponent = rightPanel.inflate(panelManager);
 
 			component = panelManager.getSplitPanel(leftComponent, rightComponent, orientation, dividerLocation);
-		} else if (particle2DPanel != null) {
-			component = particle2DPanel.inflate(panelManager);
 		} else if (electricFieldPanel != null) {
 			component = electricFieldPanel.inflate(panelManager);
+		} else if (particle2DPanel != null) {
+			component = particle2DPanel.inflate(panelManager);
+		} else if (particle3DPanel != null) {
+			component = particle3DPanel.inflate(panelManager);
+		} else if (phaseSpacePanel != null) {
+			component = phaseSpacePanel.inflate(panelManager);
 		}
 		return component;
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
@@ -3,8 +3,7 @@ package org.openpixi.pixi.ui.util.yaml;
 import java.awt.Component;
 
 import org.openpixi.pixi.ui.PanelManager;
-import org.openpixi.pixi.ui.panel.ElectricFieldPanel;
-import org.openpixi.pixi.ui.panel.Particle2DPanel;
+import org.openpixi.pixi.ui.util.yaml.panels.YamlElectricFieldPanel;
 import org.openpixi.pixi.ui.util.yaml.panels.YamlParticle2DPanel;
 
 public class YamlPanels {
@@ -15,6 +14,7 @@ public class YamlPanels {
 	public Integer dividerLocation;
 
 	public YamlParticle2DPanel particle2DPanel;
+	public YamlElectricFieldPanel electricFieldPanel;
 
 	public Component inflate(PanelManager panelManager) {
 		Component component = null;
@@ -25,7 +25,9 @@ public class YamlPanels {
 
 			component = panelManager.getSplitPanel(leftComponent, rightComponent, orientation, dividerLocation);
 		} else if (particle2DPanel != null) {
-			component = new Particle2DPanel(panelManager.getSimulationAnimation());
+			component = particle2DPanel.inflate(panelManager);
+		} else if (electricFieldPanel != null) {
+			component = electricFieldPanel.inflate(panelManager);
 		}
 		return component;
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
@@ -1,0 +1,22 @@
+package org.openpixi.pixi.ui.util.yaml;
+
+import java.awt.Component;
+
+import org.openpixi.pixi.ui.SimulationAnimation;
+import org.openpixi.pixi.ui.panel.ElectricFieldPanel;
+import org.openpixi.pixi.ui.util.yaml.panels.YamlParticle2DPanel;
+
+public class YamlPanels {
+
+	public YamlPanels leftPanel;
+	public YamlPanels rightPanel;
+	public Integer orientation;
+	public Integer dividerLocation;
+
+	public YamlParticle2DPanel particle2DPanel;
+
+	public Component inflate(SimulationAnimation simulationAnimation) {
+		Component component = new ElectricFieldPanel(simulationAnimation);
+		return component;
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
@@ -2,7 +2,13 @@ package org.openpixi.pixi.ui.util.yaml;
 
 import java.awt.Component;
 
+import javax.swing.JSplitPane;
+
 import org.openpixi.pixi.ui.PanelManager;
+import org.openpixi.pixi.ui.panel.ElectricFieldPanel;
+import org.openpixi.pixi.ui.panel.Particle2DPanel;
+import org.openpixi.pixi.ui.panel.Particle3DPanel;
+import org.openpixi.pixi.ui.panel.PhaseSpacePanel;
 import org.openpixi.pixi.ui.util.yaml.panels.YamlElectricFieldPanel;
 import org.openpixi.pixi.ui.util.yaml.panels.YamlParticle2DPanel;
 import org.openpixi.pixi.ui.util.yaml.panels.YamlParticle3DPanel;
@@ -20,6 +26,40 @@ public class YamlPanels {
 	public YamlParticle3DPanel particle3DPanel;
 	public YamlPhaseSpacePanel phaseSpacePanel;
 
+	/** Empty constructor called by SnakeYaml */
+	public YamlPanels() {
+	}
+
+	/**
+	 * Constructor which fills the values of this class according to
+	 * the component attached.
+	 * @param component Java swing component from which to extract the parameters.
+	 */
+	public YamlPanels(Component component) {
+		if (component instanceof JSplitPane) {
+			JSplitPane splitpane = (JSplitPane) component;
+			Component leftComponent = splitpane.getLeftComponent();
+			Component rightComponent = splitpane.getRightComponent();
+			orientation = splitpane.getOrientation();
+			dividerLocation = splitpane.getDividerLocation();
+			leftPanel = new YamlPanels(leftComponent);
+			rightPanel = new YamlPanels(rightComponent);
+		} else if (component instanceof ElectricFieldPanel) {
+			electricFieldPanel = new YamlElectricFieldPanel(component);
+		} else if (component instanceof Particle2DPanel) {
+			particle2DPanel = new YamlParticle2DPanel(component);
+		} else if (component instanceof Particle3DPanel) {
+			particle3DPanel = new YamlParticle3DPanel(component);
+		} else if (component instanceof PhaseSpacePanel) {
+			phaseSpacePanel = new YamlPhaseSpacePanel(component);
+		}
+	}
+
+	/**
+	 * Inflate the values into Java components that can be displayed by the PanelManager.
+	 * @param panelManager
+	 * @return
+	 */
 	public Component inflate(PanelManager panelManager) {
 		Component component = null;
 		if (leftPanel != null && rightPanel != null) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlSettings.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlSettings.java
@@ -32,6 +32,7 @@ public class YamlSettings {
 	public List<YamlParticleStream> streams;
     public YamlFields fields;
 	public YamlOutput output;
+	public YamlPanels panels;
 
 	public void applyTo(Settings settings) {
 
@@ -117,6 +118,10 @@ public class YamlSettings {
 
 		if (output != null) {
 			output.applyTo(settings);
+		}
+
+		if (panels != null) {
+			settings.setYamlPanels(panels);
 		}
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlElectricFieldPanel.java
@@ -15,6 +15,20 @@ public class YamlElectricFieldPanel {
 	public Double scaleFactor;
 	public Boolean automaticScaling;
 
+	/** Empty constructor called by SnakeYaml */
+	public YamlElectricFieldPanel() {
+	}
+
+	public YamlElectricFieldPanel(Component component) {
+		if (component instanceof ElectricFieldPanel) {
+			ElectricFieldPanel panel = (ElectricFieldPanel) component;
+			colorIndex = panel.getColorProperties().getColorIndex();
+			directionIndex = panel.getColorProperties().getDirectionIndex();
+			scaleFactor = panel.getScaleProperties().getScaleFactor();
+			automaticScaling = panel.getScaleProperties().getAutomaticScaling();
+		}
+	}
+
 	public Component inflate(PanelManager panelManager) {
 
 		ElectricFieldPanel panel = new ElectricFieldPanel(panelManager.getSimulationAnimation());

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlElectricFieldPanel.java
@@ -3,16 +3,19 @@ package org.openpixi.pixi.ui.util.yaml.panels;
 import java.awt.Component;
 
 import org.openpixi.pixi.ui.PanelManager;
-import org.openpixi.pixi.ui.panel.Particle2DPanel;
+import org.openpixi.pixi.ui.panel.ElectricFieldPanel;
 
-public class YamlParticle2DPanel {
+public class YamlElectricFieldPanel {
+
 
 	public Integer colorIndex;
 	public Integer directionIndex;
+	public Double scaleFactor;
+	public Boolean automaticScaling;
 
 	public Component inflate(PanelManager panelManager) {
 
-		Particle2DPanel panel = new Particle2DPanel(panelManager.getSimulationAnimation());
+		ElectricFieldPanel panel = new ElectricFieldPanel(panelManager.getSimulationAnimation());
 
 		if (colorIndex != null) {
 			panel.getColorProperties().setColorIndex(colorIndex);
@@ -22,6 +25,13 @@ public class YamlParticle2DPanel {
 			panel.getColorProperties().setDirectionIndex(directionIndex);
 		}
 
+		if (scaleFactor != null) {
+			panel.getScaleProperties().setScaleFactor(scaleFactor);
+		}
+
+		if (automaticScaling != null) {
+			panel.getScaleProperties().setAutomaticScaling(automaticScaling);
+		}
 		return panel;
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlElectricFieldPanel.java
@@ -7,9 +7,11 @@ import org.openpixi.pixi.ui.panel.ElectricFieldPanel;
 
 public class YamlElectricFieldPanel {
 
-
+	// Color properties
 	public Integer colorIndex;
 	public Integer directionIndex;
+
+	// Scale properties
 	public Double scaleFactor;
 	public Boolean automaticScaling;
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle2DPanel.java
@@ -1,0 +1,7 @@
+package org.openpixi.pixi.ui.util.yaml.panels;
+
+public class YamlParticle2DPanel {
+
+	public Integer colorIndex;
+	public Integer directionIndex;
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle2DPanel.java
@@ -7,8 +7,19 @@ import org.openpixi.pixi.ui.panel.Particle2DPanel;
 
 public class YamlParticle2DPanel {
 
+	// Color properties
 	public Integer colorIndex;
 	public Integer directionIndex;
+
+	// Field properties
+	public Boolean drawCurrent;
+	public Boolean drawFields;
+
+	// Info properties
+	public Boolean showInfo;
+
+	// Trace properties
+	public Boolean showTrace;
 
 	public Component inflate(PanelManager panelManager) {
 
@@ -20,6 +31,22 @@ public class YamlParticle2DPanel {
 
 		if (directionIndex != null) {
 			panel.getColorProperties().setDirectionIndex(directionIndex);
+		}
+
+		if (drawCurrent != null) {
+			panel.getFieldProperties().setDrawCurrent(drawCurrent);
+		}
+
+		if (drawFields != null) {
+			panel.getFieldProperties().setDrawFields(drawFields);
+		}
+
+		if (showInfo != null) {
+			panel.getInfoProperties().setShowInfo(showInfo);
+		}
+
+		if (showTrace != null) {
+			panel.getTraceProperties().setShowTrace(showTrace);
 		}
 
 		return panel;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle2DPanel.java
@@ -21,6 +21,22 @@ public class YamlParticle2DPanel {
 	// Trace properties
 	public Boolean showTrace;
 
+	/** Empty constructor called by SnakeYaml */
+	public YamlParticle2DPanel() {
+	}
+
+	public YamlParticle2DPanel(Component component) {
+		if (component instanceof Particle2DPanel) {
+			Particle2DPanel panel = (Particle2DPanel) component;
+			colorIndex = panel.getColorProperties().getColorIndex();
+			directionIndex = panel.getColorProperties().getDirectionIndex();
+			drawCurrent = panel.getFieldProperties().isDrawCurrent();
+			drawFields = panel.getFieldProperties().isDrawFields();
+			showInfo = panel.getInfoProperties().isShowInfo();
+			showTrace = panel.getTraceProperties().isShowTrace();
+		}
+	}
+
 	public Component inflate(PanelManager panelManager) {
 
 		Particle2DPanel panel = new Particle2DPanel(panelManager.getSimulationAnimation());

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle3DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle3DPanel.java
@@ -1,0 +1,27 @@
+package org.openpixi.pixi.ui.util.yaml.panels;
+
+import java.awt.Component;
+
+import org.openpixi.pixi.ui.PanelManager;
+import org.openpixi.pixi.ui.panel.Particle3DPanel;
+
+public class YamlParticle3DPanel {
+
+	public Integer colorIndex;
+	public Integer directionIndex;
+
+	public Component inflate(PanelManager panelManager) {
+
+		Particle3DPanel panel = new Particle3DPanel(panelManager.getSimulationAnimation());
+
+		if (colorIndex != null) {
+			panel.getColorProperties().setColorIndex(colorIndex);
+		}
+
+		if (directionIndex != null) {
+			panel.getColorProperties().setDirectionIndex(directionIndex);
+		}
+
+		return panel;
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle3DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle3DPanel.java
@@ -18,6 +18,21 @@ public class YamlParticle3DPanel {
 	// Info properties
 	public Boolean showInfo;
 
+	/** Empty constructor called by SnakeYaml */
+	public YamlParticle3DPanel() {
+	}
+
+	public YamlParticle3DPanel(Component component) {
+		if (component instanceof Particle3DPanel) {
+			Particle3DPanel panel = (Particle3DPanel) component;
+			colorIndex = panel.getColorProperties().getColorIndex();
+			directionIndex = panel.getColorProperties().getDirectionIndex();
+			drawCurrent = panel.getFieldProperties().isDrawCurrent();
+			drawFields = panel.getFieldProperties().isDrawFields();
+			showInfo = panel.getInfoProperties().isShowInfo();
+		}
+	}
+
 	public Component inflate(PanelManager panelManager) {
 
 		Particle3DPanel panel = new Particle3DPanel(panelManager.getSimulationAnimation());

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle3DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle3DPanel.java
@@ -18,6 +18,10 @@ public class YamlParticle3DPanel {
 	// Info properties
 	public Boolean showInfo;
 
+	// Projection properties
+	public Double phi;
+	public Double theta;
+
 	/** Empty constructor called by SnakeYaml */
 	public YamlParticle3DPanel() {
 	}
@@ -30,6 +34,8 @@ public class YamlParticle3DPanel {
 			drawCurrent = panel.getFieldProperties().isDrawCurrent();
 			drawFields = panel.getFieldProperties().isDrawFields();
 			showInfo = panel.getInfoProperties().isShowInfo();
+			phi = panel.getProjection().phi;
+			theta = panel.getProjection().theta;
 		}
 	}
 
@@ -57,6 +63,13 @@ public class YamlParticle3DPanel {
 			panel.getInfoProperties().setShowInfo(showInfo);
 		}
 
+		if (phi != null) {
+			panel.getProjection().phi = phi;
+		}
+
+		if (theta != null) {
+			panel.getProjection().theta = theta;
+		}
 		return panel;
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle3DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlParticle3DPanel.java
@@ -7,8 +7,16 @@ import org.openpixi.pixi.ui.panel.Particle3DPanel;
 
 public class YamlParticle3DPanel {
 
+	// Color properties
 	public Integer colorIndex;
 	public Integer directionIndex;
+
+	// Field properties
+	public Boolean drawCurrent;
+	public Boolean drawFields;
+
+	// Info properties
+	public Boolean showInfo;
 
 	public Component inflate(PanelManager panelManager) {
 
@@ -20,6 +28,18 @@ public class YamlParticle3DPanel {
 
 		if (directionIndex != null) {
 			panel.getColorProperties().setDirectionIndex(directionIndex);
+		}
+
+		if (drawCurrent != null) {
+			panel.getFieldProperties().setDrawCurrent(drawCurrent);
+		}
+
+		if (drawFields != null) {
+			panel.getFieldProperties().setDrawFields(drawFields);
+		}
+
+		if (showInfo != null) {
+			panel.getInfoProperties().setShowInfo(showInfo);
 		}
 
 		return panel;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlPhaseSpacePanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlPhaseSpacePanel.java
@@ -7,6 +7,7 @@ import org.openpixi.pixi.ui.panel.PhaseSpacePanel;
 
 public class YamlPhaseSpacePanel {
 
+	// Scale properties
 	public Double scaleFactor;
 	public Boolean automaticScaling;
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlPhaseSpacePanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlPhaseSpacePanel.java
@@ -11,6 +11,18 @@ public class YamlPhaseSpacePanel {
 	public Double scaleFactor;
 	public Boolean automaticScaling;
 
+	/** Empty constructor called by SnakeYaml */
+	public YamlPhaseSpacePanel() {
+	}
+
+	public YamlPhaseSpacePanel(Component component) {
+		if (component instanceof PhaseSpacePanel) {
+			PhaseSpacePanel panel = (PhaseSpacePanel) component;
+			scaleFactor = panel.getScaleProperties().getScaleFactor();
+			automaticScaling = panel.getScaleProperties().getAutomaticScaling();
+		}
+	}
+
 	public Component inflate(PanelManager panelManager) {
 
 		PhaseSpacePanel panel = new PhaseSpacePanel(panelManager.getSimulationAnimation());

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlPhaseSpacePanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlPhaseSpacePanel.java
@@ -1,0 +1,28 @@
+package org.openpixi.pixi.ui.util.yaml.panels;
+
+import java.awt.Component;
+
+import org.openpixi.pixi.ui.PanelManager;
+import org.openpixi.pixi.ui.panel.PhaseSpacePanel;
+
+public class YamlPhaseSpacePanel {
+
+	public Double scaleFactor;
+	public Boolean automaticScaling;
+
+	public Component inflate(PanelManager panelManager) {
+
+		PhaseSpacePanel panel = new PhaseSpacePanel(panelManager.getSimulationAnimation());
+
+
+		if (scaleFactor != null) {
+			panel.getScaleProperties().setScaleFactor(scaleFactor);
+		}
+
+		if (automaticScaling != null) {
+			panel.getScaleProperties().setAutomaticScaling(automaticScaling);
+		}
+
+		return panel;
+	}
+}


### PR DESCRIPTION
Read the panel layout from the YAML input file.

To store the current panel layout, click on tab "File" / "More..." / "Write panel settings". This will append the current panel layout to the YAML file.

"File" / "Apply" only applies the settings without modifying the panel layout. To change the panel layout, use "File" / "More..." / "Apply panel settings".
