### PR TITLE
Implement Coulomb and random gauge

### DIFF
--- a/pixi/input/Wave_Gauge_Transformation_Test.yaml
+++ b/pixi/input/Wave_Gauge_Transformation_Test.yaml
@@ -1,0 +1,39 @@
+# Wave gauge transformation test
+
+gridStep: 1
+numberOfDimensions: 3
+numberOfColors: 2
+gridCells: [256, 1, 1]
+poissonsolver: empty
+timeStep: 0.1
+duration: 1000
+
+fields:
+  SU2PlaneWaves:
+      # wave vector of the plane wave
+    - k: [0.490874, 0.0, 0.0]
+
+      # spatial part of the wave amplitude
+      aSpatial: [0.0, 1.0,0.0]
+
+      # color part of the wave amplitude
+      aColor: [1.0, 0.0, 0.0]
+
+      # magnitude of the wave amplitude
+      a: 0.1
+
+output:
+  randomGaugeInTime:
+    - interval: 10
+      offset: 5
+      aColor: [1, 1, 0]
+
+  coulombGaugeInTime:
+    - interval: 10
+      offset: 0
+
+panels:
+  electricFieldPanel:
+    colorIndex: 0
+    directionIndex: 1
+    scaleFactor: 2

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/CoulombGaugeInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/CoulombGaugeInTime.java
@@ -1,0 +1,41 @@
+package org.openpixi.pixi.diagnostics.methods;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.openpixi.pixi.diagnostics.Diagnostics;
+import org.openpixi.pixi.physics.Simulation;
+import org.openpixi.pixi.physics.gauge.CoulombGauge;
+import org.openpixi.pixi.physics.grid.Grid;
+import org.openpixi.pixi.physics.particles.IParticle;
+
+/**
+ * Applies the Coulomb Gauge to the current simulation at specified times.
+ */
+public class CoulombGaugeInTime implements Diagnostics {
+
+	private double timeInterval;
+	private int stepInterval;
+	private double timeOffset;
+	private int stepOffset;
+
+	public CoulombGaugeInTime(double timeInterval, double timeOffset) {
+		this.timeInterval = timeInterval;
+		this.timeOffset = timeOffset;
+	}
+
+	@Override
+	public void initialize(Simulation s) {
+		this.stepInterval = (int) (timeInterval / s.getTimeStep());
+		this.stepOffset = (int) (timeOffset / s.getTimeStep());
+	}
+
+	@Override
+	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps)
+			throws IOException {
+		if ((steps - stepOffset) % stepInterval == 0) {
+			CoulombGauge coulombGauge = new CoulombGauge(grid);
+			coulombGauge.applyGaugeTransformation(grid);
+		}
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/RandomGaugeInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/RandomGaugeInTime.java
@@ -1,0 +1,48 @@
+package org.openpixi.pixi.diagnostics.methods;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.openpixi.pixi.diagnostics.Diagnostics;
+import org.openpixi.pixi.physics.Simulation;
+import org.openpixi.pixi.physics.gauge.CoulombGauge;
+import org.openpixi.pixi.physics.gauge.RandomGauge;
+import org.openpixi.pixi.physics.grid.Grid;
+import org.openpixi.pixi.physics.particles.IParticle;
+
+/**
+ * Applies the Coulomb Gauge to the current simulation at specified times.
+ */
+public class RandomGaugeInTime implements Diagnostics {
+
+	private double timeInterval;
+	private int stepInterval;
+	private double timeOffset;
+	private int stepOffset;
+	/**
+	 * Random vector in color space.
+	 */
+	private double[] randomVector;
+
+	public RandomGaugeInTime(double timeInterval, double timeOffset, double[] randomVector) {
+		this.timeInterval = timeInterval;
+		this.timeOffset = timeOffset;
+		this.randomVector = randomVector;
+	}
+
+	@Override
+	public void initialize(Simulation s) {
+		this.stepInterval = (int) (timeInterval / s.getTimeStep());
+		this.stepOffset = (int) (timeOffset / s.getTimeStep());
+	}
+
+	@Override
+	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps)
+			throws IOException {
+		if ((steps - stepOffset) % stepInterval == 0) {
+			RandomGauge randomGauge = new RandomGauge(grid);
+			randomGauge.setRandomVector(randomVector);
+			randomGauge.applyGaugeTransformation(grid);
+		}
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
@@ -270,6 +270,17 @@ public class Settings {
 		this.simulationType = simulationType;
 	}
 
+	/**
+	 * Set dimension and number of grid cells in each direction.
+	 * @param gridCells
+	 */
+	public void setGridCells(int[] gridCells) {
+		setNumberOfDimensions(gridCells.length);
+		for (int i=0; i<gridCells.length; i++) {
+			setGridCells(i, gridCells[i]);
+		}
+	}
+
 	public void setGridCells(int i, int num) {
 		gridCells[i] = num;
 		simulationWidth[i] = gridStep*num;

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/CoulombGauge.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/CoulombGauge.java
@@ -1,0 +1,78 @@
+package org.openpixi.pixi.physics.fields;
+
+import org.openpixi.pixi.parallel.cellaccess.CellAction;
+import org.openpixi.pixi.physics.Settings;
+import org.openpixi.pixi.physics.grid.Grid;
+import org.openpixi.pixi.physics.grid.LinkMatrix;
+import org.openpixi.pixi.physics.grid.SU2Matrix;
+import org.openpixi.pixi.physics.grid.YMField;
+
+public class CoulombGauge {
+
+	GaugeTransform gaugeTransform = new GaugeTransform();
+
+	Grid gaugedGrid;
+
+	/** Gauge transformation */
+	private LinkMatrix[] g;
+
+	public CoulombGauge (Grid grid) {
+		gaugedGrid = new Grid(grid);
+	}
+
+	public void fixGauge(Grid grid) {
+
+		// Copy grid
+		int numberOfCells = grid.getNumberOfCells();
+
+		int colors = grid.getNumberOfColors();
+		if (colors != 2) {System.out.println("Coulomb gauge for SU(" + colors + ") not defined.\n");
+			return;
+		}
+
+		g = new SU2Matrix[numberOfCells];
+
+		// Reset the gauge transformation
+		for (int i = 0; i < g.length; i++) {
+			g[i] = new SU2Matrix(1, 0, 0, 0);
+		}
+
+		/*
+			Copy the U-field.
+		 */
+		for (int ci = 0; ci < numberOfCells; ci++) {
+			int[] cellPosition = grid.getCellPos(ci);
+			for (int d = 0; d < grid.getNumberOfDimensions(); d++) {
+				LinkMatrix U = grid.getU(cellPosition, d);
+				gaugedGrid.setU(cellPosition, d, U);
+				YMField E = grid.getE(cellPosition, d);
+				gaugedGrid.setE(cellPosition, d, E);
+			}
+		}
+
+		/*
+			Cycle through each cell and apply the gauge transformation
+		 */
+		gaugedGrid.getCellIterator().execute(gaugedGrid, gaugeTransform);
+
+	}
+
+	public Grid getGaugedGrid() {
+		return gaugedGrid;
+	}
+
+	private class GaugeTransform implements CellAction {
+		public void execute(Grid grid, int[] coor) {
+			int cellIndex = grid.getCellIndex(coor);
+			for (int d = 0; d < grid.getNumberOfDimensions(); d++) {
+				// TODO: replace dummy transformation
+				LinkMatrix U = grid.getU(coor, d);
+				U = U.mult(g[cellIndex]);
+				grid.setU(coor, d, U);
+				YMField E = grid.getE(coor, d);
+				E = (E.getLink().mult(g[cellIndex])).getLinearizedAlgebraElement();
+				grid.setE(coor, d, E);
+			}
+		}
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/CoulombGauge.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/CoulombGauge.java
@@ -1,23 +1,43 @@
 package org.openpixi.pixi.physics.fields;
 
 import org.openpixi.pixi.parallel.cellaccess.CellAction;
-import org.openpixi.pixi.physics.Settings;
 import org.openpixi.pixi.physics.grid.Grid;
 import org.openpixi.pixi.physics.grid.LinkMatrix;
+import org.openpixi.pixi.physics.grid.SU2Field;
 import org.openpixi.pixi.physics.grid.SU2Matrix;
 import org.openpixi.pixi.physics.grid.YMField;
+
+import edu.emory.mathcs.jtransforms.fft.DoubleFFT_3D;
 
 public class CoulombGauge {
 
 	GaugeTransform gaugeTransform = new GaugeTransform();
+	CalculateDivergence calculateDivergence = new CalculateDivergence();
+	InverseLaplaceOperator inverseLaplaceOperator = new InverseLaplaceOperator();
 
 	Grid gaugedGrid;
 
 	/** Gauge transformation */
 	private LinkMatrix[] g;
 
+	private double[][][] fftArray;
+	private DoubleFFT_3D fft;
+
+	/**
+	 * Constructor. Obtain size of required grid from other grid.
+	 * @param grid Grid that should be duplicated in size.
+	 */
 	public CoulombGauge (Grid grid) {
 		gaugedGrid = new Grid(grid);
+
+		if(grid.getNumberOfDimensions() != 3) {
+			System.out.println("Coulomb gauge transformation currently only available for 3 dimensions!");
+		}
+		// JTransform requires twice as many rows in the last column,
+		// for real and imaginary parts
+		fftArray = new double[grid.getNumCells(0)][grid.getNumCells(1)][2 * grid.getNumCells(2)];
+
+		fft = new DoubleFFT_3D(grid.getNumCells(0), grid.getNumCells(1), grid.getNumCells(2));
 	}
 
 	public void fixGauge(Grid grid) {
@@ -50,11 +70,54 @@ public class CoulombGauge {
 			}
 		}
 
+		// TODO: Iterate until required accuracy is reached.
+		for (int j = 0; j < 3; j++) {
+			double divergenceSquaredSum = iterateCoulombGauge();
+			System.out.println("Iteration " + j + " - Divergence U: " + divergenceSquaredSum);
+		}
+	}
+
+	/**
+	 * Performs a single iteration step.
+	 * @return previous divergence
+	 */
+	private double iterateCoulombGauge() {
+		double divergenceSquaredSum = 0;
+
+		for (int color = 0; color < gaugedGrid.getNumberOfColors(); color++) {
+			// Calculate Divergence and put into fftArray
+			calculateDivergence.setColorAndResetSum(0);
+			gaugedGrid.getCellIterator().execute(gaugedGrid, calculateDivergence);
+			divergenceSquaredSum += calculateDivergence.getDivergenceSquaredSum();
+
+			// Solve Poisson's equation by applying the inverse Laplace operator
+			// for discrete lattice derivatives in Fourier space:
+			fft.complexForward(fftArray);
+			gaugedGrid.getCellIterator().execute(gaugedGrid, inverseLaplaceOperator);
+			fft.complexInverse(fftArray, true);
+
+			// Add result to gauge transformation
+			for (int i = 0; i < g.length; i++) {
+				int[] coor = gaugedGrid.getCellPos(i);
+
+				// real part:
+				double value = fftArray[coor[0]][coor[1]][2 * coor[2]];
+				g[i].set(color, value);
+			}
+		}
+
+		// Calculate g(x) = exp(i g psi^\dagger)
+		for (int i = 0; i < g.length; i++) {
+			// psi is stored in g for convenience:
+			SU2Field psidagger = (SU2Field) g[i].adj().proj();
+			g[i] = psidagger.getLinkExact();
+		}
+
 		/*
 			Cycle through each cell and apply the gauge transformation
 		 */
 		gaugedGrid.getCellIterator().execute(gaugedGrid, gaugeTransform);
-
+		return divergenceSquaredSum;
 	}
 
 	public Grid getGaugedGrid() {
@@ -64,15 +127,87 @@ public class CoulombGauge {
 	private class GaugeTransform implements CellAction {
 		public void execute(Grid grid, int[] coor) {
 			int cellIndex = grid.getCellIndex(coor);
-			for (int d = 0; d < grid.getNumberOfDimensions(); d++) {
-				// TODO: replace dummy transformation
-				LinkMatrix U = grid.getU(coor, d);
-				U = U.mult(g[cellIndex]);
-				grid.setU(coor, d, U);
-				YMField E = grid.getE(coor, d);
-				E = (E.getLink().mult(g[cellIndex])).getLinearizedAlgebraElement();
-				grid.setE(coor, d, E);
+			for (int dir = 0; dir < grid.getNumberOfDimensions(); dir++) {
+				/*
+				 * U_i(x) -> g(x) U_i(x) g^\dagger(x+i)
+				 */
+				LinkMatrix U = grid.getU(coor, dir);
+				int shiftedCellIndex = grid.getCellIndex(grid.shift(coor, dir, 1));
+				LinkMatrix gdaggershifted = g[shiftedCellIndex].adj();
+				U = g[cellIndex].mult(U).mult(gdaggershifted);
+				grid.setU(coor, dir, U);
+
+				/*
+				 * E_i(x) -> g(x) E_i(x) g^\dagger(x)
+				 */
+				YMField E = grid.getE(coor, dir);
+				LinkMatrix gdagger = g[cellIndex].adj();
+				E = (g[cellIndex].mult(E.getLink()).mult(gdagger)).getLinearizedAlgebraElement();
+				// TODO: rather work with exact mapping?
+				//E = (g[cellIndex].mult(E.getLinkExact()).mult(gdagger)).getAlgebraElement();
+				grid.setE(coor, dir, E);
 			}
 		}
 	}
+
+	private class CalculateDivergence implements CellAction {
+		private int color;
+		private double divergenceSquaredSum;
+
+		public void setColorAndResetSum(int color) {
+			this.color = color;
+			divergenceSquaredSum = 0;
+		}
+
+		public double getDivergenceSquaredSum() {
+			return divergenceSquaredSum;
+		}
+
+		public void execute(Grid grid, int[] coor) {
+			double divergenceU = 0;
+			for (int dir = 0; dir < grid.getNumberOfDimensions(); dir++) {
+				/*
+				 * U_i(x) - U_i(x-i)
+				 */
+				LinkMatrix U = grid.getU(coor, dir);
+				LinkMatrix Ushifted = grid.getU(grid.shift(coor, dir, -1), dir);
+				divergenceU += U.get(color) - Ushifted.get(color);
+			}
+			fftArray[coor[0]][coor[1]][2 * coor[2]] = divergenceU; // real part
+			fftArray[coor[0]][coor[1]][2 * coor[2] + 1] = 0; // imaginary part
+			double divergenceUSquared = divergenceU * divergenceU;
+			synchronized(this) {
+				divergenceSquaredSum += divergenceUSquared;
+			}
+		}
+	}
+
+	private class InverseLaplaceOperator implements CellAction {
+		public void execute(Grid grid, int[] coor) {
+			int kx = coor[0];
+			int ky = coor[1];
+			int kz = coor[2];
+			if (kx == 0 && ky == 0 && kz == 0) {
+				// zero vector component does not contribute:
+				fftArray[0][0][0] = 0; // real part
+				fftArray[0][0][1] = 0; // imaginary part
+			} else {
+				// Calculate inverse Laplace operator on the lattice for discrete derivatives:
+				double Nx = grid.getNumCells(0);
+				double Ny = grid.getNumCells(1);
+				double Nz = grid.getNumCells(2);
+
+				double inverseLaplace = -0.5 / ((Math.cos(2 * Math.PI * kx / Nx)
+						+ Math.cos(2 * Math.PI * ky / Ny)
+						+ Math.cos(2 * Math.PI * kz / Nz) - 3.));
+
+				// Real part:
+				fftArray[coor[0]][coor[1]][2 * coor[2]] *= inverseLaplace;
+
+				// Imaginary part:
+				fftArray[coor[0]][coor[1]][2 * coor[2] + 1] *= inverseLaplace;
+			}
+		}
+	}
+
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2FocusedGaussianPulse.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2FocusedGaussianPulse.java
@@ -78,14 +78,7 @@ public class SU2FocusedGaussianPulse implements IFieldGenerator {
 					this.amplitudeMagnitude * this.amplitudeSpatialDirection[i] * this.amplitudeColorDirection[2]);
 		}
 
-		/*
-			Calculate number of cells in the grid.
-		 */
-		int numberOfCells = 1;
-		for (int i = 0; i < this.numberOfDimensions; i++) {
-			numberOfCells *= grid.getNumCells(i);
-		}
-
+		int numberOfCells = grid.getNumberOfCells();
 
 		/*
 			Cycle through each cell and apply the focused gaussian pulse configuration to the links and electric fields.

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2FocusedGaussianPulse.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2FocusedGaussianPulse.java
@@ -78,7 +78,7 @@ public class SU2FocusedGaussianPulse implements IFieldGenerator {
 					this.amplitudeMagnitude * this.amplitudeSpatialDirection[i] * this.amplitudeColorDirection[2]);
 		}
 
-		int numberOfCells = grid.getNumberOfCells();
+		int numberOfCells = grid.getTotalNumberOfCells();
 
 		/*
 			Cycle through each cell and apply the focused gaussian pulse configuration to the links and electric fields.

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2GaussianPulse.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2GaussianPulse.java
@@ -61,7 +61,7 @@ public class SU2GaussianPulse implements IFieldGenerator {
 					this.amplitudeMagnitude * this.amplitudeSpatialDirection[i] * this.amplitudeColorDirection[2]);
 		}
 
-		int numberOfCells = grid.getNumberOfCells();
+		int numberOfCells = grid.getTotalNumberOfCells();
 
 		/*
 			Cycle through each cell and apply the gaussian pulse configuration to the links and electric fields.

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2GaussianPulse.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2GaussianPulse.java
@@ -61,14 +61,7 @@ public class SU2GaussianPulse implements IFieldGenerator {
 					this.amplitudeMagnitude * this.amplitudeSpatialDirection[i] * this.amplitudeColorDirection[2]);
 		}
 
-		/*
-			Calculate number of cells in the grid.
-		 */
-		int numberOfCells = 1;
-		for (int i = 0; i < this.numberOfDimensions; i++) {
-			numberOfCells *= grid.getNumCells(i);
-		}
-
+		int numberOfCells = grid.getNumberOfCells();
 
 		/*
 			Cycle through each cell and apply the gaussian pulse configuration to the links and electric fields.

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2PlanePulse.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2PlanePulse.java
@@ -61,7 +61,7 @@ public class SU2PlanePulse implements IFieldGenerator {
 					this.amplitudeMagnitude * this.amplitudeSpatialDirection[i] * this.amplitudeColorDirection[2]);
 		}
 
-		int numberOfCells = grid.getNumberOfCells();
+		int numberOfCells = grid.getTotalNumberOfCells();
 
 		/*
 			Cycle through each cell and apply the plane pulse configuration to the links and electric fields.

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2PlanePulse.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2PlanePulse.java
@@ -61,14 +61,7 @@ public class SU2PlanePulse implements IFieldGenerator {
 					this.amplitudeMagnitude * this.amplitudeSpatialDirection[i] * this.amplitudeColorDirection[2]);
 		}
 
-		/*
-			Calculate number of cells in the grid.
-		 */
-		int numberOfCells = 1;
-		for (int i = 0; i < this.numberOfDimensions; i++) {
-			numberOfCells *= grid.getNumCells(i);
-		}
-
+		int numberOfCells = grid.getNumberOfCells();
 
 		/*
 			Cycle through each cell and apply the plane pulse configuration to the links and electric fields.

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2PlaneWave.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2PlaneWave.java
@@ -53,7 +53,7 @@ public class SU2PlaneWave implements IFieldGenerator {
 					this.amplitudeMagnitude * this.amplitudeSpatialDirection[i] * this.amplitudeColorDirection[2]);
 		}
 
-		int numberOfCells = grid.getNumberOfCells();
+		int numberOfCells = grid.getTotalNumberOfCells();
 
 		/*
 			Cycle through each cell and apply the plane wave configuration to the links and electric fields.

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2PlaneWave.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2PlaneWave.java
@@ -53,14 +53,7 @@ public class SU2PlaneWave implements IFieldGenerator {
 					this.amplitudeMagnitude * this.amplitudeSpatialDirection[i] * this.amplitudeColorDirection[2]);
 		}
 
-		/*
-			Calculate number of cells in the grid.
-		 */
-		int numberOfCells = 1;
-		for (int i = 0; i < this.numberOfDimensions; i++) {
-			numberOfCells *= grid.getNumCells(i);
-		}
-
+		int numberOfCells = grid.getNumberOfCells();
 
 		/*
 			Cycle through each cell and apply the plane wave configuration to the links and electric fields.

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2RandomFields.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2RandomFields.java
@@ -19,7 +19,7 @@ public class SU2RandomFields implements IFieldGenerator {
 		this.numberOfDimensions = s.getNumberOfDimensions();
 		this.numberOfComponents = 3;
 
-		int numberOfCells = g.getNumberOfCells();
+		int numberOfCells = g.getTotalNumberOfCells();
 
 		double magnitude = 10.0;
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2RandomFields.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/fieldgenerators/SU2RandomFields.java
@@ -19,12 +19,7 @@ public class SU2RandomFields implements IFieldGenerator {
 		this.numberOfDimensions = s.getNumberOfDimensions();
 		this.numberOfComponents = 3;
 
-		// Calculate number of cells in the grid.
-
-		int numberOfCells = 1;
-		for (int i = 0; i < this.numberOfDimensions; i++) {
-			numberOfCells *= g.getNumCells(i);
-		}
+		int numberOfCells = g.getNumberOfCells();
 
 		double magnitude = 10.0;
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/gauge/CoulombGauge.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/gauge/CoulombGauge.java
@@ -146,7 +146,11 @@ public class CoulombGauge {
 				double Ny = grid.getNumCells(1);
 				double Nz = grid.getNumCells(2);
 
-				double inverseLaplace = -0.5 / ((Math.cos(2 * Math.PI * kx / Nx)
+//				double inverseLaplace = -0.5 / ((Math.cos(2 * Math.PI * kx / Nx)
+//						+ Math.cos(2 * Math.PI * ky / Ny)
+//						+ Math.cos(2 * Math.PI * kz / Nz) - 3.));
+
+				double inverseLaplace = +3.25 / ((Math.cos(2 * Math.PI * kx / Nx)
 						+ Math.cos(2 * Math.PI * ky / Ny)
 						+ Math.cos(2 * Math.PI * kz / Nz) - 3.));
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/gauge/CoulombGauge.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/gauge/CoulombGauge.java
@@ -56,7 +56,7 @@ public class CoulombGauge {
 		int colors = transformation.gaugedGrid.getNumberOfColors();
 		for (int color = 0; color < colors; color++) {
 			// Calculate Divergence and put into fftArray
-			calculateDivergence.setColorAndResetSum(0);
+			calculateDivergence.setColorAndResetSum(color);
 			transformation.gaugedGrid.getCellIterator().execute(transformation.gaugedGrid, calculateDivergence);
 			divergenceSquaredSum += calculateDivergence.getDivergenceSquaredSum();
 
@@ -72,7 +72,9 @@ public class CoulombGauge {
 
 				// real part:
 				double value = fftArray[coor[0]][coor[1]][2 * coor[2]];
-				transformation.g[i].set(color, value);
+
+				// Store values temporarily in SU2Matrix instead of SU2Field:
+				transformation.g[i].set(color + 1, value);
 			}
 		}
 
@@ -118,8 +120,9 @@ public class CoulombGauge {
 				/*
 				 * U_i(x) - U_i(x-i)
 				 */
-				LinkMatrix U = grid.getU(coor, dir);
-				LinkMatrix Ushifted = grid.getU(grid.shift(coor, dir, -1), dir);
+				YMField U = grid.getU(coor, dir).getAlgebraElement();
+				YMField Ushifted = grid.getU(grid.shift(coor, dir, -1), dir).getAlgebraElement();
+
 				divergenceU += U.get(color) - Ushifted.get(color);
 			}
 			fftArray[coor[0]][coor[1]][2 * coor[2]] = divergenceU; // real part
@@ -146,11 +149,7 @@ public class CoulombGauge {
 				double Ny = grid.getNumCells(1);
 				double Nz = grid.getNumCells(2);
 
-//				double inverseLaplace = -0.5 / ((Math.cos(2 * Math.PI * kx / Nx)
-//						+ Math.cos(2 * Math.PI * ky / Ny)
-//						+ Math.cos(2 * Math.PI * kz / Nz) - 3.));
-
-				double inverseLaplace = +3.25 / ((Math.cos(2 * Math.PI * kx / Nx)
+				double inverseLaplace = -0.5 / ((Math.cos(2 * Math.PI * kx / Nx)
 						+ Math.cos(2 * Math.PI * ky / Ny)
 						+ Math.cos(2 * Math.PI * kz / Nz) - 3.));
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/gauge/CoulombGauge.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/gauge/CoulombGauge.java
@@ -8,6 +8,9 @@ import org.openpixi.pixi.physics.grid.Grid;
 import org.openpixi.pixi.physics.grid.SU2Field;
 import org.openpixi.pixi.physics.grid.YMField;
 
+/**
+ * Appy the Coulomb gauge transformation to a grid.
+ */
 public class CoulombGauge extends GaugeTransformation {
 
 	CalculateDivergence calculateDivergence = new CalculateDivergence();

--- a/pixi/src/main/java/org/openpixi/pixi/physics/gauge/DoubleFFTWrapper.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/gauge/DoubleFFTWrapper.java
@@ -1,0 +1,124 @@
+package org.openpixi.pixi.physics.gauge;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.emory.mathcs.jtransforms.fft.DoubleFFT_1D;
+import edu.emory.mathcs.jtransforms.fft.DoubleFFT_2D;
+import edu.emory.mathcs.jtransforms.fft.DoubleFFT_3D;
+
+/**
+ * FFT Wrapper for jtransform for arbitrary dimensions (up to 3).
+ *
+ */
+public class DoubleFFTWrapper {
+
+	private int[] dimensions;
+	private List<Integer> dimensionsFFT;
+
+	private DoubleFFT_1D doubleFFT_1D;
+	private DoubleFFT_2D doubleFFT_2D;
+	private DoubleFFT_3D doubleFFT_3D;
+
+	/**
+	 * Constructor of FFT Wrapper
+	 * @param dimensions dimension and size in each direction
+	 */
+	public DoubleFFTWrapper(int[] dimensions) {
+		this.dimensions = dimensions;
+
+		dimensionsFFT = getEffectiveDimension(dimensions);
+
+		if (dimensionsFFT.size() < 0 || dimensionsFFT.size() > 3) {
+			System.out.println("FFTWrapper: dimension " + dimensionsFFT.size() + " is not allowed.");
+		}
+
+		switch(dimensionsFFT.size()) {
+		case 1:
+			doubleFFT_1D = new DoubleFFT_1D(dimensionsFFT.get(0));
+			break;
+		case 2:
+			doubleFFT_2D = new DoubleFFT_2D(dimensionsFFT.get(0), dimensionsFFT.get(1));
+			break;
+		case 3:
+			doubleFFT_3D = new DoubleFFT_3D(dimensionsFFT.get(0), dimensionsFFT.get(1), dimensionsFFT.get(2));
+			break;
+		}
+	}
+
+	/**
+	 * Return a list of dimensions whose size > 1.
+	 *
+	 * @param dimensions
+	 * @return
+	 */
+	private List<Integer> getEffectiveDimension(int[] dimensions) {
+		List<Integer> effectiveDimensions = new ArrayList<Integer>();
+		for (int d : dimensions) {
+			if (d > 1) {
+				effectiveDimensions.add(d);
+			} else if (d < 1) {
+				System.out.println("FFTWrapper: Dimension < 1 along a direction is not allowed");
+			}
+		}
+		return effectiveDimensions;
+	}
+
+	public void complexForward(double[] data) {
+		switch(dimensionsFFT.size()) {
+		case 1:
+			doubleFFT_1D.complexForward(data);
+			break;
+		case 2:
+			doubleFFT_2D.complexForward(data);
+			break;
+		case 3:
+			doubleFFT_3D.complexForward(data);
+			break;
+		}
+	}
+
+	public void complexInverse(double[] data, boolean scale) {
+		switch(dimensionsFFT.size()) {
+		case 1:
+			doubleFFT_1D.complexInverse(data, scale);
+			break;
+		case 2:
+			doubleFFT_2D.complexInverse(data, scale);
+			break;
+		case 3:
+			doubleFFT_3D.complexInverse(data, scale);
+			break;
+		}
+	}
+
+	/**
+	 * Return array size for FFT.
+	 * Takes into account factor 2 for real and imaginary parts.
+	 * @return
+	 */
+	public int getFFTArraySize() {
+		int arraySize = 2; // factor 2 for real and imaginary parts.
+		for (int size : dimensions) {
+			arraySize *= size;
+		}
+		return arraySize;
+	}
+
+	/**
+	 * Return array index for FFT.
+	 * Takes into account factor 2 for real and imaginary parts.
+	 * Add 0 to obtain index for real part.
+	 * Add 1 to obtain index for imaginary part.
+	 * @param coordinates
+	 * @return
+	 */
+	public int getFFTArrayIndex(int[] coordinates) {
+		int index = coordinates[0];
+		for (int i = 1; i < dimensions.length; i++) {
+			index *= dimensions[i];
+			index += coordinates[i];
+		}
+		return 2 * index; // factor 2 for real and imaginary parts
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/gauge/GaugeTransformation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/gauge/GaugeTransformation.java
@@ -1,0 +1,92 @@
+package org.openpixi.pixi.physics.gauge;
+
+import org.openpixi.pixi.parallel.cellaccess.CellAction;
+import org.openpixi.pixi.physics.grid.Grid;
+import org.openpixi.pixi.physics.grid.LinkMatrix;
+import org.openpixi.pixi.physics.grid.SU2Matrix;
+import org.openpixi.pixi.physics.grid.YMField;
+
+public class GaugeTransformation {
+
+	GaugeTransform gaugeTransform = new GaugeTransform();
+
+	public Grid gaugedGrid;
+
+	/** Gauge transformation */
+	public LinkMatrix[] g;
+
+
+	/**
+	 * Constructor. Obtain size of required grid from other grid.
+	 * @param grid Grid that should be duplicated in size.
+	 */
+	public GaugeTransformation(Grid grid) {
+		gaugedGrid = new Grid(grid);
+	}
+
+	/**
+	 * Copy grid and reset gauge transformation
+	 */
+	public void copyGrid(Grid grid) {
+
+
+		// Copy grid
+		int numberOfCells = grid.getNumberOfCells();
+
+		int colors = grid.getNumberOfColors();
+		if (colors != 2) {System.out.println("Coulomb gauge for SU(" + colors + ") not defined.\n");
+			return;
+		}
+
+		g = new SU2Matrix[numberOfCells];
+
+		// Reset the gauge transformation
+		for (int i = 0; i < g.length; i++) {
+			g[i] = new SU2Matrix(1, 0, 0, 0);
+		}
+
+		/*
+			Copy the U-field.
+		 */
+		for (int ci = 0; ci < numberOfCells; ci++) {
+			int[] cellPosition = grid.getCellPos(ci);
+			for (int d = 0; d < grid.getNumberOfDimensions(); d++) {
+				LinkMatrix U = grid.getU(cellPosition, d);
+				gaugedGrid.setU(cellPosition, d, U);
+				YMField E = grid.getE(cellPosition, d);
+				gaugedGrid.setE(cellPosition, d, E);
+			}
+		}
+	}
+
+	public void applyGaugeTransformation() {
+		gaugedGrid.getCellIterator().execute(gaugedGrid, gaugeTransform);
+	}
+
+	private class GaugeTransform implements CellAction {
+		public void execute(Grid grid, int[] coor) {
+			int cellIndex = grid.getCellIndex(coor);
+			for (int dir = 0; dir < grid.getNumberOfDimensions(); dir++) {
+				/*
+				 * U_i(x) -> g(x) U_i(x) g^\dagger(x+i)
+				 */
+				LinkMatrix U = grid.getU(coor, dir);
+				int shiftedCellIndex = grid.getCellIndex(grid.shift(coor, dir, 1));
+				LinkMatrix gdaggershifted = g[shiftedCellIndex].adj();
+				U = g[cellIndex].mult(U).mult(gdaggershifted);
+				grid.setU(coor, dir, U);
+
+				/*
+				 * E_i(x) -> g(x) E_i(x) g^\dagger(x)
+				 */
+				YMField E = grid.getE(coor, dir);
+				LinkMatrix gdagger = g[cellIndex].adj();
+				E = (g[cellIndex].mult(E.getLink()).mult(gdagger)).getLinearizedAlgebraElement();
+				// TODO: rather work with exact mapping?
+				//E = (g[cellIndex].mult(E.getLinkExact()).mult(gdagger)).getAlgebraElement();
+				grid.setE(coor, dir, E);
+			}
+		}
+	}
+
+}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/gauge/GaugeTransformation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/gauge/GaugeTransformation.java
@@ -31,7 +31,7 @@ public class GaugeTransformation {
 	 * @param grid
 	 */
 	private void resetGaugeTransformation(Grid grid) {
-		int numberOfCells = grid.getNumberOfCells();
+		int numberOfCells = grid.getTotalNumberOfCells();
 
 		int colors = grid.getNumberOfColors();
 		if (colors == 2) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/gauge/GaugeTransformation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/gauge/GaugeTransformation.java
@@ -8,62 +8,52 @@ import org.openpixi.pixi.physics.grid.YMField;
 
 public class GaugeTransformation {
 
-	GaugeTransform gaugeTransform = new GaugeTransform();
-
-	public Grid gaugedGrid;
+	private GaugeTransformationAction gaugeTransformationAction = new GaugeTransformationAction();
 
 	/** Gauge transformation */
-	public LinkMatrix[] g;
+	private LinkMatrix[] g;
 
+	/** Get gauge transformation array */
+	public LinkMatrix[] getG() {
+		return g;
+	}
 
 	/**
 	 * Constructor. Obtain size of required grid from other grid.
 	 * @param grid Grid that should be duplicated in size.
 	 */
 	public GaugeTransformation(Grid grid) {
-		gaugedGrid = new Grid(grid);
+		resetGaugeTransformation(grid);
 	}
 
 	/**
-	 * Copy grid and reset gauge transformation
+	 * Reset gauge transformation
+	 * @param grid
 	 */
-	public void copyGrid(Grid grid) {
-
-
-		// Copy grid
+	private void resetGaugeTransformation(Grid grid) {
 		int numberOfCells = grid.getNumberOfCells();
 
 		int colors = grid.getNumberOfColors();
-		if (colors != 2) {System.out.println("Coulomb gauge for SU(" + colors + ") not defined.\n");
-			return;
-		}
-
-		g = new SU2Matrix[numberOfCells];
-
-		// Reset the gauge transformation
-		for (int i = 0; i < g.length; i++) {
-			g[i] = new SU2Matrix(1, 0, 0, 0);
-		}
-
-		/*
-			Copy the U-field.
-		 */
-		for (int ci = 0; ci < numberOfCells; ci++) {
-			int[] cellPosition = grid.getCellPos(ci);
-			for (int d = 0; d < grid.getNumberOfDimensions(); d++) {
-				LinkMatrix U = grid.getU(cellPosition, d);
-				gaugedGrid.setU(cellPosition, d, U);
-				YMField E = grid.getE(cellPosition, d);
-				gaugedGrid.setE(cellPosition, d, E);
+		if (colors == 2) {
+			g = new SU2Matrix[numberOfCells];
+			for (int i = 0; i < g.length; i++) {
+				g[i] = new SU2Matrix(1, 0, 0, 0);
 			}
+		} else {
+			System.out.println("Gauge transformation for SU(" + colors + ") not defined.\n");
 		}
 	}
 
-	public void applyGaugeTransformation() {
-		gaugedGrid.getCellIterator().execute(gaugedGrid, gaugeTransform);
+	/**
+	 * Apply the current gauge transformation to the grid
+	 *
+	 * @param grid
+	 */
+	public void applyGaugeTransformation(Grid grid) {
+		grid.getCellIterator().execute(grid, gaugeTransformationAction);
 	}
 
-	private class GaugeTransform implements CellAction {
+	private class GaugeTransformationAction implements CellAction {
 		public void execute(Grid grid, int[] coor) {
 			int cellIndex = grid.getCellIndex(coor);
 			for (int dir = 0; dir < grid.getNumberOfDimensions(); dir++) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/gauge/RandomGauge.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/gauge/RandomGauge.java
@@ -11,9 +11,9 @@ public class RandomGauge extends GaugeTransformation {
 	private RandomGaugeTransformationAction randomGaugeTransformationAction = new RandomGaugeTransformationAction();
 
 	/**
-	 * Accuracy goal for the transformation.
+	 * Random vector in color space.
 	 */
-	private double[] randomVector = new double[] {0, 0, 0};
+	private double[] randomVector;
 
 	public void setRandomVector(double[] randomVector) {
 		this.randomVector = randomVector;
@@ -25,6 +25,7 @@ public class RandomGauge extends GaugeTransformation {
 	 */
 	public RandomGauge(Grid grid) {
 		super(grid);
+		setRandomVector(new double[] {0, 0, 0});
 	}
 
 	public void applyGaugeTransformation(Grid grid) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/gauge/RandomGauge.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/gauge/RandomGauge.java
@@ -1,0 +1,48 @@
+package org.openpixi.pixi.physics.gauge;
+
+import org.openpixi.pixi.parallel.cellaccess.CellAction;
+import org.openpixi.pixi.physics.grid.Grid;
+import org.openpixi.pixi.physics.grid.SU2Field;
+
+/**
+ * Apply a random gauge transformation to a grid.
+ */
+public class RandomGauge extends GaugeTransformation {
+	private RandomGaugeTransformationAction randomGaugeTransformationAction = new RandomGaugeTransformationAction();
+
+	/**
+	 * Accuracy goal for the transformation.
+	 */
+	private double[] randomVector = new double[] {0, 0, 0};
+
+	public void setRandomVector(double[] randomVector) {
+		this.randomVector = randomVector;
+	}
+
+	/**
+	 * Constructor. Obtain size of required grid from other grid.
+	 * @param grid Grid that should be duplicated in size.
+	 */
+	public RandomGauge(Grid grid) {
+		super(grid);
+	}
+
+	public void applyGaugeTransformation(Grid grid) {
+		// prepare the g field in a random way:
+		grid.getCellIterator().execute(grid, randomGaugeTransformationAction);
+
+		// apply the gauge transformation:
+		super.applyGaugeTransformation(grid);
+	}
+
+	private class RandomGaugeTransformationAction implements CellAction {
+		public void execute(Grid grid, int[] coor) {
+			double a = 2 * (Math.random() - 0.5) * randomVector[0];
+			double b = 2 * (Math.random() - 0.5) * randomVector[1];
+			double c = 2 * (Math.random() - 0.5) * randomVector[2];
+			SU2Field field = new SU2Field(a, b, c);
+			int index = grid.getCellIndex(coor);
+			getG()[index] = field.getLinkExact();
+		}
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Cell.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Cell.java
@@ -26,7 +26,11 @@ public class Cell implements Serializable {
 	/**Link matrices at time t + dt/2 */
 	private LinkMatrix[] Unext;
 
-	
+	/**
+	 * Constructor for Cell.
+	 * @param dimensions Number of spatial dimensions (e.g. 3)
+	 * @param colors Number of colors N for the gauge group SU(N)
+	 */
 	public Cell(int dimensions, int colors) {
 		if(colors == 2) {
 			F = new SU2Field[dimensions][dimensions];
@@ -48,7 +52,9 @@ public class Cell implements Serializable {
 				}
 			}
 		}
-		else {}
+		else {
+			System.out.println("Cell constructor for SU(" + colors + ") not defined.\n");
+		}
 	}
 
 	/**

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -245,7 +245,7 @@ public class Grid {
 	 * Calculate total number of cells in the grid.
 	 * @return Total number of cells in the grid.
 	 */
-	public int getNumberOfCells() {
+	public int getTotalNumberOfCells() {
 		int numberOfCells = 1;
 		for (int i = 0; i < numDim; i++) {
 			numberOfCells *= getNumCells(i);
@@ -365,7 +365,7 @@ public class Grid {
 	 * @param grid
 	 */
 	private void copyValuesFrom(Grid grid) {
-		int numberOfCells = grid.getNumberOfCells();
+		int numberOfCells = grid.getTotalNumberOfCells();
 		for (int ci = 0; ci < numberOfCells; ci++) {
 			int[] cellPosition = grid.getCellPos(ci);
 			for (int d = 0; d < numDim; d++) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -233,6 +233,18 @@ public class Grid {
 	}
 
 	/**
+	 * Calculate total number of cells in the grid.
+	 * @return Total number of cells in the grid.
+	 */
+	public int getNumberOfCells() {
+		int numberOfCells = 1;
+		for (int i = 0; i < numDim; i++) {
+			numberOfCells *= getNumCells(i);
+		}
+		return numberOfCells;
+	}
+
+	/**
 	 * Returns the lattice spacing of the grid.
 	 * @return  Lattice spacing of the grid.
 	 */

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -224,6 +224,15 @@ public class Grid {
 	}
 
 	/**
+	 * Returns an array of the number of cells in the grid
+	 * in a given direction.
+	 * @return      Array of number of cells in given direction.
+	 */
+	public int[] getNumCells() {
+		return numCells;
+	}
+
+	/**
 	 * Returns the number of cells in the grid in a given direction.
 	 * @param dir   Index of the direction
 	 * @return      Number of cells in given direction.

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -328,7 +328,7 @@ public class Grid {
 
 	/**
 	 * Constructor for the Grid class.
-	 * It creates an empty grid of the same size.
+	 * It creates a grid of the same size and deep copies U and E fields.
 	 * @param grid  Grid from which to copy dimensions
 	 */
 	public Grid(Grid grid) {
@@ -344,9 +344,29 @@ public class Grid {
 
 		createGrid();
 
+		copyValuesFrom(grid);
+
 		// TODO: Share iterators is ok?
 		this.fsolver = grid.fsolver;
 		this.cellIterator = grid.cellIterator;
+	}
+
+	/**
+	 * Copy U and E field values from one grid to another.
+	 * @param grid
+	 */
+	private void copyValuesFrom(Grid grid) {
+		int numberOfCells = grid.getNumberOfCells();
+		for (int ci = 0; ci < numberOfCells; ci++) {
+			int[] cellPosition = grid.getCellPos(ci);
+			for (int d = 0; d < numDim; d++) {
+				LinkMatrix U = grid.getU(cellPosition, d);
+				this.setU(cellPosition, d, U);
+				YMField E = grid.getE(cellPosition, d);
+				this.setE(cellPosition, d, E);
+				// TODO: if desired: Copy other fields as well.
+			}
+		}
 	}
 
 	/**

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -295,6 +295,10 @@ public class Grid {
 		return numDim;
 	}
 
+	public int getNumberOfColors() {
+		return numCol;
+	}
+
 	/**
 	 * Main constructor for the Grid class. Given a settings file it initializes the lattice and sets up the FieldSolver
 	 * and the CellIterator.
@@ -320,6 +324,29 @@ public class Grid {
 		this.cellIterator = settings.getCellIterator();
 		this.cellIterator.setNormalMode(numCells);
 		
+	}
+
+	/**
+	 * Constructor for the Grid class.
+	 * It creates an empty grid of the same size.
+	 * @param grid  Grid from which to copy dimensions
+	 */
+	public Grid(Grid grid) {
+		gaugeCoupling = grid.gaugeCoupling;
+		as = grid.as;
+		numCol = grid.numCol;
+		numDim = grid.numDim;
+		numCells = new int[numDim];
+
+		for(int i = 0; i < numDim; i++) {
+			numCells[i] = grid.numCells[i];
+		}
+
+		createGrid();
+
+		// TODO: Share iterators is ok?
+		this.fsolver = grid.fsolver;
+		this.cellIterator = grid.cellIterator;
 	}
 
 	/**

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -65,8 +65,9 @@ public class ElectricFieldPanel extends AnimationPanel {
 		Grid drawGrid = s.grid;
 		if (useCoulombGauge) {
 			CoulombGauge coulombGauge = new CoulombGauge(s.grid);
-			coulombGauge.fixGauge(s.grid);
-			drawGrid = coulombGauge.getGaugedGrid();
+			Grid gridCopy = new Grid(s.grid);
+			coulombGauge.applyGaugeTransformation(gridCopy);
+			drawGrid = gridCopy;
 		}
 
 		// Draw particles on a central line:

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -6,6 +6,7 @@ import java.awt.Graphics2D;
 import javax.swing.Box;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.gauge.CoulombGauge;
+import org.openpixi.pixi.physics.gauge.RandomGauge;
 import org.openpixi.pixi.physics.grid.Grid;
 import org.openpixi.pixi.physics.particles.IParticle;
 import org.openpixi.pixi.ui.SimulationAnimation;
@@ -68,6 +69,13 @@ public class ElectricFieldPanel extends AnimationPanel {
 			Grid gridCopy = new Grid(s.grid);
 			coulombGauge.applyGaugeTransformation(gridCopy);
 			drawGrid = gridCopy;
+
+//			// Test random gauge:
+//			RandomGauge randomGauge = new RandomGauge(s.grid);
+//			randomGauge.setRandomVector(new double[] {0, 1, 0});
+//			Grid gridCopy = new Grid(s.grid);
+//			randomGauge.applyGaugeTransformation(gridCopy);
+//			drawGrid = gridCopy;
 		}
 
 		// Draw particles on a central line:

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -5,7 +5,7 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import javax.swing.Box;
 import org.openpixi.pixi.physics.Simulation;
-import org.openpixi.pixi.physics.fields.CoulombGauge;
+import org.openpixi.pixi.physics.gauge.CoulombGauge;
 import org.openpixi.pixi.physics.grid.Grid;
 import org.openpixi.pixi.physics.particles.IParticle;
 import org.openpixi.pixi.ui.SimulationAnimation;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -5,9 +5,12 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import javax.swing.Box;
 import org.openpixi.pixi.physics.Simulation;
+import org.openpixi.pixi.physics.fields.CoulombGauge;
+import org.openpixi.pixi.physics.grid.Grid;
 import org.openpixi.pixi.physics.particles.IParticle;
 import org.openpixi.pixi.ui.SimulationAnimation;
 import org.openpixi.pixi.ui.panel.properties.ColorProperties;
+import org.openpixi.pixi.ui.panel.properties.GaugeProperties;
 import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
 
 /**
@@ -19,6 +22,7 @@ public class ElectricFieldPanel extends AnimationPanel {
 
 	ColorProperties colorProperties = new ColorProperties();
 	ScaleProperties scaleProperties = new ScaleProperties();
+	GaugeProperties gaugeProperties = new GaugeProperties();
 
 	/** Constructor */
 	public ElectricFieldPanel(SimulationAnimation simulationAnimation) {
@@ -56,6 +60,14 @@ public class ElectricFieldPanel extends AnimationPanel {
 
 		int colorIndex = colorProperties.getColorIndex();
 		int directionIndex = colorProperties.getDirectionIndex();
+
+		boolean useCoulombGauge = gaugeProperties.isCoulombGauge();
+		Grid drawGrid = s.grid;
+		if (useCoulombGauge) {
+			CoulombGauge coulombGauge = new CoulombGauge(s.grid);
+			coulombGauge.fixGauge(s.grid);
+			drawGrid = coulombGauge.getGaugedGrid();
+		}
 
 		// Draw particles on a central line:
 		for (int i = 0; i < s.particles.size(); i++) {
@@ -107,7 +119,7 @@ public class ElectricFieldPanel extends AnimationPanel {
 					In the flipped and translated coordinate system defined above we have to add the fields to the
 					center of the panel in order to get the expected result.
 				*/
-				double electricField = s.grid.getE(pos, directionIndex).get(colorIndex) / (as * g);
+				double electricField = drawGrid.getE(pos, directionIndex).get(colorIndex) / (as * g);
 				scaleProperties.putValue(electricField);
 				newValue = (int) (((0.5 + scaleE * electricField) * panelHeight));
 
@@ -140,7 +152,7 @@ public class ElectricFieldPanel extends AnimationPanel {
 					In the flipped and translated coordinate system defined above we have to add the fields to the
 					center of the panel in order to get the expected result.
 				*/
-				double gaugeField = s.grid.getU(pos, directionIndex).getLinearizedAlgebraElement().get(colorIndex) / (as * g);
+				double gaugeField = drawGrid.getU(pos, directionIndex).getLinearizedAlgebraElement().get(colorIndex) / (as * g);
 				scaleProperties.putValue(gaugeField);
 				newValue = (int) (((0.5 + scaleA * gaugeField) * panelHeight));
 
@@ -157,6 +169,7 @@ public class ElectricFieldPanel extends AnimationPanel {
 		addLabel(box, "Electric field panel");
 		colorProperties.addComponents(box);
 		scaleProperties.addComponents(box);
+		gaugeProperties.addComponents(box);
 	}
 
 	public ColorProperties getColorProperties() {
@@ -165,5 +178,9 @@ public class ElectricFieldPanel extends AnimationPanel {
 
 	public ScaleProperties getScaleProperties() {
 		return scaleProperties;
+	}
+
+	public GaugeProperties getGaugeProperties() {
+		return gaugeProperties;
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/GaugeProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/GaugeProperties.java
@@ -1,0 +1,41 @@
+package org.openpixi.pixi.ui.panel.properties;
+
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+
+import javax.swing.Box;
+import javax.swing.JCheckBox;
+
+public class GaugeProperties {
+
+	private boolean coulombGauge = false;
+
+	public boolean isCoulombGauge() {
+		return coulombGauge;
+	}
+
+	public void setCoulombGauge(boolean coulombGauge) {
+		this.coulombGauge = coulombGauge;
+	}
+
+	public void addComponents(Box box) {
+
+		JCheckBox currentgridCheck;
+		currentgridCheck = new JCheckBox("Coulomb gauge");
+		currentgridCheck.addItemListener(new DrawCurrentListener());
+		currentgridCheck.setSelected(coulombGauge);
+
+		Box cellSettings = Box.createVerticalBox();
+		cellSettings.add(currentgridCheck);
+		cellSettings.add(Box.createVerticalGlue());
+
+		box.add(cellSettings);
+	}
+
+	class DrawCurrentListener implements ItemListener {
+		public void itemStateChanged(ItemEvent event){
+			GaugeProperties.this.coulombGauge = 
+					(event.getStateChange() == ItemEvent.SELECTED);
+		}
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlOutput.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlOutput.java
@@ -1,7 +1,9 @@
 package org.openpixi.pixi.ui.util.yaml;
 
 import java.util.ArrayList;
+
 import org.openpixi.pixi.physics.Settings;
+import org.openpixi.pixi.ui.util.yaml.filegenerators.YamlCoulombGaugeInTime;
 import org.openpixi.pixi.ui.util.yaml.filegenerators.YamlParticlesInTime;
 import org.openpixi.pixi.ui.util.yaml.filegenerators.YamlBulkQuantitiesInTime;
 
@@ -12,6 +14,8 @@ public class YamlOutput {
 	public ArrayList<YamlParticlesInTime> particlesInTime = new ArrayList<YamlParticlesInTime>();
 	
 	public ArrayList<YamlBulkQuantitiesInTime> bulkQuantitiesInTime = new ArrayList<YamlBulkQuantitiesInTime>();
+
+	public ArrayList<YamlCoulombGaugeInTime> coulombGaugeInTime = new ArrayList<YamlCoulombGaugeInTime>();
 
 	/**
 	 * Creates FileGenerator instances and applies them to the Settings instance.
@@ -25,6 +29,10 @@ public class YamlOutput {
 
 		for (YamlBulkQuantitiesInTime output2 : bulkQuantitiesInTime) {
 			s.addDiagnostics(output2.getFileGenerator());
+		}
+
+		for (YamlCoulombGaugeInTime output : coulombGaugeInTime) {
+			s.addDiagnostics(output.getFileGenerator());
 		}
 	}
 	

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlOutput.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlOutput.java
@@ -6,6 +6,7 @@ import org.openpixi.pixi.physics.Settings;
 import org.openpixi.pixi.ui.util.yaml.filegenerators.YamlCoulombGaugeInTime;
 import org.openpixi.pixi.ui.util.yaml.filegenerators.YamlParticlesInTime;
 import org.openpixi.pixi.ui.util.yaml.filegenerators.YamlBulkQuantitiesInTime;
+import org.openpixi.pixi.ui.util.yaml.filegenerators.YamlRandomGaugeInTime;
 
 public class YamlOutput {
 	/**
@@ -17,21 +18,27 @@ public class YamlOutput {
 
 	public ArrayList<YamlCoulombGaugeInTime> coulombGaugeInTime = new ArrayList<YamlCoulombGaugeInTime>();
 
+	public ArrayList<YamlRandomGaugeInTime> randomGaugeInTime = new ArrayList<YamlRandomGaugeInTime>();
+
 	/**
 	 * Creates FileGenerator instances and applies them to the Settings instance.
 	 * @param s
 	 */
 
 	public void applyTo(Settings s) {
-		for (YamlParticlesInTime output1 : particlesInTime) {
-			s.addDiagnostics(output1.getFileGenerator());
+		for (YamlParticlesInTime output : particlesInTime) {
+			s.addDiagnostics(output.getFileGenerator());
 		}
 
-		for (YamlBulkQuantitiesInTime output2 : bulkQuantitiesInTime) {
-			s.addDiagnostics(output2.getFileGenerator());
+		for (YamlBulkQuantitiesInTime output : bulkQuantitiesInTime) {
+			s.addDiagnostics(output.getFileGenerator());
 		}
 
 		for (YamlCoulombGaugeInTime output : coulombGaugeInTime) {
+			s.addDiagnostics(output.getFileGenerator());
+		}
+
+		for (YamlRandomGaugeInTime output : randomGaugeInTime) {
 			s.addDiagnostics(output.getFileGenerator());
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlCoulombGaugeInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlCoulombGaugeInTime.java
@@ -1,0 +1,29 @@
+package org.openpixi.pixi.ui.util.yaml.filegenerators;
+
+import org.openpixi.pixi.diagnostics.methods.CoulombGaugeInTime;
+
+/**
+ * Yaml wrapper for the YamlParticlesInTime FileGenerator.
+ */
+public class YamlCoulombGaugeInTime {
+
+	/**
+	 * Measurement interval.
+	 */
+	public double interval;
+
+	/**
+	 * Measurement interval offset.
+	 */
+	public double offset;
+
+	/**
+	 * Returns an instance of CoulombGaugeInTime according to the parameters in the YAML file.
+	 *
+	 * @return Instance of BulkQuantitiesInTime.
+	 */
+	public CoulombGaugeInTime getFileGenerator() {
+		CoulombGaugeInTime fileGen = new CoulombGaugeInTime(interval, offset);
+		return fileGen;
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlRandomGaugeInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlRandomGaugeInTime.java
@@ -1,0 +1,46 @@
+package org.openpixi.pixi.ui.util.yaml.filegenerators;
+
+import java.util.List;
+
+import org.openpixi.pixi.diagnostics.methods.CoulombGaugeInTime;
+import org.openpixi.pixi.diagnostics.methods.RandomGaugeInTime;
+
+/**
+ * Yaml wrapper for the YamlParticlesInTime FileGenerator.
+ */
+public class YamlRandomGaugeInTime {
+
+	/**
+	 * Measurement interval.
+	 */
+	public double interval;
+
+	/**
+	 * Measurement interval offset.
+	 */
+	public double offset;
+
+	/**
+	 * Amplitude of random component in color space.
+	 */
+	public List<Double> aColor;
+
+	/**
+	 * Returns an instance of CoulombGaugeInTime according to the parameters in the YAML file.
+	 *
+	 * @return Instance of BulkQuantitiesInTime.
+	 */
+	public RandomGaugeInTime getFileGenerator() {
+		double[] aColorArray = getDoubleArray(aColor);
+		RandomGaugeInTime fileGen = new RandomGaugeInTime(interval, offset, aColorArray);
+		return fileGen;
+	}
+
+	private double[] getDoubleArray(List<Double> list) {
+		double[] array = new double[list.size()];
+		for (int i = 0; i < list.size(); i++) {
+			array[i] = list.get(i);
+		}
+		return array;
+	}
+}

--- a/pixi/src/test/java/org/openpixi/pixi/gauge/CoulombGaugeTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/gauge/CoulombGaugeTest.java
@@ -116,7 +116,7 @@ public class CoulombGaugeTest {
 	 */
 	private void printU(String string, Grid grid) {
 		System.out.print(string + ": ");
-		for (int i = 0; i < grid.getNumberOfCells(); i++) {
+		for (int i = 0; i < grid.getTotalNumberOfCells(); i++) {
 			int[] coor = grid.getCellPos(i);
 			System.out.print("" + grid.getCell(coor).getU(0).get(0) + "|" + grid.getCell(coor).getU(0).get(1) + ", ");
 		}

--- a/pixi/src/test/java/org/openpixi/pixi/gauge/CoulombGaugeTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/gauge/CoulombGaugeTest.java
@@ -1,5 +1,7 @@
 package org.openpixi.pixi.gauge;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.openpixi.pixi.physics.Settings;
 import org.openpixi.pixi.physics.Simulation;
@@ -15,7 +17,7 @@ import org.openpixi.pixi.physics.grid.SU2Matrix;
 public class CoulombGaugeTest {
 
 	@Test
-	public void testCoulombGauge() {
+	public void testAbelianCoulombGauge() {
 		// Initialize simulation
 
 		Settings settings = new Settings();
@@ -25,7 +27,7 @@ public class CoulombGaugeTest {
 		double[] k = new double[] {0, 0, 0};
 		double[] amplitudeSpatialDirection = new double[] {1, 0, 0};
 		double[] amplitudeColorDirection = new double[] {1, 0, 0};
-		double amplitudeMagnitude = 0;
+		double amplitudeMagnitude = 1;
 		SU2PlaneWave constantfield = new SU2PlaneWave(k, amplitudeSpatialDirection, amplitudeColorDirection, amplitudeMagnitude);
 
 		settings.addFieldGenerator(constantfield);
@@ -36,19 +38,36 @@ public class CoulombGaugeTest {
 		GaugeTransformation transformation = new GaugeTransformation(grid);
 		transformation.copyGrid(grid);
 
-		printU("Start: ", transformation.gaugedGrid);
+//		printU("Start: ", transformation.gaugedGrid);
 
 		CoulombGauge coulomb = new CoulombGauge(transformation.gaugedGrid);
 		coulomb.fixGauge(transformation.gaugedGrid);
 
-		printU("Coulomb gauge: ", coulomb.getGaugedGrid());
-		printg("Coulomb g:", coulomb.getGaugeTransformation());
+		Double[] convergenceList = coulomb.getLastConvergence();
+//		printConvergence(convergenceList);
 
+		Assert.assertEquals(convergenceList.length, 1);
+		Assert.assertTrue(convergenceList[convergenceList.length -1] < coulomb.getAccuracyGoal());
+
+//		printU("Coulomb gauge: ", coulomb.getGaugedGrid());
+//		printg("Coulomb g:", coulomb.getGaugeTransformation());
+
+		// Apply gauge transformation
 		LinkMatrix g1 = (new SU2Field(.1, 0, 0)).getLinkExact();
 		transformation.g[0] = transformation.g[0].mult(g1);
-		//transformation.g[1] = transformation.g[1].mult(g1);
+
 		transformation.applyGaugeTransformation();
 
+		// Apply Coulomb gauge transformation:
+		coulomb = new CoulombGauge(transformation.gaugedGrid);
+		coulomb.fixGauge(transformation.gaugedGrid);
+
+		convergenceList = coulomb.getLastConvergence();
+		Assert.assertEquals(convergenceList.length, 2);
+		Assert.assertTrue(convergenceList[convergenceList.length -1] < coulomb.getAccuracyGoal());
+
+//		printConvergence(convergenceList);
+/*
 		printU("Test transformation: ", transformation.gaugedGrid);
 		printg("Test g:", transformation.g);
 
@@ -62,8 +81,102 @@ public class CoulombGaugeTest {
 
 			transformation.copyGrid(coulomb.getGaugedGrid());
 		}
+*/
 	}
 
+	@Test
+	public void testNonAbelianCoulombGauge() {
+		// Initialize simulation
+
+		Settings settings = new Settings();
+		settings.setNumberOfColors(2);
+		settings.setGridCells(new int[] {2, 2, 2});
+
+		double[] k = new double[] {0, 0, 0};
+		double[] amplitudeSpatialDirection = new double[] {1, 0, 0};
+		double[] amplitudeColorDirection = new double[] {1, 0, 0};
+		double amplitudeMagnitude = 1;
+		SU2PlaneWave constantfield = new SU2PlaneWave(k, amplitudeSpatialDirection, amplitudeColorDirection, amplitudeMagnitude);
+
+		settings.addFieldGenerator(constantfield);
+
+		Simulation s = new Simulation(settings);
+		Grid grid = s.grid;
+
+		GaugeTransformation transformation = new GaugeTransformation(grid);
+		transformation.copyGrid(grid);
+
+//		printU("Start: ", transformation.gaugedGrid);
+
+		CoulombGauge coulomb = new CoulombGauge(transformation.gaugedGrid);
+		coulomb.fixGauge(transformation.gaugedGrid);
+
+		Double[] convergenceList = coulomb.getLastConvergence();
+//		printConvergence(convergenceList);
+
+		Assert.assertEquals(convergenceList.length, 1);
+		Assert.assertTrue(convergenceList[convergenceList.length -1] < coulomb.getAccuracyGoal());
+
+//		printU("Coulomb gauge: ", coulomb.getGaugedGrid());
+//		printg("Coulomb g:", coulomb.getGaugeTransformation());
+
+		// Apply gauge transformation
+		LinkMatrix g1 = (new SU2Field(.1, 0, 0)).getLinkExact();
+		transformation.g[0] = transformation.g[0].mult(g1);
+
+		transformation.applyGaugeTransformation();
+
+		// Apply Coulomb gauge transformation:
+		coulomb = new CoulombGauge(transformation.gaugedGrid);
+		coulomb.fixGauge(transformation.gaugedGrid);
+
+		Assert.assertEquals(convergenceList.length, 1);
+		Assert.assertTrue(convergenceList[convergenceList.length -1] < coulomb.getAccuracyGoal());
+
+		LinkMatrix g2 = (new SU2Field(0, 0, .1)).getLinkExact();
+		transformation.g[1] = transformation.g[1].mult(g2);
+
+		transformation.applyGaugeTransformation();
+
+		// Apply Coulomb gauge transformation:
+		coulomb = new CoulombGauge(transformation.gaugedGrid);
+		coulomb.fixGauge(transformation.gaugedGrid);
+
+		convergenceList = coulomb.getLastConvergence();
+		Assert.assertTrue(convergenceList.length > 3); // Need a few iterations
+		Assert.assertTrue(convergenceList[convergenceList.length -1] < coulomb.getAccuracyGoal());
+
+//		printConvergence(convergenceList);
+/*
+		printU("Test transformation: ", transformation.gaugedGrid);
+		printg("Test g:", transformation.g);
+
+		for (int i = 0; i < 3; i++) {
+			System.out.println("Iteration: " + i);
+			coulomb = new CoulombGauge(transformation.gaugedGrid);
+			coulomb.fixGauge(transformation.gaugedGrid);
+
+			printU("Coulomb gauge: ", coulomb.getGaugedGrid());
+			printg("Coulomb g:", coulomb.getGaugeTransformation());
+
+			transformation.copyGrid(coulomb.getGaugedGrid());
+		}
+*/
+	}
+
+	/**
+	 * Output for debugging
+	 */
+	private void printConvergence(Double[] convergenceList) {
+		for (Double convergence : convergenceList) {
+			System.out.println("convergence: " + convergence);
+		}
+	}
+	/**
+	 * Output for debugging
+	 * @param string
+	 * @param grid
+	 */
 	private void printU(String string, Grid grid) {
 		System.out.print(string + ": ");
 		for (int i = 0; i < grid.getNumberOfCells(); i++) {
@@ -73,6 +186,12 @@ public class CoulombGaugeTest {
 		System.out.println();
 	}
 
+
+	/**
+	 * Output for debugging
+	 * @param string
+	 * @param grid
+	 */
 	private void printg(String string, LinkMatrix[] g) {
 		System.out.print(string + ": ");
 		for (int i = 0; i < g.length; i++) {

--- a/pixi/src/test/java/org/openpixi/pixi/gauge/CoulombGaugeTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/gauge/CoulombGaugeTest.java
@@ -20,7 +20,7 @@ public class CoulombGaugeTest {
 
 		Settings settings = new Settings();
 		settings.setNumberOfColors(2);
-		settings.setGridCells(new int[] {2, 2, 2});
+		settings.setGridCells(new int[] {3, 3, 3});
 
 		double[] k = new double[] {0, 0, 0};
 		double[] amplitudeSpatialDirection = new double[] {1, 0, 0};
@@ -44,19 +44,23 @@ public class CoulombGaugeTest {
 		printU("Coulomb gauge: ", coulomb.getGaugedGrid());
 		printg("Coulomb g:", coulomb.getGaugeTransformation());
 
-		LinkMatrix g1 = (new SU2Field(-1, 0, 0)).getLinkExact();
+		LinkMatrix g1 = (new SU2Field(.001, 0, 0)).getLinkExact();
 		transformation.g[0] = transformation.g[0].mult(g1);
 		transformation.applyGaugeTransformation();
 
 		printU("Test transformation: ", transformation.gaugedGrid);
 		printg("Test g:", transformation.g);
 
-		coulomb = new CoulombGauge(transformation.gaugedGrid);
-		coulomb.fixGauge(transformation.gaugedGrid);
+		for (int i = 0; i < 3; i++) {
+			System.out.println("Iteration: " + i);
+			coulomb = new CoulombGauge(transformation.gaugedGrid);
+			coulomb.fixGauge(transformation.gaugedGrid);
 
-		printU("Coulomb gauge: ", coulomb.getGaugedGrid());
-		printg("Coulomb g:", coulomb.getGaugeTransformation());
+			printU("Coulomb gauge: ", coulomb.getGaugedGrid());
+			printg("Coulomb g:", coulomb.getGaugeTransformation());
 
+			transformation.copyGrid(coulomb.getGaugedGrid());
+		}
 	}
 
 	private void printU(String string, Grid grid) {

--- a/pixi/src/test/java/org/openpixi/pixi/gauge/CoulombGaugeTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/gauge/CoulombGaugeTest.java
@@ -20,12 +20,12 @@ public class CoulombGaugeTest {
 
 		Settings settings = new Settings();
 		settings.setNumberOfColors(2);
-		settings.setGridCells(new int[] {3, 3, 3});
+		settings.setGridCells(new int[] {2, 2, 2});
 
 		double[] k = new double[] {0, 0, 0};
 		double[] amplitudeSpatialDirection = new double[] {1, 0, 0};
 		double[] amplitudeColorDirection = new double[] {1, 0, 0};
-		double amplitudeMagnitude = 1.0;
+		double amplitudeMagnitude = 0;
 		SU2PlaneWave constantfield = new SU2PlaneWave(k, amplitudeSpatialDirection, amplitudeColorDirection, amplitudeMagnitude);
 
 		settings.addFieldGenerator(constantfield);
@@ -44,8 +44,9 @@ public class CoulombGaugeTest {
 		printU("Coulomb gauge: ", coulomb.getGaugedGrid());
 		printg("Coulomb g:", coulomb.getGaugeTransformation());
 
-		LinkMatrix g1 = (new SU2Field(.001, 0, 0)).getLinkExact();
+		LinkMatrix g1 = (new SU2Field(.1, 0, 0)).getLinkExact();
 		transformation.g[0] = transformation.g[0].mult(g1);
+		//transformation.g[1] = transformation.g[1].mult(g1);
 		transformation.applyGaugeTransformation();
 
 		printU("Test transformation: ", transformation.gaugedGrid);
@@ -67,7 +68,7 @@ public class CoulombGaugeTest {
 		System.out.print(string + ": ");
 		for (int i = 0; i < grid.getNumberOfCells(); i++) {
 			int[] coor = grid.getCellPos(i);
-			System.out.print("" + grid.getCell(coor).getU(0).get(0) + ", ");
+			System.out.print("" + grid.getCell(coor).getU(0).get(0) + "|" + grid.getCell(coor).getU(0).get(1) + ", ");
 		}
 		System.out.println();
 	}

--- a/pixi/src/test/java/org/openpixi/pixi/gauge/CoulombGaugeTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/gauge/CoulombGaugeTest.java
@@ -1,0 +1,78 @@
+package org.openpixi.pixi.gauge;
+
+import org.junit.Test;
+import org.openpixi.pixi.physics.Settings;
+import org.openpixi.pixi.physics.Simulation;
+import org.openpixi.pixi.physics.fields.fieldgenerators.SU2PlaneWave;
+import org.openpixi.pixi.physics.fields.fieldgenerators.SU2RandomFields;
+import org.openpixi.pixi.physics.gauge.CoulombGauge;
+import org.openpixi.pixi.physics.gauge.GaugeTransformation;
+import org.openpixi.pixi.physics.grid.Grid;
+import org.openpixi.pixi.physics.grid.LinkMatrix;
+import org.openpixi.pixi.physics.grid.SU2Field;
+import org.openpixi.pixi.physics.grid.SU2Matrix;
+
+public class CoulombGaugeTest {
+
+	@Test
+	public void testCoulombGauge() {
+		// Initialize simulation
+
+		Settings settings = new Settings();
+		settings.setNumberOfColors(2);
+		settings.setGridCells(new int[] {2, 2, 2});
+
+		double[] k = new double[] {0, 0, 0};
+		double[] amplitudeSpatialDirection = new double[] {1, 0, 0};
+		double[] amplitudeColorDirection = new double[] {1, 0, 0};
+		double amplitudeMagnitude = 1.0;
+		SU2PlaneWave constantfield = new SU2PlaneWave(k, amplitudeSpatialDirection, amplitudeColorDirection, amplitudeMagnitude);
+
+		settings.addFieldGenerator(constantfield);
+
+		Simulation s = new Simulation(settings);
+		Grid grid = s.grid;
+
+		GaugeTransformation transformation = new GaugeTransformation(grid);
+		transformation.copyGrid(grid);
+
+		printU("Start: ", transformation.gaugedGrid);
+
+		CoulombGauge coulomb = new CoulombGauge(transformation.gaugedGrid);
+		coulomb.fixGauge(transformation.gaugedGrid);
+
+		printU("Coulomb gauge: ", coulomb.getGaugedGrid());
+		printg("Coulomb g:", coulomb.getGaugeTransformation());
+
+		LinkMatrix g1 = (new SU2Field(-1, 0, 0)).getLinkExact();
+		transformation.g[0] = transformation.g[0].mult(g1);
+		transformation.applyGaugeTransformation();
+
+		printU("Test transformation: ", transformation.gaugedGrid);
+		printg("Test g:", transformation.g);
+
+		coulomb = new CoulombGauge(transformation.gaugedGrid);
+		coulomb.fixGauge(transformation.gaugedGrid);
+
+		printU("Coulomb gauge: ", coulomb.getGaugedGrid());
+		printg("Coulomb g:", coulomb.getGaugeTransformation());
+
+	}
+
+	private void printU(String string, Grid grid) {
+		System.out.print(string + ": ");
+		for (int i = 0; i < grid.getNumberOfCells(); i++) {
+			int[] coor = grid.getCellPos(i);
+			System.out.print("" + grid.getCell(coor).getU(0).get(0) + ", ");
+		}
+		System.out.println();
+	}
+
+	private void printg(String string, LinkMatrix[] g) {
+		System.out.print(string + ": ");
+		for (int i = 0; i < g.length; i++) {
+			System.out.print("" + g[i].get(0) + "|" + g[i].get(1) + ", ");
+		}
+		System.out.println();
+	}
+}


### PR DESCRIPTION
New classes are added for general gauge transformations, in particular for the Coulomb gauge and a random gauge.
- There is a switch to turn on Coulomb gauge in a live preview in the electric field panel.
- Coulomb and Random gauge transformations can be applied to the simulation at predefined intervals through a YAML setting - see the example file "Wave_Gauge_Transformation_Test.yaml"
