### PR TITLE
YAML panel classes for energy density panels

### DIFF
--- a/pixi/input/Dual_Focused_Gaussian_Pulse_with_EnergyDensity.yaml
+++ b/pixi/input/Dual_Focused_Gaussian_Pulse_with_EnergyDensity.yaml
@@ -1,0 +1,74 @@
+# Dual focused gaussian pulse test with impact parameter
+
+gridStep: 1
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 6
+gridCells: [128, 128, 1]
+poissonsolver: empty
+timeStep: 0.2
+duration: 1000
+
+fields:
+  SU2FocusedGaussianPulses:
+    - dir: [1.0, 0.0, 0.0]
+      pos: [64, 64, 0.0]
+      aSpatial: [0.0, 0.0, 1.0]
+      aColor: [1.0, 0.0, 0.0]
+      a: 4
+      sigma: 3
+      angle: 1.0
+      distance: 32.0
+    - dir: [-1.0, 0.0, 0.0]
+      pos: [64, 64, 0.0]
+      aSpatial: [0.0, 0.0, 1.0]
+      aColor: [0.0, 1.0, 0.0]
+      a: 4
+      sigma: 3
+      angle: 1.0
+      distance: 32.0
+
+# Generated panel code:
+panels:
+  dividerLocation: 532
+  leftPanel:
+    dividerLocation: 393
+    leftPanel:
+      particle2DPanel:
+        colorIndex: 2
+        directionIndex: 2
+        drawCurrent: false
+        drawFields: true
+        showInfo: false
+        showTrace: false
+    orientation: 0
+    rightPanel:
+      energyDensity2DPanel:
+        automaticScaling: false
+        scaleFactor: 10.0
+        showInfo: false
+  orientation: 1
+  rightPanel:
+    dividerLocation: 439
+    leftPanel:
+      electricFieldPanel:
+        automaticScaling: false
+        colorIndex: 0
+        directionIndex: 2
+        scaleFactor: 1.0
+    orientation: 0
+    rightPanel:
+      dividerLocation: 178
+      leftPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 1
+          directionIndex: 2
+          scaleFactor: 1.0
+      orientation: 0
+      rightPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 2
+          directionIndex: 2
+          scaleFactor: 1.0

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
@@ -9,10 +9,14 @@ import org.openpixi.pixi.ui.panel.ElectricFieldPanel;
 import org.openpixi.pixi.ui.panel.Particle2DPanel;
 import org.openpixi.pixi.ui.panel.Particle3DPanel;
 import org.openpixi.pixi.ui.panel.PhaseSpacePanel;
+import org.openpixi.pixi.ui.panel.EnergyDensity1DPanel;
+import org.openpixi.pixi.ui.panel.EnergyDensity2DPanel;
 import org.openpixi.pixi.ui.util.yaml.panels.YamlElectricFieldPanel;
 import org.openpixi.pixi.ui.util.yaml.panels.YamlParticle2DPanel;
 import org.openpixi.pixi.ui.util.yaml.panels.YamlParticle3DPanel;
 import org.openpixi.pixi.ui.util.yaml.panels.YamlPhaseSpacePanel;
