### PR TITLE
Generate screen shots from the 3D GL panel

### DIFF
--- a/pixi/input/Dual_Focused_Gaussian_Pulse_with_EnergyDensity_Screenshot.yaml
+++ b/pixi/input/Dual_Focused_Gaussian_Pulse_with_EnergyDensity_Screenshot.yaml
@@ -39,6 +39,12 @@ output:
       offset : 0
       width: 1280
       height: 720
+      panel:
+        energyDensity3DGLPanel:
+          automaticScaling: false
+          phi: -1.5707963267948966
+          scaleFactor: 20
+          theta: 0.7853981633974483
 
 # Generated panel code:
 panels:

--- a/pixi/input/Dual_Focused_Gaussian_Pulse_with_EnergyDensity_Screenshot.yaml
+++ b/pixi/input/Dual_Focused_Gaussian_Pulse_with_EnergyDensity_Screenshot.yaml
@@ -45,6 +45,8 @@ output:
           phi: -1.5707963267948966
           scaleFactor: 20
           theta: 0.7853981633974483
+          distanceFactor: 1
+          heightFactor: 0.250
 
 # Generated panel code:
 panels:

--- a/pixi/input/Dual_Focused_Gaussian_Pulse_with_EnergyDensity_Screenshot.yaml
+++ b/pixi/input/Dual_Focused_Gaussian_Pulse_with_EnergyDensity_Screenshot.yaml
@@ -31,10 +31,8 @@ fields:
 
 output:
   screenshotInTime:
-      # File path
-    - path: "img-{counter}.png"
-
-      # Measurement interval
+    # 3D screenshot
+    - path: "img3D-{counter}.png"
       interval: 1.0
       offset : 0
       width: 1280
@@ -47,6 +45,17 @@ output:
           theta: 0.7853981633974483
           distanceFactor: 1
           heightFactor: 0.250
+
+    # 2D screenshot
+    - path: "img2D-{counter}.png"
+      interval: 1.0
+      offset : 0
+      width: 1280
+      height: 720
+      panel:
+        energyDensity2DGLPanel:
+          automaticScaling: false
+          scaleFactor: 20
 
 # Generated panel code:
 panels:

--- a/pixi/input/Dual_Focused_Gaussian_Pulse_with_EnergyDensity_Screenshot.yaml
+++ b/pixi/input/Dual_Focused_Gaussian_Pulse_with_EnergyDensity_Screenshot.yaml
@@ -34,7 +34,7 @@ output:
     # 3D screenshot
     - path: "img3D-{counter}.png"
       interval: 1.0
-      offset : 0
+      offset : 1.0
       width: 1280
       height: 720
       panel:
@@ -49,7 +49,7 @@ output:
     # 2D screenshot
     - path: "img2D-{counter}.png"
       interval: 1.0
-      offset : 0
+      offset : 1.0
       width: 1280
       height: 720
       panel:

