### PR TITLE
Workaround for problem with JOGL and Java package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 *~
 *.swp
 
+# JOGL workaround library files
+*.so
+
 target/
 lib/
 

--- a/pixi/README.txt
+++ b/pixi/README.txt
@@ -41,6 +41,10 @@ To build Pixi:
 To launch Pixi:
     java -jar target/pixi-x.x-SNAPSHOT.jar
 
+(In case there is a problem with an OpenGL panel, execute
+    scripts/jogl-bug-workaround
+    java -jar target/pixi-x.x-SNAPSHOT.jar
+)
 
 DEVELOP IN ECLIPSE
 ==================
@@ -52,7 +56,7 @@ To launch Pixi in Eclipse ( http://www.eclipse.org/ ) do the following:
 	git clone git://github.com/openpixi/openpixi.git
 2) Open Eclipse and go to Help > Install New Software
 3) Choose "All Available Sites" from the dropdown menu
-4) Search for "maven", choose the desired result and press finish
+4) Search for "m2e", choose the desired result (Maven integration) and press finish
 5) File > Import > Maven > Existing Maven Projects
 6) Select the local folder that you have chosen previously
 

--- a/pixi/pom.xml
+++ b/pixi/pom.xml
@@ -85,6 +85,7 @@
 
 	<properties>
 		<java.version>1.6</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<profiles>

--- a/pixi/scripts/jogl-bug-workaround
+++ b/pixi/scripts/jogl-bug-workaround
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Apply a bug fix such that that package can use JOGL.
+#
+# The bug has been described here:
+# http://stackoverflow.com/questions/22213948/wrong-library-path-when-executing-from-maven-shaded-jar
+#
+# July 2, 2015
+
+# USAGE:
+# cd pixi
+# mvn clean package
+# scripts/jogl-bug-workaround
+# java -jar target/pixi-0.6-SNAPSHOT.jar
+
+PIXIVERSION=0.6-SNAPSHOT
+JOGLVERSION=2.0.2
+PLATFORM=linux-amd64
+
+MAVENDIR=~/.m2
+JOGAMPDIR=$MAVENDIR/repository/org/jogamp
+
+CURRENTDIR=.
+TARGETDIR=$CURRENTDIR/target
+
+# Create copy of gluegen-jar file in target directory with the right name
+cp $JOGAMPDIR/gluegen/gluegen-rt/$JOGLVERSION/gluegen-rt-$JOGLVERSION-natives-$PLATFORM.jar $TARGETDIR/pixi-$PIXIVERSION-natives-linux-amd64.jar
+
+# Extract other libraries
+cp $JOGAMPDIR/jogl/jogl-all/$JOGLVERSION/jogl-all-$JOGLVERSION-natives-$PLATFORM.jar $CURRENTDIR
+unzip -o $CURRENTDIR/jogl-all-$JOGLVERSION-natives-$PLATFORM.jar *.so
+rm $CURRENTDIR/jogl-all-$JOGLVERSION-natives-$PLATFORM.jar
+

--- a/pixi/scripts/jogl-bug-workaround
+++ b/pixi/scripts/jogl-bug-workaround
@@ -30,3 +30,9 @@ cp $JOGAMPDIR/jogl/jogl-all/$JOGLVERSION/jogl-all-$JOGLVERSION-natives-$PLATFORM
 unzip -o $CURRENTDIR/jogl-all-$JOGLVERSION-natives-$PLATFORM.jar *.so
 rm $CURRENTDIR/jogl-all-$JOGLVERSION-natives-$PLATFORM.jar
 
+if [ -z ${LD_LIBRARY_PATH+x} ]
+then
+  echo ""
+  echo "Please execute the following line:"
+  echo "export LD_LIBRARY_PATH=."
+fi


### PR DESCRIPTION
Apply a bug fix such that that package can use JOGL.

The bug has been described here:
http://stackoverflow.com/questions/22213948/wrong-library-path-when-executing-from-maven-shaded-jar

USAGE of the script:

``` bash
cd pixi
mvn clean package
scripts/jogl-bug-workaround
java -jar target/pixi-0.6-SNAPSHOT.jar
```
