### PR TITLE
Bug fixes for occupation numbers 

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -89,7 +89,9 @@ public class OccupationNumbersInTime implements Diagnostics {
 		}
 
 		// Write header
-		this.writeHeader(outputFileName);
+		if(!outputType.equals(OUTPUT_NONE)) {
+			this.writeHeader(outputFileName);
+		}
 
 		// Include lattice momentum vectors (optional)
 		if(outputType.equals(OUTPUT_CSV_WITH_VECTORS)) {
@@ -179,7 +181,6 @@ public class OccupationNumbersInTime implements Diagnostics {
 			double normalizationConstant = 1.0 / (2.0 * simulationBoxVolume * simulationBoxVolume);
 			energyDensity *= normalizationConstant;
 
-			computationCounter++;
 
 			// Generate output (write to file, terminal, etc..)
 			if(this.outputType.equals(OUTPUT_CSV)) {
@@ -194,6 +195,8 @@ public class OccupationNumbersInTime implements Diagnostics {
 				this.writeCSVFile(this.outputFileName, false);
 			}
 
+
+			computationCounter++;
 		}
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
@@ -181,6 +181,8 @@ public class Simulation {
 		particles = (ArrayList<IParticle>) settings.getParticles();
 		f = settings.getForce();
 
+		diagnostics = settings.getDiagnostics();
+
 		DoubleBox simulationBox = new DoubleBox(numberOfDimensions, new double[] {0, 0, 0},
 				new double[] {this.getWidth(), this.getHeight(), this.getDepth()});
 		IParticleBoundaryConditions particleBoundaryConditions;
@@ -242,21 +244,9 @@ public class Simulation {
 		}
 		*/
 
+
+
 		//updateVelocities(); TODO: Write this method!!
-
-		// Cycle through diagnostic objects and initialize them.
-		diagnostics = settings.getDiagnostics();
-		for (int f = 0; f < diagnostics.size(); f++)
-        {
-			diagnostics.get(f).initialize(this);
-        }
-
-		//Here we run the diagnostics routines on the initial state!!
-		try {
-			runDiagnostics();
-		} catch (IOException ex) {
-			//TODO: Take care of the exception!!
-		}
 
 	}
 
@@ -300,6 +290,13 @@ public class Simulation {
 	 */
 	public void step() throws FileNotFoundException,IOException {
 
+		// Initialize and run diagnostics before first simulation step.
+		if(totalSimulationSteps == 0) {
+			for (int f = 0; f < diagnostics.size(); f++) {
+				diagnostics.get(f).initialize(this);
+			}
+			runDiagnostics();
+		}
 		//Link and particle reassignment
 		grid.storeFields();
 		//reassignParticles(); TODO: Write this method!!

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -51,6 +51,10 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		super(simulationAnimation);
 		scaleProperties.setAutomaticScaling(true);
 		frameCounter = 0;
+
+		simulation = this.simulationAnimation.getSimulation();
+		diagnostic = new OccupationNumbersInTime(1.0, "none", "", true);
+		diagnostic.initialize(simulation);
 	}
 
 	@Override
@@ -58,9 +62,6 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		frameSkip = (frameSkipProperties.getValue() > 1) ? frameSkipProperties.getValue() : 1;
 		if( frameCounter % frameSkip == 0)
 		{
-			simulation = this.simulationAnimation.getSimulation();
-			diagnostic = new OccupationNumbersInTime(1.0, "none", "", true);
-			diagnostic.initialize(simulation);
 
 			GL2 gl2 = glautodrawable.getGL().getGL2();
 			int width = glautodrawable.getWidth();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -55,6 +55,7 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		simulation = this.simulationAnimation.getSimulation();
 		diagnostic = new OccupationNumbersInTime(1.0, "none", "", true);
 		diagnostic.initialize(simulation);
+
 	}
 
 	@Override
@@ -62,6 +63,10 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		frameSkip = (frameSkipProperties.getValue() > 1) ? frameSkipProperties.getValue() : 1;
 		if( frameCounter % frameSkip == 0)
 		{
+			if(simulation != simulationAnimation.getSimulation()) {
+				simulation = this.simulationAnimation.getSimulation();
+				diagnostic.initialize(simulation);
+			}
 
 			GL2 gl2 = glautodrawable.getGL().getGL2();
 			int width = glautodrawable.getWidth();


### PR DESCRIPTION
1) Small fixes for the occupation numbers diagnostic and the panel.

2) Change of behavior: Loading a YAML file in the UI does not create/overwrite the output files anymore. Files are only written once the user starts the simulation. 