--- a/pixi/input/Dual_Focused_Gaussian_Pulse_with_EnergyDensity_Screenshot.yaml
+++ b/pixi/input/Dual_Focused_Gaussian_Pulse_with_EnergyDensity_Screenshot.yaml
@@ -1,0 +1,76 @@
+# Dual focused gaussian pulse test with impact parameter
+
+gridStep: 1
+couplingConstant: 1
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 6
+gridCells: [128, 128, 1]
+poissonsolver: empty
+timeStep: 0.2
+duration: 1000
+
+fields:
+  SU2FocusedGaussianPulses:
+    - dir: [1.0, 0.0, 0.0]
+      pos: [64, 74, 0.0]
+      aSpatial: [0.0, 0.0, 1.0]
+      aColor: [1.0, 0.0, 0.0]
+      a: 4
+      sigma: 3
+      angle: 1.0
+      distance: 32.0
+    - dir: [-1.0, 0.0, 0.0]
+      pos: [64, 56, 0.0]
+      aSpatial: [0.0, 0.0, 1.0]
+      aColor: [0.0, 1.0, 0.0]
+      a: 4
+      sigma: 3
+      angle: 1.0
+      distance: 32.0
+
+output:
+  screenshotInTime:
+      # File path
+    - path: "img-{counter}.png"
+
+      # Measurement interval
+      interval: 1.0
+      offset : 0
+      width: 1280
+      height: 720
+
+# Generated panel code:
+panels:
+  dividerLocation: 420
+  leftPanel:
+    dividerLocation: 318
+    leftPanel:
+      particle2DPanel:
+        colorIndex: 2
+        directionIndex: 2
+        drawCurrent: false
+        drawFields: true
+        showInfo: false
+        showTrace: false
+    orientation: 0
+    rightPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: true
+        scaleFactor: 1.0
+  orientation: 1
+  rightPanel:
+    dividerLocation: 318
+    leftPanel:
+      electricFieldPanel:
+        automaticScaling: false
+        colorIndex: 0
+        directionIndex: 2
+        scaleFactor: 1.0
+    orientation: 0
+    rightPanel:
+      energyDensity3DGLPanel:
+        automaticScaling: true
+        phi: -1.5707963267948966
+        scaleFactor: 1.0
+        theta: 0.7853981633974483

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
@@ -32,8 +32,11 @@ public class ScreenshotInTime implements Diagnostics {
 	private int stepInterval;
 	private double timeOffset;
 	private int stepOffset;
+	private int stepIterations;
+	private int timeout;
 	private int width;
 	private int height;
+	private boolean finished;
 
 	private Simulation simulation;
 	private SimulationAnimation simulationAnimation;
@@ -53,6 +56,8 @@ public class ScreenshotInTime implements Diagnostics {
 	public void initialize(Simulation s) {
 		this.stepInterval = (int) (timeInterval / s.getTimeStep());
 		this.stepOffset = (int) (timeOffset / s.getTimeStep());
+		this.stepIterations = s.getIterations();
+		finished = false;
 		this.simulation = s;
 		this.simulationAnimation = new SimulationAnimation(s);
 		this.energyDensity3DGLPanel = new EnergyDensity3DGLPanel(simulationAnimation);
@@ -79,7 +84,10 @@ public class ScreenshotInTime implements Diagnostics {
 	@Override
 	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps)
 			throws IOException {
-		if ((steps - stepOffset) % stepInterval == 0) {
+		if (finished) {
+			return;
+		}
+		if ((stepInterval > 0) && ((steps - stepOffset) % stepInterval == 0)) {
 
 			glautodrawable.getContext().makeCurrent();
 
@@ -93,6 +101,11 @@ public class ScreenshotInTime implements Diagnostics {
 			File file = getOutputFile(pathWithNumber);
 			ImageIO.write(im, "png", file);
 
+		}
+		if (steps >= stepIterations - 1) {
+			finished = true;
+
+			System.out.println("use: ffmpeg -r 25 -sameq -i img-%05d.png test_1.mov");
 			// Create movie using e.g.
 			// ffmpeg -r 25 -sameq -i img-%05d.png test_1.mov
 		}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
@@ -1,0 +1,110 @@
+package org.openpixi.pixi.diagnostics.methods;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+
+import javax.imageio.ImageIO;
+import javax.media.opengl.DefaultGLCapabilitiesChooser;
+import javax.media.opengl.GLAutoDrawable;
+import javax.media.opengl.GLCapabilities;
+import javax.media.opengl.GLDrawableFactory;
+import javax.media.opengl.GLProfile;
+
+import org.openpixi.pixi.diagnostics.Diagnostics;
+import org.openpixi.pixi.physics.Simulation;
+import org.openpixi.pixi.physics.gauge.CoulombGauge;
+import org.openpixi.pixi.physics.grid.Grid;
+import org.openpixi.pixi.physics.particles.IParticle;
+import org.openpixi.pixi.ui.SimulationAnimation;
+import org.openpixi.pixi.ui.panel.gl.EnergyDensity3DGLPanel;
+
+import com.jogamp.opengl.util.awt.AWTGLReadBufferUtil;
+
+/**
+ * Takes a screenshot of the current simulation at specified times.
+ */
+public class ScreenshotInTime implements Diagnostics {
+
+	private String path;
+	private double timeInterval;
+	private int stepInterval;
+	private double timeOffset;
+	private int stepOffset;
+	private int width;
+	private int height;
+
+	private Simulation simulation;
+	private SimulationAnimation simulationAnimation;
+	private EnergyDensity3DGLPanel energyDensity3DGLPanel;
+
+	GLAutoDrawable glautodrawable;
+
+	public ScreenshotInTime(String path, double timeInterval, double timeOffset, int width, int height) {
+		this.path = path;
+		this.timeInterval = timeInterval;
+		this.timeOffset = timeOffset;
+		this.width = width;
+		this.height = height;
+	}
+
+	@Override
+	public void initialize(Simulation s) {
+		this.stepInterval = (int) (timeInterval / s.getTimeStep());
+		this.stepOffset = (int) (timeOffset / s.getTimeStep());
+		this.simulation = s;
+		this.simulationAnimation = new SimulationAnimation(s);
+		this.energyDensity3DGLPanel = new EnergyDensity3DGLPanel(simulationAnimation);
+
+		// TODO: Supply parameters from YAML
+		energyDensity3DGLPanel.getScaleProperties().setScaleFactor(15);
+
+		// Prepare offscreen OpenGL drawable
+		GLProfile glp = GLProfile.getDefault();
+		GLCapabilities caps = new GLCapabilities(glp);
+		caps.setHardwareAccelerated(true);
+		caps.setDoubleBuffered(false);
+		//caps.setAlphaBits(8);
+		caps.setRedBits(8);
+		caps.setBlueBits(8);
+		caps.setGreenBits(8);
+		caps.setOnscreen(false);
+		GLDrawableFactory factory = GLDrawableFactory.getFactory(glp);
+
+		glautodrawable = factory.createGLPbuffer(factory.getDefaultDevice(), caps, new DefaultGLCapabilitiesChooser(), width, height, null);
+		glautodrawable.display();
+	}
+
+	@Override
+	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps)
+			throws IOException {
+		if ((steps - stepOffset) % stepInterval == 0) {
+
+			glautodrawable.getContext().makeCurrent();
+
+			energyDensity3DGLPanel.display(glautodrawable);
+
+			BufferedImage im = new AWTGLReadBufferUtil(glautodrawable.getGLProfile(), true).readPixelsToBufferedImage(glautodrawable.getGL(), 0, 0, width, height, true); 
+
+			int counter = steps / stepInterval;
+			String counterString = String.format("%05d", counter);
+			String pathWithNumber = path.replace("{counter}", counterString);
+			File file = getOutputFile(pathWithNumber);
+			ImageIO.write(im, "png", file);
+
+			// Create movie using e.g.
+			// ffmpeg -r 25 -sameq -i img-%05d.png test_1.mov
+		}
+	}
+
+	/** Creates a file with a given name in the output folder*/
+	private File getOutputFile(String filename) {
+		// Default output path is
+		// 'output/' + filename
+		File fullpath = new File("output");
+		if(!fullpath.exists()) fullpath.mkdir();
+
+		return new File(fullpath, filename);
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
@@ -86,6 +86,10 @@ public class ScreenshotInTime implements Diagnostics {
 
 				glautodrawable = factory.createGLPbuffer(factory.getDefaultDevice(), caps, new DefaultGLCapabilitiesChooser(), width, height, null);
 				glautodrawable.display();
+				glautodrawable.getContext().makeCurrent();
+
+				animationGLPanel.reshape(glautodrawable, 0, 0, width, height);
+
 			} else if (component instanceof AnimationPanel) {
 				// TODO: Can not yet draw non-OpenGL panels.
 			}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
@@ -102,7 +102,7 @@ public class ScreenshotInTime implements Diagnostics {
 		if (finished) {
 			return;
 		}
-		if ((stepInterval > 0) && ((steps - stepOffset) % stepInterval == 0)) {
+		if ((stepInterval > 0) && (steps - stepOffset >= 0) && ((steps - stepOffset) % stepInterval == 0)) {
 
 			if (animationGLPanel != null) {
 				glautodrawable.getContext().makeCurrent();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
@@ -52,7 +52,7 @@ public class PanelManager {
 	JMenuItem itemEnergyDensity2DGLPanel;
 	JMenuItem itemEnergyDensity3DGLPanel;
 
-	PanelManager(MainControlApplet m) {
+	public PanelManager(MainControlApplet m) {
 		mainControlApplet = m;
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
@@ -44,6 +44,15 @@ public class SimulationAnimation {
 		s = InitialConditions.initEmptySimulation();
 	}
 
+	/**
+	 * Alternative Constructor to create a dummy SimulationAnimation object as a wrapper for a panel.
+	 *
+	 * @param simulation  The simulation object.
+	 */
+	public SimulationAnimation(Simulation simulation) {
+		this.s = simulation;
+	}
+
 	/** Listener for timer */
 	public class TimerListener implements ActionListener {
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
@@ -59,6 +59,10 @@ public class SimulationAnimation {
 		public void actionPerformed(ActionEvent eve) {
 			try {
 				s.step();
+				if (s.totalSimulationSteps == s.getIterations()) {
+					// Stop simulation (the user can continue by hand)
+					stopAnimation();
+				}
 			} catch (FileNotFoundException ex) {
 				Logger.getLogger(Particle2DPanel.class.getName()).log(Level.SEVERE, null, ex);
 			} catch (IOException ex2) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
@@ -148,7 +148,8 @@ public class SimulationAnimation {
 		//updateFieldForce();
 		//s.prepareAllParticles();
 		//s.turnGridForceOn();
-		timer.start();
+//		timer.start();
+		repaint();
 	}
 
 //	public void calculateFields() {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
@@ -21,7 +21,7 @@ import org.openpixi.pixi.ui.util.FrameRateDetector;
  */
 public class SimulationAnimation {
 
-	private Simulation s;
+	protected Simulation s;
 
 //	private boolean relativistic = true;
 
@@ -42,15 +42,6 @@ public class SimulationAnimation {
 		timer = new Timer(interval, new TimerListener());
 		frameratedetector = new FrameRateDetector(500);
 		s = InitialConditions.initEmptySimulation();
-	}
-
-	/**
-	 * Alternative Constructor to create a dummy SimulationAnimation object as a wrapper for a panel.
-	 *
-	 * @param simulation  The simulation object.
-	 */
-	public SimulationAnimation(Simulation simulation) {
-		this.s = simulation;
 	}
 
 	/** Listener for timer */

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -59,9 +59,9 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 		Simulation s = getSimulationAnimation().getSimulation();
 
 		/** Scaling factor for the displayed panel in x-direction*/
-		double sx = getWidth() / s.getWidth();
+		double sx = width / s.getWidth();
 		/** Scaling factor for the displayed panel in y-direction*/
-		double sy = getHeight() / s.getHeight();
+		double sy = height / s.getHeight();
 
 		// Lattice spacing and coupling constant
 		double as = s.grid.getLatticeSpacing();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity3DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity3DGLPanel.java
@@ -58,8 +58,8 @@ public class EnergyDensity3DGLPanel extends AnimationGLPanel {
 
 		phi = - 0.5 * Math.PI;
 		theta = Math.PI * 0.25;
-		distanceFactor = .5; // 1
-		heightFactor = .125; // .25
+		distanceFactor = 1;
+		heightFactor = .25;
 
 		scaleProperties.setAutomaticScaling(true);
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity3DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity3DGLPanel.java
@@ -42,6 +42,12 @@ public class EnergyDensity3DGLPanel extends AnimationGLPanel {
 	public double phi;
 	public double theta;
 
+	/** Distance of viewer */
+	public double distanceFactor;
+
+	/** Maximum height of values */
+	public double heightFactor;
+
 	/** Constructor */
 	public EnergyDensity3DGLPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
@@ -52,8 +58,12 @@ public class EnergyDensity3DGLPanel extends AnimationGLPanel {
 
 		phi = - 0.5 * Math.PI;
 		theta = Math.PI * 0.25;
+		distanceFactor = .5; // 1
+		heightFactor = .125; // .25
 
 		scaleProperties.setAutomaticScaling(true);
+		scaleProperties.setAutomaticScaling(false);
+		scaleProperties.setScaleFactor(10);
 	}
 
 	@Override
@@ -80,15 +90,19 @@ public class EnergyDensity3DGLPanel extends AnimationGLPanel {
 
 		// Perspective.
 		float size = (float) Math.max(s.getWidth(), s.getHeight());
-		float distance = size;
+		float distance = (float) distanceFactor * size;
 		float widthHeightRatio = (float) width / (float) height;
 
 		// Scaling for height:
-		float heightfactor = 0.25f * size;
+		float heightScale = (float) heightFactor * size;
 
 		gl2.glMatrixMode( GL2.GL_PROJECTION );
 		gl2.glLoadIdentity();
-		glu.gluPerspective(45, widthHeightRatio, 1, 2.5 * distance);
+		glu.gluPerspective(
+				45, // field of view angle, in degrees
+				widthHeightRatio, // aspect ratio of field of view
+				1, // distance to near clipping plane
+				2.5 * size); // distance to far clipping plane
 		glu.gluLookAt(
 				s.getWidth() / 2 + distance * Math.cos(phi) * Math.sin(theta), s.getHeight() / 2 + distance * Math.sin(phi) * Math.sin(theta), distance * Math.cos(theta), // where we stand
 				s.getWidth() / 2, s.getHeight() / 2, 0, // where we are viewing at
@@ -157,9 +171,9 @@ public class EnergyDensity3DGLPanel extends AnimationGLPanel {
 
 				if (k > 0) {
 					gl2.glColor3f( previousRed[k], previousGreen[k], previousBlue[k]);
-					gl2.glVertex3f( xstart2, ystart2, heightfactor * previousValue[k]);
+					gl2.glVertex3f( xstart2, ystart2, heightScale * previousValue[k]);
 					gl2.glColor3f( red, green, blue);
-					gl2.glVertex3f( xstart3, ystart2, heightfactor * (float) value);
+					gl2.glVertex3f( xstart3, ystart2, heightScale * (float) value);
 				}
 				previousValue[k] = (float) value;
 				previousRed[k] = (float) red;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity3DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity3DGLPanel.java
@@ -62,8 +62,6 @@ public class EnergyDensity3DGLPanel extends AnimationGLPanel {
 		heightFactor = .125; // .25
 
 		scaleProperties.setAutomaticScaling(true);
-		scaleProperties.setAutomaticScaling(false);
-		scaleProperties.setScaleFactor(10);
 	}
 
 	@Override

--- a/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
@@ -132,6 +132,9 @@ public class FileTab extends Box {
 	class ApplyButtonListener implements ActionListener {
 		public void actionPerformed(ActionEvent event) {
 			applyTextAreaSettings();
+
+			// Also start animation immediately:
+			simulationAnimation.startAnimation();
 		}
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
@@ -169,7 +169,7 @@ public class FileTab extends Box {
 	}
 
 	/**
-	 * Apply the settings from the text area and restart the simulation.
+	 * Apply the settings from the text area and reset the simulation.
 	 */
 	public void applyTextAreaSettings() {
 		String string = fileTextArea.getText();
@@ -183,7 +183,7 @@ public class FileTab extends Box {
 	}
 
 	/**
-	 * Apply the panel settings from the text area and restart the simulation.
+	 * Apply the panel settings from the text area (without resetting the simulation).
 	 */
 	public void applyTextAreaPanelSettings() {
 		String string = fileTextArea.getText();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlOutput.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlOutput.java
@@ -7,6 +7,7 @@ import org.openpixi.pixi.ui.util.yaml.filegenerators.YamlCoulombGaugeInTime;
 import org.openpixi.pixi.ui.util.yaml.filegenerators.YamlParticlesInTime;
 import org.openpixi.pixi.ui.util.yaml.filegenerators.YamlBulkQuantitiesInTime;
 import org.openpixi.pixi.ui.util.yaml.filegenerators.YamlRandomGaugeInTime;
+import org.openpixi.pixi.ui.util.yaml.filegenerators.YamlScreenshotInTime;
 
 public class YamlOutput {
 	/**
@@ -19,6 +20,8 @@ public class YamlOutput {
 	public ArrayList<YamlCoulombGaugeInTime> coulombGaugeInTime = new ArrayList<YamlCoulombGaugeInTime>();
 
 	public ArrayList<YamlRandomGaugeInTime> randomGaugeInTime = new ArrayList<YamlRandomGaugeInTime>();
+
+	public ArrayList<YamlScreenshotInTime> screenshotInTime = new ArrayList<YamlScreenshotInTime>();
 
 	/**
 	 * Creates FileGenerator instances and applies them to the Settings instance.
@@ -39,6 +42,10 @@ public class YamlOutput {
 		}
 
 		for (YamlRandomGaugeInTime output : randomGaugeInTime) {
+			s.addDiagnostics(output.getFileGenerator());
+		}
+
+		for (YamlScreenshotInTime output : screenshotInTime) {
 			s.addDiagnostics(output.getFileGenerator());
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlScreenshotInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlScreenshotInTime.java
@@ -1,0 +1,44 @@
+package org.openpixi.pixi.ui.util.yaml.filegenerators;
+
+import org.openpixi.pixi.diagnostics.methods.ScreenshotInTime;
+
+/**
+ * Yaml wrapper for the YamlParticlesInTime FileGenerator.
+ */
+public class YamlScreenshotInTime {
+
+	/**
+	 * File name.
+	 */
+	public String path;
+
+	/**
+	 * Measurement interval.
+	 */
+	public double interval;
+
+	/**
+	 * Measurement interval offset.
+	 */
+	public double offset;
+
+	/**
+	 * Display width.
+	 */
+	public int width;
+
+	/**
+	 * Display height.
+	 */
+	public int height;
+
+	/**
+	 * Returns an instance of BulkQuantitiesInTime according to the parameters in the YAML file.
+	 *
+	 * @return Instance of BulkQuantitiesInTime.
+	 */
+	public ScreenshotInTime getFileGenerator() {
+		ScreenshotInTime fileGen = new ScreenshotInTime(path, interval, offset, width, height);
+		return fileGen;
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlScreenshotInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlScreenshotInTime.java
@@ -1,6 +1,7 @@
 package org.openpixi.pixi.ui.util.yaml.filegenerators;
 
 import org.openpixi.pixi.diagnostics.methods.ScreenshotInTime;
+import org.openpixi.pixi.ui.util.yaml.YamlPanels;
 
 /**
  * Yaml wrapper for the YamlParticlesInTime FileGenerator.
@@ -32,13 +33,15 @@ public class YamlScreenshotInTime {
 	 */
 	public int height;
 
+	public YamlPanels panel;
+
 	/**
 	 * Returns an instance of BulkQuantitiesInTime according to the parameters in the YAML file.
 	 *
 	 * @return Instance of BulkQuantitiesInTime.
 	 */
 	public ScreenshotInTime getFileGenerator() {
-		ScreenshotInTime fileGen = new ScreenshotInTime(path, interval, offset, width, height);
+		ScreenshotInTime fileGen = new ScreenshotInTime(path, interval, offset, width, height, panel);
 		return fileGen;
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensity3DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensity3DGLPanel.java
@@ -15,6 +15,12 @@ public class YamlEnergyDensity3DGLPanel {
 	public Double phi;
 	public Double theta;
 
+	/** Distance of viewer */
+	public Double distanceFactor;
+
+	/** Maximum height of values */
+	public Double heightFactor;
+
 	/** Empty constructor called by SnakeYaml */
 	public YamlEnergyDensity3DGLPanel() {
 	}
@@ -26,6 +32,8 @@ public class YamlEnergyDensity3DGLPanel {
 			automaticScaling = panel.getScaleProperties().getAutomaticScaling();
 			phi = panel.phi;
 			theta = panel.theta;
+			distanceFactor = panel.distanceFactor;
+			heightFactor = panel.heightFactor;
 		}
 	}
 
@@ -47,6 +55,14 @@ public class YamlEnergyDensity3DGLPanel {
 
 		if (theta != null) {
 			panel.theta = theta;
+		}
+
+		if (distanceFactor != null) {
+			panel.distanceFactor = distanceFactor;
+		}
+
+		if (heightFactor != null) {
+			panel.heightFactor = heightFactor;
 		}
 
 		return panel;


### PR DESCRIPTION
Add new file generator to generate screen shots of the 3D GL panel and write them to png files.

Desired width and height can be specified and the image is rendered off-screen. It is not necessary to have a 3D GL panel open during rendering.

**WARNING: Change of behavior:**
- Now the simulation will not start automatically after opening it, but one has to press the "Start" button or press "Apply". In this way, one can modify the YAML file (e.g. change output paths) before the simulation starts.
- The simulation will stop after the time specified in the YAML file by "duration". One can press "Start" to continue the simulation on screen, but no further images are written to a file.
