### PR TITLE
Energy density from occupation numbers in Chart2DPanel

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -129,8 +129,8 @@ public class OccupationNumbersInTime implements Diagnostics {
 						eFFTdata[j][k][fftIndex + 1] = 0.0;
 
 						// Gauge fields need to be averaged over two time-steps.
-						YMField gaugeFieldAsAlgebraElement0 = grid.getU(i, j).getLinearizedAlgebraElement();
-						YMField gaugeFieldAsAlgebraElement1 = grid.getUnext(i, j).getLinearizedAlgebraElement();
+						YMField gaugeFieldAsAlgebraElement0 = grid.getU(i, j).getAlgebraElement();
+						YMField gaugeFieldAsAlgebraElement1 = grid.getUnext(i, j).getAlgebraElement();
 						double gaugeFieldComponent0 = 2.0 * gaugeFieldAsAlgebraElement0.proj(k) * gainv;
 						double gaugeFieldComponent1 = 2.0 * gaugeFieldAsAlgebraElement1.proj(k) * gainv;
 						aFFTdata[j][k][fftIndex] = 0.5 * (gaugeFieldComponent0 + gaugeFieldComponent1);

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -89,7 +89,9 @@ public class OccupationNumbersInTime implements Diagnostics {
 		}
 
 		// Write header
-		this.writeHeader(outputFileName);
+		if(!outputType.equals(OUTPUT_NONE)) {
+			this.writeHeader(outputFileName);
+		}
 
 		// Include lattice momentum vectors (optional)
 		if(outputType.equals(OUTPUT_CSV_WITH_VECTORS)) {
@@ -179,7 +181,6 @@ public class OccupationNumbersInTime implements Diagnostics {
 			double normalizationConstant = 1.0 / (2.0 * simulationBoxVolume * simulationBoxVolume);
 			energyDensity *= normalizationConstant;
 
-			computationCounter++;
 
 			// Generate output (write to file, terminal, etc..)
 			if(this.outputType.equals(OUTPUT_CSV)) {
@@ -194,6 +195,8 @@ public class OccupationNumbersInTime implements Diagnostics {
 				this.writeCSVFile(this.outputFileName, false);
 			}
 
+
+			computationCounter++;
 		}
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
@@ -181,6 +181,8 @@ public class Simulation {
 		particles = (ArrayList<IParticle>) settings.getParticles();
 		f = settings.getForce();
 
+		diagnostics = settings.getDiagnostics();
+
 		DoubleBox simulationBox = new DoubleBox(numberOfDimensions, new double[] {0, 0, 0},
 				new double[] {this.getWidth(), this.getHeight(), this.getDepth()});
 		IParticleBoundaryConditions particleBoundaryConditions;
@@ -242,21 +244,9 @@ public class Simulation {
 		}
 		*/
 
+
+
 		//updateVelocities(); TODO: Write this method!!
-
-		// Cycle through diagnostic objects and initialize them.
-		diagnostics = settings.getDiagnostics();
-		for (int f = 0; f < diagnostics.size(); f++)
-        {
-			diagnostics.get(f).initialize(this);
-        }
-
-		//Here we run the diagnostics routines on the initial state!!
-		try {
-			runDiagnostics();
-		} catch (IOException ex) {
-			//TODO: Take care of the exception!!
-		}
 
 	}
 
@@ -300,6 +290,13 @@ public class Simulation {
 	 */
 	public void step() throws FileNotFoundException,IOException {
 
+		// Initialize and run diagnostics before first simulation step.
+		if(totalSimulationSteps == 0) {
+			for (int f = 0; f < diagnostics.size(); f++) {
+				diagnostics.get(f).initialize(this);
+			}
+			runDiagnostics();
+		}
 		//Link and particle reassignment
 		grid.storeFields();
 		//reassignParticles(); TODO: Write this method!!

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
@@ -138,8 +138,8 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 		traces[INDEX_GAUSS_VIOLATION].addPoint(time, gaussViolation);
 		traces[INDEX_ENERGY_DENSITY].addPoint(time, energyDensity);
 		traces[INDEX_PX].addPoint(time, px);
-		traces[INDEX_PX].addPoint(time, py);
-		traces[INDEX_PX].addPoint(time, pz);
+		traces[INDEX_PY].addPoint(time, py);
+		traces[INDEX_PZ].addPoint(time, pz);
 
 		if(showChartsProperty.getValue(INDEX_ENERGY_DENSITY_2)) {
 			occupationNumbers.initialize(s);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
@@ -14,6 +14,7 @@ import java.text.DecimalFormat;
 
 import javax.swing.Box;
 
+import org.openpixi.pixi.diagnostics.methods.OccupationNumbersInTime;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.measurements.FieldMeasurements;
 import org.openpixi.pixi.ui.SimulationAnimation;
@@ -34,6 +35,7 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 	public final int INDEX_PX = 4;
 	public final int INDEX_PY = 5;
 	public final int INDEX_PZ = 6;
+	public final int INDEX_ENERGY_DENSITY_2 = 7;
 
 	String[] chartLabel = new String[] {
 			"Gauss law violation",
@@ -42,7 +44,8 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 			"Energy density",
 			"px",
 			"py",
-			"pz"
+			"pz",
+			"Energy density (occupation numbers)"
 	};
 
 	Color[] traceColors = new Color[] {
@@ -52,7 +55,8 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 			Color.black,
 			Color.red,
 			Color.green,
-			Color.blue
+			Color.blue,
+			Color.magenta
 	};
 
 	public BooleanProperties logarithmicProperty;
@@ -61,6 +65,8 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 	private boolean oldLogarithmicValue = false;
 
 	private FieldMeasurements fieldMeasurements;
+
+	private OccupationNumbersInTime occupationNumbers;
 
 	/** Constructor */
 	public Chart2DPanel(SimulationAnimation simulationAnimation) {
@@ -81,6 +87,7 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 
 		showChartsProperty = new BooleanArrayProperties(chartLabel, new boolean[chartLabel.length]);
 
+		occupationNumbers = new OccupationNumbersInTime(1.0, "none", "", false);
 		// Linear scale
 		AAxis<?> axisy = new AxisLinear<AxisScalePolicyAutomaticBestFit>(
 				new LabelFormatterSimple(),
@@ -133,6 +140,12 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 		traces[INDEX_PX].addPoint(time, px);
 		traces[INDEX_PX].addPoint(time, py);
 		traces[INDEX_PX].addPoint(time, pz);
+
+		if(showChartsProperty.getValue(INDEX_ENERGY_DENSITY_2)) {
+			occupationNumbers.initialize(s);
+			occupationNumbers.calculate(s.grid, s.particles, 0);
+			traces[INDEX_ENERGY_DENSITY_2].addPoint(time, occupationNumbers.energyDensity);
+		}
 
 		for (int i = 0; i < showChartsProperty.getSize(); i++) {
 			traces[i].setVisible(showChartsProperty.getValue(i));

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -51,6 +51,10 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		super(simulationAnimation);
 		scaleProperties.setAutomaticScaling(true);
 		frameCounter = 0;
+
+		simulation = this.simulationAnimation.getSimulation();
+		diagnostic = new OccupationNumbersInTime(1.0, "none", "", true);
+		diagnostic.initialize(simulation);
 	}
 
 	@Override
@@ -58,9 +62,6 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		frameSkip = (frameSkipProperties.getValue() > 1) ? frameSkipProperties.getValue() : 1;
 		if( frameCounter % frameSkip == 0)
 		{
-			simulation = this.simulationAnimation.getSimulation();
-			diagnostic = new OccupationNumbersInTime(1.0, "none", "", true);
-			diagnostic.initialize(simulation);
 
 			GL2 gl2 = glautodrawable.getGL().getGL2();
 			int width = glautodrawable.getWidth();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -55,6 +55,7 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		simulation = this.simulationAnimation.getSimulation();
 		diagnostic = new OccupationNumbersInTime(1.0, "none", "", true);
 		diagnostic.initialize(simulation);
+
 	}
 
 	@Override
@@ -62,6 +63,10 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		frameSkip = (frameSkipProperties.getValue() > 1) ? frameSkipProperties.getValue() : 1;
 		if( frameCounter % frameSkip == 0)
 		{
+			if(simulation != simulationAnimation.getSimulation()) {
+				simulation = this.simulationAnimation.getSimulation();
+				diagnostic.initialize(simulation);
+			}
 
 			GL2 gl2 = glautodrawable.getGL().getGL2();
 			int width = glautodrawable.getWidth();


### PR DESCRIPTION
- Added the energy density from OccupationNumbersInTime to the new chart panel.
- Small change for occupation numbers: the diagnostic now uses the exact gauge fields instead of the linear approximation from the links. In the abelian case the two energy densities (one from BulkQuantitiesInTime and the other from OccupationNumbersInTime) now seem to fit much better.
- Also had to include some commits from the my last pull request because they were reverted in https://github.com/openpixi/openpixi/pull/121. 
