### PR TITLE
Yang Mills gauge link conventions

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/FieldGenerators/SU2PlanePulse.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/FieldGenerators/SU2PlanePulse.java
@@ -84,13 +84,13 @@ public class SU2PlanePulse implements IFieldGenerator {
 				scalarProduct += this.direction[i] * (currentPosition[i] - this.position[i]);
 			}
 
-			//Multiplicative factor for the plane pulse at t = - dt/2 (for electric fields)
-			double phaseE = scalarProduct + c*timeStep/2.0;
-			double electricFieldFactor =  g * as * c * phaseE / Math.pow(sigma, 2.0) *
+			//Multiplicative factor for the plane pulse at t = 0 (for electric fields)
+			double phaseE = scalarProduct;
+			double electricFieldFactor =  - g * as * c * phaseE / Math.pow(sigma, 2.0) *
 					Math.exp(- Math.pow(phaseE / this.sigma, 2.0) / 2.0);
-			//Multiplicative factor for the plane pulse at t = 0 (for links)
-			double phaseU = scalarProduct;
-			double gaugeFieldFactor = g* as * Math.exp(- Math.pow(phaseU / this.sigma, 2.0) / 2.0);
+			//Multiplicative factor for the plane pulse at t = dt/2 (for links)
+			double phaseU = scalarProduct - c * timeStep / 2.0;
+			double gaugeFieldFactor = g * as * Math.exp(- Math.pow(phaseU / this.sigma, 2.0) / 2.0);
 
 
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/FieldGenerators/SU2PlaneWave.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/FieldGenerators/SU2PlaneWave.java
@@ -79,9 +79,9 @@ public class SU2PlaneWave implements IFieldGenerator {
             }
             omega = s.getSpeedOfLight() * Math.sqrt(omega);
 
-            //Factor of the plane wave at t = - dt/2 (for electric fields)
+            //Factor of the plane wave at t = 0 (for electric fields)
             double factorForE = - g * as * omega * Math.sin(kx);
-            //Phase of the plane wave at t = 0 (for links)
+            //Phase of the plane wave at t = dt/2 (for links)
             double factorForU = g * as * Math.cos(omega * timeStep /2.0  - kx);
 
 
@@ -93,7 +93,6 @@ public class SU2PlaneWave implements IFieldGenerator {
                 //Setup the gauge links
                 SU2Matrix U = (SU2Matrix) currentCell.getU(i).mult(amplitudeYMField[i].mult(factorForU).getLinkExact());
 				currentCell.setU(i, U);
-				//System.out.println(currentCell.getU(i).get(0));
 
                 //Setup the electric fields
                 currentCell.addE(i, amplitudeYMField[i].mult(factorForE));

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/FieldGenerators/SU2PlaneWave.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/FieldGenerators/SU2PlaneWave.java
@@ -80,9 +80,9 @@ public class SU2PlaneWave implements IFieldGenerator {
             omega = s.getSpeedOfLight() * Math.sqrt(omega);
 
             //Factor of the plane wave at t = - dt/2 (for electric fields)
-            double factorForE = g * as * omega * Math.sin(omega * (this.timeStep / 2.0) + kx);
+            double factorForE = - g * as * omega * Math.sin(kx);
             //Phase of the plane wave at t = 0 (for links)
-            double factorForU = g * as * Math.cos(kx);
+            double factorForU = g * as * Math.cos(omega * timeStep /2.0  - kx);
 
 
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/GeneralYangMillsSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/GeneralYangMillsSolver.java
@@ -64,7 +64,7 @@ public class GeneralYangMillsSolver extends FieldSolver
 					plaquettes[0] = plaquettes[0].add(plaquettes[p]);
 				}
 
-				YMField currentE =  grid.getE(coor, i).sub(plaquettes[0].proj().mult(2 * at / (as * as )));
+				YMField currentE = grid.getE(coor, i).add(plaquettes[0].proj().mult(2 * at / (as * as )));
 				grid.setE(coor, i, currentE);
 			}
 		}
@@ -86,8 +86,8 @@ public class GeneralYangMillsSolver extends FieldSolver
 
 			for(int k=0;k<coor.length;k++) {
 
-				V = grid.getE(coor, k).mult(at).getLinkExact();	//minus sign takes take of conjugation
-				grid.setUnext( coor, k, grid.getU(coor, k).mult(V) );
+				V = grid.getE(coor, k).mult(-at).getLinkExact();	//minus sign takes take of conjugation
+				grid.setUnext( coor, k, V.mult(grid.getU(coor, k)) );
 
 			}
 		}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Cell.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Cell.java
@@ -11,19 +11,19 @@ public class Cell implements Serializable {
 	/**Local electric current in d directions*/
 	private YMField[] J;
 
-	/**Local charge density*/
+	/**Local charge density at time */
 	private YMField rho;
 
-	/**Electric fields in d directions at time t+dt*/
+	/**Electric fields in d directions at time t */
 	private YMField[] E;
 	
-	/**Purely spatial components of the field-strength tensor*/
+	/**Purely spatial components of the field-strength tensor at time*/
 	private YMField[][] F;
 	
-	/**Link matrices at time t*/
+	/**Link matrices at time t - dt/2 */
 	private LinkMatrix[] U;
 	
-	/**Link matrices at time t+dt*/
+	/**Link matrices at time t + dt/2 */
 	private LinkMatrix[] Unext;
 
 	

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -370,7 +370,7 @@ public class Grid {
 	/**
 	 * Calculates the plaquette starting at lattice coordinate coor in the plane of d1 and d2 with orientations o1, o2.
 	 * This method implements the following definition of the plaquette:
-	 *      U_{x, ij} = U_{x+j, -j} U_{x+i+j, -i} U_{x+i, j} U_{x, i}
+	 *      U_{x, ij} = U_{x, i} U_{x+i, j} U_{x+i+j, -i} U_{x+j, -j}
 	 *
 	 *
 	 * @param coor  Lattice coordinate from where the plaquette starts
@@ -403,7 +403,7 @@ public class Grid {
 			Plaquette calculation
 		 */
 
-		return U4.mult(U3).mult(U2).mult(U1);
+		return U1.mult(U2.mult(U3.mult(U4)));
 	}
 
 	/**


### PR DESCRIPTION
Changed the convention used for gauge links from the one used in Rebhan, Romatschke, Strickland (2005) [arXiv:hep-ph/0505261] to the more common convention used in e.g. Bodeker, Moore, Rummukainen (1999) [arXiv:hep-ph/9907545] and many lattice gauge theory text books. This does not change the behavior of the simulation.
