### PR TITLE
Update panels while animation is stopped

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
@@ -101,7 +101,7 @@ public class SimulationAnimation {
 		listeners.remove(listener);
 	}
 
-	private void repaint() {
+	public void repaint() {
 		// Let all listeners know
 		for (SimulationAnimationListener l : listeners) {
 			l.repaint();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/AnimationPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/AnimationPanel.java
@@ -14,7 +14,7 @@ import org.openpixi.pixi.ui.SimulationAnimationListener;
 
 public class AnimationPanel extends JPanel implements FocusablePanel {
 
-	private SimulationAnimation simulationAnimation;
+	protected SimulationAnimation simulationAnimation;
 	private MyAnimationListener listener;
 	boolean focus = false;
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -21,13 +21,16 @@ import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
  */
 public class ElectricFieldPanel extends AnimationPanel {
 
-	ColorProperties colorProperties = new ColorProperties();
-	ScaleProperties scaleProperties = new ScaleProperties();
-	GaugeProperties gaugeProperties = new GaugeProperties();
+	ColorProperties colorProperties;
+	ScaleProperties scaleProperties;
+	GaugeProperties gaugeProperties;
 
 	/** Constructor */
 	public ElectricFieldPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
+		colorProperties = new ColorProperties(simulationAnimation);
+		scaleProperties = new ScaleProperties(simulationAnimation);
+		gaugeProperties = new GaugeProperties(simulationAnimation);
 	}
 
 	/** Display the particles */

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/EnergyDensity1DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/EnergyDensity1DPanel.java
@@ -17,11 +17,12 @@ import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
  */
 public class EnergyDensity1DPanel extends AnimationPanel {
 	
-	ScaleProperties scaleProperties = new ScaleProperties();
+	ScaleProperties scaleProperties;
 
 	/** Constructor */
 	public EnergyDensity1DPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
+		scaleProperties = new ScaleProperties(simulationAnimation);
 	}
 
 	public void paintComponent(Graphics graph1) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/EnergyDensity2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/EnergyDensity2DPanel.java
@@ -39,12 +39,14 @@ import org.openpixi.pixi.ui.panel.properties.InfoProperties;
  */
 public class EnergyDensity2DPanel extends AnimationPanel {
 
-	ScaleProperties scaleProperties = new ScaleProperties();	
-	InfoProperties infoProperties = new InfoProperties();
+	ScaleProperties scaleProperties;
+	InfoProperties infoProperties;
 	
 	/** Constructor */
 	public EnergyDensity2DPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
+		scaleProperties = new ScaleProperties(simulationAnimation);
+		infoProperties = new InfoProperties(simulationAnimation);
 	}
 
 	/** Display the particles */

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle2DPanel.java
@@ -41,14 +41,18 @@ import org.openpixi.pixi.ui.panel.properties.TraceProperties;
  */
 public class Particle2DPanel extends AnimationPanel {
 
-	ColorProperties colorProperties = new ColorProperties();
-	FieldProperties fieldProperties = new FieldProperties();
-	InfoProperties infoProperties = new InfoProperties();
-	TraceProperties traceProperties = new TraceProperties();
+	ColorProperties colorProperties;
+	FieldProperties fieldProperties;
+	InfoProperties infoProperties;
+	TraceProperties traceProperties;
 
 	/** Constructor */
 	public Particle2DPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
+		colorProperties = new ColorProperties(simulationAnimation);
+		fieldProperties = new FieldProperties(simulationAnimation);
+		infoProperties = new InfoProperties(simulationAnimation);
+		traceProperties = new TraceProperties(simulationAnimation);
 	}
 
 	public void clear() {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
@@ -43,9 +43,9 @@ import org.openpixi.pixi.ui.util.projection.SphereObject;
  */
 public class Particle3DPanel extends AnimationPanel {
 
-	ColorProperties colorProperties = new ColorProperties();
-	FieldProperties fieldProperties = new FieldProperties();
-	InfoProperties infoProperties = new InfoProperties();
+	ColorProperties colorProperties;
+	FieldProperties fieldProperties;
+	InfoProperties infoProperties;
 
 	/** Whether to combine the spatial components of the fields into a single vector
 	 * or whether to keep them separate. */
@@ -65,6 +65,9 @@ public class Particle3DPanel extends AnimationPanel {
 	/** Constructor */
 	public Particle3DPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
+		colorProperties = new ColorProperties(simulationAnimation);
+		fieldProperties = new FieldProperties(simulationAnimation);
+		infoProperties = new InfoProperties(simulationAnimation);
 
 		projection.phi = 0;
 		projection.theta = 0;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
@@ -279,10 +279,12 @@ public class Particle3DPanel extends AnimationPanel {
 			mouseOldX = e.getX();
 			mouseOldY = e.getY();
 			super.mouseDragged(e);
+			simulationAnimation.repaint();
 		}
 
 		public void mouseReleased(MouseEvent e) {
 			super.mouseReleased(e);
+			simulationAnimation.repaint();
 		}
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/PhaseSpacePanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/PhaseSpacePanel.java
@@ -16,11 +16,12 @@ import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
  */
 public class PhaseSpacePanel extends AnimationPanel {
 
-	ScaleProperties scaleProperties = new ScaleProperties();
+	ScaleProperties scaleProperties;
 
 	/** Constructor */
 	public PhaseSpacePanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
+		scaleProperties = new ScaleProperties(simulationAnimation);
 	}
 
 	/** Display the particles */

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
@@ -83,9 +83,9 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 
 		this.fieldMeasurements = new FieldMeasurements();
 
-		logarithmicProperty = new BooleanProperties("Logarithmic scale", false);
+		logarithmicProperty = new BooleanProperties(simulationAnimation, "Logarithmic scale", false);
 
-		showChartsProperty = new BooleanArrayProperties(chartLabel, new boolean[chartLabel.length]);
+		showChartsProperty = new BooleanArrayProperties(simulationAnimation, chartLabel, new boolean[chartLabel.length]);
 
 		occupationNumbers = new OccupationNumbersInTime(1.0, "none", "", false);
 		// Linear scale

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -37,11 +37,12 @@ import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
  */
 public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 
-	ScaleProperties scaleProperties = new ScaleProperties();
+	ScaleProperties scaleProperties;
 
 	/** Constructor */
 	public EnergyDensity2DGLPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
+		scaleProperties = new ScaleProperties(simulationAnimation);
 
 		scaleProperties.setAutomaticScaling(true);
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity3DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity3DGLPanel.java
@@ -37,7 +37,7 @@ import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
  */
 public class EnergyDensity3DGLPanel extends AnimationGLPanel {
 
-	ScaleProperties scaleProperties = new ScaleProperties();
+	ScaleProperties scaleProperties;
 
 	public double phi;
 	public double theta;
@@ -51,6 +51,7 @@ public class EnergyDensity3DGLPanel extends AnimationGLPanel {
 	/** Constructor */
 	public EnergyDensity3DGLPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
+		scaleProperties = new ScaleProperties(simulationAnimation);
 
 		MouseListener l = new MouseListener();
 		addMouseListener(l);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity3DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity3DGLPanel.java
@@ -206,10 +206,12 @@ public class EnergyDensity3DGLPanel extends AnimationGLPanel {
 			mouseOldX = e.getX();
 			mouseOldY = e.getY();
 			super.mouseDragged(e);
+			simulationAnimation.repaint();
 		}
 
 		public void mouseReleased(MouseEvent e) {
 			super.mouseReleased(e);
+			simulationAnimation.repaint();
 		}
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -37,7 +37,7 @@ import javax.swing.*;
 public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 
 	ScaleProperties scaleProperties = new ScaleProperties();
-	BooleanProperties colorfulProperties = new BooleanProperties("Colorful occupation numbers", true);
+	BooleanProperties colorfulProperties;
 	IntegerProperties frameSkipProperties = new IntegerProperties("Skipped frames:", 2);
 
 	OccupationNumbersInTime diagnostic;
@@ -49,6 +49,7 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 	/** Constructor */
 	public OccupationNumbers2DGLPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
+		colorfulProperties = new BooleanProperties(simulationAnimation, "Colorful occupation numbers", true);
 		scaleProperties.setAutomaticScaling(true);
 		frameCounter = 0;
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -36,9 +36,9 @@ import javax.swing.*;
  */
 public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 
-	ScaleProperties scaleProperties = new ScaleProperties();
+	ScaleProperties scaleProperties;
 	BooleanProperties colorfulProperties;
-	IntegerProperties frameSkipProperties = new IntegerProperties("Skipped frames:", 2);
+	IntegerProperties frameSkipProperties;
 
 	OccupationNumbersInTime diagnostic;
 	Simulation simulation;
@@ -49,7 +49,9 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 	/** Constructor */
 	public OccupationNumbers2DGLPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
+		scaleProperties = new ScaleProperties(simulationAnimation);
 		colorfulProperties = new BooleanProperties(simulationAnimation, "Colorful occupation numbers", true);
+		frameSkipProperties = new IntegerProperties(simulationAnimation, "Skipped frames:", 2);
 		scaleProperties.setAutomaticScaling(true);
 		frameCounter = 0;
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/BooleanArrayProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/BooleanArrayProperties.java
@@ -1,6 +1,9 @@
 package org.openpixi.pixi.ui.panel.properties;
 
 import javax.swing.*;
+
+import org.openpixi.pixi.ui.SimulationAnimation;
+
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.ArrayList;
@@ -12,12 +15,14 @@ import java.util.List;
  */
 public class BooleanArrayProperties {
 
+	private SimulationAnimation simulationAnimation;
 	private boolean[] valueList;
 	private String[] nameList;
 	private JCheckBox[] boolCheckList;
 
-	public BooleanArrayProperties(String[] nameList, boolean[] initialValueList)
+	public BooleanArrayProperties(SimulationAnimation simulationAnimation, String[] nameList, boolean[] initialValueList)
 	{
+		this.simulationAnimation = simulationAnimation;
 		this.nameList = nameList;
 		boolCheckList = new JCheckBox[this.nameList.length];
 		valueList = new boolean[this.nameList.length];
@@ -91,6 +96,7 @@ public class BooleanArrayProperties {
 		public void itemStateChanged(ItemEvent event){
 			BooleanArrayProperties.this.valueList[index] =
 					(event.getStateChange() == ItemEvent.SELECTED);
+			simulationAnimation.repaint();
 		}
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/BooleanProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/BooleanProperties.java
@@ -1,6 +1,9 @@
 package org.openpixi.pixi.ui.panel.properties;
 
 import javax.swing.*;
+
+import org.openpixi.pixi.ui.SimulationAnimation;
+
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 
@@ -9,12 +12,14 @@ import java.awt.event.ItemListener;
  */
 public class BooleanProperties {
 
+	private SimulationAnimation simulationAnimation;
 	private boolean value;
 	private String name;
 	private JCheckBox boolCheck;
 
-	public BooleanProperties(String name, boolean initialValue)
+	public BooleanProperties(SimulationAnimation simulationAnimation, String name, boolean initialValue)
 	{
+		this.simulationAnimation = simulationAnimation;
 		this.name = name;
 		boolCheck = new JCheckBox(name);
 		this.setValue(initialValue);
@@ -48,6 +53,7 @@ public class BooleanProperties {
 		public void itemStateChanged(ItemEvent event){
 			BooleanProperties.this.value =
 					(event.getStateChange() == ItemEvent.SELECTED);
+			simulationAnimation.repaint();
 		}
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ColorProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ColorProperties.java
@@ -8,14 +8,16 @@ import javax.swing.Box;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 
+import org.openpixi.pixi.ui.SimulationAnimation;
+
 /**
  * Common properties in connection with color fields
  *
  */
 public class ColorProperties {
 
+	private SimulationAnimation simulationAnimation;
 	private int colorIndex = 0;
-
 	private int directionIndex = 1;
 
 	String[] colorString = {
@@ -27,6 +29,10 @@ public class ColorProperties {
 			"x",
 			"y",
 			"z"};
+
+	public ColorProperties(SimulationAnimation simulationAnimation) {
+		this.simulationAnimation = simulationAnimation;
+	}
 
 	public int getColorIndex() {
 		return colorIndex;
@@ -83,6 +89,7 @@ public class ColorProperties {
 			JComboBox cbox = (JComboBox) eve.getSource();
 			int id = cbox.getSelectedIndex();
 			ColorProperties.this.colorIndex = id;
+			simulationAnimation.repaint();
 		}
 	}
 
@@ -91,6 +98,7 @@ public class ColorProperties {
 			JComboBox cbox = (JComboBox) eve.getSource();
 			int id = cbox.getSelectedIndex();
 			ColorProperties.this.directionIndex = id;
+			simulationAnimation.repaint();
 		}
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/FieldProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/FieldProperties.java
@@ -6,10 +6,17 @@ import java.awt.event.ItemListener;
 import javax.swing.Box;
 import javax.swing.JCheckBox;
 
+import org.openpixi.pixi.ui.SimulationAnimation;
+
 public class FieldProperties {
 
+	private SimulationAnimation simulationAnimation;
 	private boolean drawCurrent = false;
 	private boolean drawFields = false;
+
+	public FieldProperties(SimulationAnimation simulationAnimation) {
+		this.simulationAnimation = simulationAnimation;
+	}
 
 	public boolean isDrawCurrent() {
 		return drawCurrent;
@@ -52,6 +59,7 @@ public class FieldProperties {
 		public void itemStateChanged(ItemEvent event){
 			FieldProperties.this.drawCurrent = 
 					(event.getStateChange() == ItemEvent.SELECTED);
+			simulationAnimation.repaint();
 		}
 	}
 
@@ -59,6 +67,7 @@ public class FieldProperties {
 		public void itemStateChanged(ItemEvent event){
 			FieldProperties.this.drawFields = 
 					(event.getStateChange() == ItemEvent.SELECTED);
+			simulationAnimation.repaint();
 		}
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/GaugeProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/GaugeProperties.java
@@ -6,9 +6,16 @@ import java.awt.event.ItemListener;
 import javax.swing.Box;
 import javax.swing.JCheckBox;
 
+import org.openpixi.pixi.ui.SimulationAnimation;
+
 public class GaugeProperties {
 
+	private SimulationAnimation simulationAnimation;
 	private boolean coulombGauge = false;
+
+	public GaugeProperties(SimulationAnimation simulationAnimation) {
+		this.simulationAnimation = simulationAnimation;
+	}
 
 	public boolean isCoulombGauge() {
 		return coulombGauge;
@@ -36,6 +43,7 @@ public class GaugeProperties {
 		public void itemStateChanged(ItemEvent event){
 			GaugeProperties.this.coulombGauge = 
 					(event.getStateChange() == ItemEvent.SELECTED);
+			simulationAnimation.repaint();
 		}
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/InfoProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/InfoProperties.java
@@ -9,14 +9,20 @@ import javax.swing.Box;
 import javax.swing.JCheckBox;
 
 import org.openpixi.pixi.physics.Simulation;
+import org.openpixi.pixi.ui.SimulationAnimation;
 import org.openpixi.pixi.ui.panel.AnimationPanel;
 import org.openpixi.pixi.ui.util.FrameRateDetector;
 
 public class InfoProperties {
 
+	private SimulationAnimation simulationAnimation;
 	public boolean showInfo = false;
 
 	Color darkGreen = new Color(0x00, 0x80, 0x00);
+
+	public InfoProperties(SimulationAnimation simulationAnimation) {
+		this.simulationAnimation = simulationAnimation;
+	}
 
 	public boolean isShowInfo() {
 		return showInfo;
@@ -44,6 +50,7 @@ public class InfoProperties {
 		public void itemStateChanged(ItemEvent event) {
 			InfoProperties.this.showInfo =
 					(event.getStateChange() == ItemEvent.SELECTED);
+			simulationAnimation.repaint();
 		}
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/IntegerProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/IntegerProperties.java
@@ -1,6 +1,9 @@
 package org.openpixi.pixi.ui.panel.properties;
 
 import javax.swing.*;
+
+import org.openpixi.pixi.ui.SimulationAnimation;
+
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -10,14 +13,16 @@ import java.awt.event.ActionListener;
  */
 public class IntegerProperties {
 
+	private SimulationAnimation simulationAnimation;
 	private int value;
 	private String name;
 
 	private JLabel label;
 	private JTextField textField;
 
-	public IntegerProperties(String name, int initialValue)
+	public IntegerProperties(SimulationAnimation simulationAnimation, String name, int initialValue)
 	{
+		this.simulationAnimation = simulationAnimation;
 		this.name = name;
 		textField = new JTextField();
 		this.setValue(initialValue);
@@ -56,6 +61,7 @@ public class IntegerProperties {
 	class TextFieldListener implements ActionListener {
 		public void actionPerformed(ActionEvent event) {
 			value = Integer.parseInt(textField.getText());
+			simulationAnimation.repaint();
 		}
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ScaleProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ScaleProperties.java
@@ -12,8 +12,11 @@ import javax.swing.JLabel;
 import javax.swing.JTextField;
 import javax.swing.SwingConstants;
 
+import org.openpixi.pixi.ui.SimulationAnimation;
+
 public class ScaleProperties {
 
+	private SimulationAnimation simulationAnimation;
 	private double scaleFactor = 1;
 	private double automaticScaleFactor = 1;
 	private boolean automaticScaling = false;
@@ -21,6 +24,10 @@ public class ScaleProperties {
 
 	private JLabel label;
 	private JTextField textField;
+
+	public ScaleProperties(SimulationAnimation simulationAnimation) {
+		this.simulationAnimation = simulationAnimation;
+	}
 
 	public double getScaleFactor() {
 		return scaleFactor;
@@ -113,12 +120,14 @@ public class ScaleProperties {
 			ScaleProperties.this.automaticScaling =
 					(event.getStateChange() == ItemEvent.SELECTED);
 			ScaleProperties.this.updateTextFieldStatus();
+			simulationAnimation.repaint();
 		}
 	}
 
 	class TextFieldListener implements ActionListener {
 		public void actionPerformed(ActionEvent event) {
 			scaleFactor = Double.parseDouble(textField.getText());
+			simulationAnimation.repaint();
 		}
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/TraceProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/TraceProperties.java
@@ -6,12 +6,19 @@ import java.awt.event.ItemListener;
 import javax.swing.Box;
 import javax.swing.JCheckBox;
 
+import org.openpixi.pixi.ui.SimulationAnimation;
+
 public class TraceProperties {
 
+	private SimulationAnimation simulationAnimation;
 	/** A state for the trace */
 	public boolean showTrace = false;
 
 	private boolean resetTrace;
+
+	public TraceProperties(SimulationAnimation simulationAnimation) {
+		this.simulationAnimation = simulationAnimation;
+	}
 
 	public void clear() {
 		resetTrace = true;
@@ -57,6 +64,7 @@ public class TraceProperties {
 		public void itemStateChanged(ItemEvent event){
 			TraceProperties.this.showTrace = 
 					(event.getStateChange() == ItemEvent.SELECTED);
+			simulationAnimation.repaint();
 		}
 	}
 


### PR DESCRIPTION
- All panels are repainted if a setting is changed even if the simulation is stopped.
- Allow rotation of 3D views with the mouse even when animation is stopped (This applies to Particle3DPanel and EnergyDensity3DGLPanel)