+import org.openpixi.pixi.ui.util.yaml.panels.YamlEnergyDensity1DPanel;
+import org.openpixi.pixi.ui.util.yaml.panels.YamlEnergyDensity2DPanel;
 
 public class YamlPanels {
 
@@ -25,6 +29,8 @@ public class YamlPanels {
 	public YamlParticle2DPanel particle2DPanel;
 	public YamlParticle3DPanel particle3DPanel;
 	public YamlPhaseSpacePanel phaseSpacePanel;
+	public YamlEnergyDensity1DPanel energyDensity1DPanel;
+	public YamlEnergyDensity2DPanel energyDensity2DPanel;
 
 	/** Empty constructor called by SnakeYaml */
 	public YamlPanels() {
@@ -52,6 +58,10 @@ public class YamlPanels {
 			particle3DPanel = new YamlParticle3DPanel(component);
 		} else if (component instanceof PhaseSpacePanel) {
 			phaseSpacePanel = new YamlPhaseSpacePanel(component);
+		} else if (component instanceof EnergyDensity1DPanel) {
+			energyDensity1DPanel = new YamlEnergyDensity1DPanel(component);
+		} else if (component instanceof EnergyDensity2DPanel) {
+			energyDensity2DPanel = new YamlEnergyDensity2DPanel(component);
 		}
 	}
 
@@ -76,6 +86,10 @@ public class YamlPanels {
 			component = particle3DPanel.inflate(panelManager);
 		} else if (phaseSpacePanel != null) {
 			component = phaseSpacePanel.inflate(panelManager);
+		} else if (energyDensity1DPanel != null) {
+			component = energyDensity1DPanel.inflate(panelManager);
+		} else if (energyDensity2DPanel != null) {
+			component = energyDensity2DPanel.inflate(panelManager);
 		}
 		return component;
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensity1DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensity1DPanel.java
@@ -1,0 +1,39 @@
+package org.openpixi.pixi.ui.util.yaml.panels;
+
+import java.awt.Component;
+
+import org.openpixi.pixi.ui.PanelManager;
+import org.openpixi.pixi.ui.panel.EnergyDensity1DPanel;
+
+public class YamlEnergyDensity1DPanel {
+
+	// Scale properties
+	public Double scaleFactor;
+	public Boolean automaticScaling;
+
+	/** Empty constructor called by SnakeYaml */
+	public YamlEnergyDensity1DPanel() {
+	}
+
+	public YamlEnergyDensity1DPanel(Component component) {
+		if (component instanceof EnergyDensity1DPanel) {
+			EnergyDensity1DPanel panel = (EnergyDensity1DPanel) component;
+			scaleFactor = panel.getScaleProperties().getScaleFactor();
+			automaticScaling = panel.getScaleProperties().getAutomaticScaling();
+		}
+	}
+
+	public Component inflate(PanelManager panelManager) {
+
+		EnergyDensity1DPanel panel = new EnergyDensity1DPanel(panelManager.getSimulationAnimation());
+
+		if (scaleFactor != null) {
+			panel.getScaleProperties().setScaleFactor(scaleFactor);
+		}
+
+		if (automaticScaling != null) {
+			panel.getScaleProperties().setAutomaticScaling(automaticScaling);
+		}
+		return panel;
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensity2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensity2DPanel.java
@@ -1,0 +1,48 @@
+package org.openpixi.pixi.ui.util.yaml.panels;
+
+import java.awt.Component;
+
+import org.openpixi.pixi.ui.PanelManager;
+import org.openpixi.pixi.ui.panel.EnergyDensity2DPanel;
+
+public class YamlEnergyDensity2DPanel {
+
+	// Info properties
+	public Boolean showInfo;
+	
+	// Scale properties
+	public Double scaleFactor;
+	public Boolean automaticScaling;	
+
+	/** Empty constructor called by SnakeYaml */
+	public YamlEnergyDensity2DPanel() {
+	}
+
+	public YamlEnergyDensity2DPanel(Component component) {
+		if (component instanceof EnergyDensity2DPanel) {
+			EnergyDensity2DPanel panel = (EnergyDensity2DPanel) component;
+			scaleFactor = panel.getScaleProperties().getScaleFactor();
+			automaticScaling = panel.getScaleProperties().getAutomaticScaling();
+			showInfo = panel.getInfoProperties().isShowInfo();
+		}
+	}
+
+	public Component inflate(PanelManager panelManager) {
+
+		EnergyDensity2DPanel panel = new EnergyDensity2DPanel(panelManager.getSimulationAnimation());
+
+		if (showInfo != null) {
+			panel.getInfoProperties().setShowInfo(showInfo);
+		}
+		
+		if (scaleFactor != null) {
+			panel.getScaleProperties().setScaleFactor(scaleFactor);
+		}
+
+		if (automaticScaling != null) {
+			panel.getScaleProperties().setAutomaticScaling(automaticScaling);
+		}
+
+		return panel;
+	}
+}


### PR DESCRIPTION
YAML panel classes for the use of both energy density panels in YAML files have been added, together with a new YAML file as an example.
