### PR TITLE
Choose coordinate for display in ElectricFieldPanel

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -13,9 +13,9 @@ import org.openpixi.pixi.physics.particles.IParticle;
 import org.openpixi.pixi.ui.SimulationAnimation;
 import org.openpixi.pixi.ui.panel.properties.BooleanArrayProperties;
 import org.openpixi.pixi.ui.panel.properties.ColorProperties;
-import org.openpixi.pixi.ui.panel.properties.ComboBoxProperties;
 import org.openpixi.pixi.ui.panel.properties.GaugeProperties;
 import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
+import org.openpixi.pixi.ui.panel.properties.StringProperties;
 
 /**
  * This panel shows the one-dimensional electric field along the x-direction.
@@ -28,7 +28,7 @@ public class ElectricFieldPanel extends AnimationPanel {
 	ScaleProperties scaleProperties;
 	GaugeProperties gaugeProperties;
 	public BooleanArrayProperties showFieldProperties;
-	public ComboBoxProperties surfaceProperties;
+	public StringProperties showCoordinateProperties;
 
 	public final int INDEX_E = 0;
 	public final int INDEX_U = 1;
@@ -68,14 +68,15 @@ public class ElectricFieldPanel extends AnimationPanel {
 		gaugeProperties = new GaugeProperties(simulationAnimation);
 		showFieldProperties = new BooleanArrayProperties(simulationAnimation, fieldLabel, fieldInit);
 
-		// Construct array:
-		int boxsize = simulationAnimation.getSimulation().grid.getNumCells(1);
-		ArrayList<String> entries = new ArrayList<String>();
-		entries.add("All");
-		for (int i = 0; i < boxsize; i++) {
-			entries.add("" + i);
+		// Construct default string:
+		// x is the coordinate displayed as x-asis.
+		// i is the loop coordinate
+		String coordinates = "x, i, ";
+		for(int w = 2; w < simulationAnimation.getSimulation().getNumberOfDimensions(); w++) {
+			coordinates += simulationAnimation.getSimulation().grid.getNumCells(w)/2 + ", ";
 		}
-		surfaceProperties = new ComboBoxProperties(simulationAnimation, "Which line", entries.toArray(new String[0]), 0);
+		coordinates = coordinates.substring(0, coordinates.length() - 2);
+		showCoordinateProperties = new StringProperties(simulationAnimation, "Show coordinate", coordinates);
 	}
 
 	/** Display the particles */
@@ -160,35 +161,49 @@ public class ElectricFieldPanel extends AnimationPanel {
 		int directionIndex = colorProperties.getDirectionIndex();
 
 		int[] pos = new int[s.getNumberOfDimensions()];
-		for(int w = 2; w < s.getNumberOfDimensions(); w++) {
+		for(int w = 0; w < s.getNumberOfDimensions(); w++) {
 			pos[w] = s.grid.getNumCells(w)/2;
 		}
 
 		graph.setColor(fieldColors[type]);
 
 		int kmin = 0;
-		int kmax = 0;
-		if (surfaceProperties.getIndex() == 0) {
-			// Show all surfaces
+		int kmax = 1;
+		int abscissaIndex = 0; // x-axis by default
+		int loopIndex = -1; // No loop index set
+		String[] indices = showCoordinateProperties.getValue().split(",");
+		int imax = Math.min(indices.length, s.getNumberOfDimensions());
+		for (int i = 0; i < imax; i++) {
+			if (indices[i].trim().equals("x")) {
+				abscissaIndex = i;
+			} else if (indices[i].trim().equals("i")) {
+				loopIndex = i;
+			} else {
+				try{
+					pos[i] = Integer.parseInt(indices[i].trim());
+				} catch (NumberFormatException e) {
+					// No error message - use default instead.
+				}
+			}
+		}
+		if (loopIndex != -1) {
+			// Show all lines
 			kmin = 0;
-			kmax = s.grid.getNumCells(1);
-		} else {
-			// Show only selected surface.
-			// Index differs by one:
-			kmin = surfaceProperties.getIndex() - 1;
-			kmax = kmin + 1;
+			kmax = s.grid.getNumCells(loopIndex);
 		}
 		for(int k = kmin; k < kmax; k++)
 		{
 			int newPosition = 0;
 			int newValue = 0;
-			for(int i = 0; i < s.grid.getNumCells(0); i++)
+			for(int i = 0; i < s.grid.getNumCells(abscissaIndex); i++)
 			{
 
 				int oldPosition = newPosition;
 				int oldValue = newValue;
-				pos[0] = i;
-				pos[1] = k;
+				pos[abscissaIndex] = i;
+				if (loopIndex != -1) {
+					pos[loopIndex] = k;
+				}
 
 				// Electric fields are placed at the lattice points.
 				newPosition = (int) (s.grid.getLatticeSpacing() * (i) * sx);
@@ -230,7 +245,7 @@ public class ElectricFieldPanel extends AnimationPanel {
 		addLabel(box, "Electric field panel");
 		showFieldProperties.addComponents(box);
 		colorProperties.addComponents(box);
-		surfaceProperties.addComponents(box);
+		showCoordinateProperties.addComponents(box);
 		scaleProperties.addComponents(box);
 		gaugeProperties.addComponents(box);
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -3,15 +3,17 @@ package org.openpixi.pixi.ui.panel;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.util.ArrayList;
+
 import javax.swing.Box;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.gauge.CoulombGauge;
-import org.openpixi.pixi.physics.gauge.RandomGauge;
 import org.openpixi.pixi.physics.grid.Grid;
 import org.openpixi.pixi.physics.particles.IParticle;
 import org.openpixi.pixi.ui.SimulationAnimation;
 import org.openpixi.pixi.ui.panel.properties.BooleanArrayProperties;
 import org.openpixi.pixi.ui.panel.properties.ColorProperties;
+import org.openpixi.pixi.ui.panel.properties.ComboBoxProperties;
 import org.openpixi.pixi.ui.panel.properties.GaugeProperties;
 import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
 
@@ -26,6 +28,7 @@ public class ElectricFieldPanel extends AnimationPanel {
 	ScaleProperties scaleProperties;
 	GaugeProperties gaugeProperties;
 	public BooleanArrayProperties showFieldProperties;
+	public ComboBoxProperties surfaceProperties;
 
 	public final int INDEX_E = 0;
 	public final int INDEX_U = 1;
@@ -64,6 +67,15 @@ public class ElectricFieldPanel extends AnimationPanel {
 		scaleProperties = new ScaleProperties(simulationAnimation);
 		gaugeProperties = new GaugeProperties(simulationAnimation);
 		showFieldProperties = new BooleanArrayProperties(simulationAnimation, fieldLabel, fieldInit);
+
+		// Construct array:
+		int boxsize = simulationAnimation.getSimulation().grid.getNumCells(1);
+		ArrayList<String> entries = new ArrayList<String>();
+		entries.add("All");
+		for (int i = 0; i < boxsize; i++) {
+			entries.add("" + i);
+		}
+		surfaceProperties = new ComboBoxProperties(simulationAnimation, "Which line", entries.toArray(new String[0]), 0);
 	}
 
 	/** Display the particles */
@@ -154,7 +166,19 @@ public class ElectricFieldPanel extends AnimationPanel {
 
 		graph.setColor(fieldColors[type]);
 
-		for(int k = 0; k < s.grid.getNumCells(1); k++)
+		int kmin = 0;
+		int kmax = 0;
+		if (surfaceProperties.getIndex() == 0) {
+			// Show all surfaces
+			kmin = 0;
+			kmax = s.grid.getNumCells(1);
+		} else {
+			// Show only selected surface.
+			// Index differs by one:
+			kmin = surfaceProperties.getIndex() - 1;
+			kmax = kmin + 1;
+		}
+		for(int k = kmin; k < kmax; k++)
 		{
 			int newPosition = 0;
 			int newValue = 0;
@@ -206,6 +230,7 @@ public class ElectricFieldPanel extends AnimationPanel {
 		addLabel(box, "Electric field panel");
 		showFieldProperties.addComponents(box);
 		colorProperties.addComponents(box);
+		surfaceProperties.addComponents(box);
 		scaleProperties.addComponents(box);
 		gaugeProperties.addComponents(box);
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ComboBoxProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ComboBoxProperties.java
@@ -1,0 +1,96 @@
+package org.openpixi.pixi.ui.panel.properties;
+
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.swing.Box;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+
+import org.openpixi.pixi.ui.SimulationAnimation;
+
+/**
+ * A generic class for setting ComboBox properties.
+ *
+ */
+public class ComboBoxProperties {
+
+	private SimulationAnimation simulationAnimation;
+	private JComboBox myComboBox;
+	private int index = 0;
+	private String label;
+	private String[] entries = {};
+
+	public ComboBoxProperties(SimulationAnimation simulationAnimation, String label, String[] entries, int index) {
+		this.simulationAnimation = simulationAnimation;
+		this.label = label;
+		this.entries = entries;
+		this.index = index;
+	}
+
+	public int getIndex() {
+		return index;
+	}
+
+	public void setIndex(int id)
+	{
+		index = id;
+		if (myComboBox != null) {
+			myComboBox.setSelectedIndex(index);
+		}
+	}
+
+	public void addComponents(Box box) {
+
+		Box settingControls = Box.createVerticalBox();
+
+		myComboBox = new JComboBox(entries);
+		myComboBox.addActionListener(new MyListener());
+		myComboBox.setSelectedIndex(index);
+		myComboBox.setPreferredSize(new Dimension(myComboBox.getPreferredSize().width, 5));
+		JLabel colorLabel = new JLabel(label);
+		Box colorBox = Box.createVerticalBox();
+		colorBox.add(colorLabel);
+		colorBox.add(myComboBox);
+
+		settingControls.add(colorBox);
+		settingControls.add(Box.createVerticalGlue());
+
+		box.add(settingControls);
+	}
+
+	/**
+	 * Return string from currently selected entry.
+	 * @return
+	 */
+	public String getStringFromEntry() {
+		return entries[index];
+	}
+
+	/**
+	 * Set values according to string array provided.
+	 * @param names
+	 */
+	public void setEntryFromString(String entry) {
+		for (int i = 0; i < entries.length; i++) {
+			if (entries[i].equals(entry)) {
+				setIndex(i);
+				break;
+			}
+		}
+	}
+
+	class MyListener implements ActionListener {
+		public void actionPerformed(ActionEvent eve) {
+			JComboBox cbox = (JComboBox) eve.getSource();
+			int id = cbox.getSelectedIndex();
+			index = id;
+			simulationAnimation.repaint();
+		}
+	}
+
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/StringProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/StringProperties.java
@@ -56,6 +56,7 @@ public class StringProperties {
 	{
 		this.value = value;
 		textField.setText(value);
+		simulationAnimation.repaint();
 	}
 
 	class TextFieldListener implements ActionListener {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/StringProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/StringProperties.java
@@ -1,0 +1,67 @@
+package org.openpixi.pixi.ui.panel.properties;
+
+import javax.swing.*;
+
+import org.openpixi.pixi.ui.SimulationAnimation;
+
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/**
+ * A generic text field for setting integer values.
+ */
+public class StringProperties {
+
+	private SimulationAnimation simulationAnimation;
+	private String name;
+	private String value;
+
+	private JLabel label;
+	private JTextField textField;
+
+	public StringProperties(SimulationAnimation simulationAnimation, String name, String initialValue)
+	{
+		this.simulationAnimation = simulationAnimation;
+		this.name = name;
+		textField = new JTextField();
+		this.setValue(initialValue);
+	}
+
+	public void addComponents(Box box)
+	{
+		Box settingControls = Box.createVerticalBox();
+
+		label = new JLabel(name, SwingConstants.CENTER);
+
+		textField.setText(value);
+		textField.addActionListener(new TextFieldListener());
+		textField.setMaximumSize(
+				new Dimension(400/*Integer.MAX_VALUE*/, textField.getPreferredSize().height));
+
+
+		settingControls.add(label);
+		settingControls.add(textField);
+		settingControls.add(Box.createVerticalGlue());
+
+		box.add(settingControls);
+	}
+
+	public String getValue()
+	{
+		return value;
+	}
+
+	public void setValue(String value)
+	{
+		this.value = value;
+		textField.setText(value);
+	}
+
+	class TextFieldListener implements ActionListener {
+		public void actionPerformed(ActionEvent event) {
+			value = textField.getText();
+			simulationAnimation.repaint();
+		}
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlElectricFieldPanel.java
@@ -18,6 +18,9 @@ public class YamlElectricFieldPanel {
 	public Double scaleFactor;
 	public Boolean automaticScaling;
 
+	// Coordinate properties
+	public String showCoordinates;
+
 	/** Empty constructor called by SnakeYaml */
 	public YamlElectricFieldPanel() {
 	}
@@ -30,6 +33,7 @@ public class YamlElectricFieldPanel {
 			directionIndex = panel.getColorProperties().getDirectionIndex();
 			scaleFactor = panel.getScaleProperties().getScaleFactor();
 			automaticScaling = panel.getScaleProperties().getAutomaticScaling();
+			showCoordinates = panel.showCoordinateProperties.getValue();
 		}
 	}
 
@@ -55,6 +59,10 @@ public class YamlElectricFieldPanel {
 
 		if (automaticScaling != null) {
 			panel.getScaleProperties().setAutomaticScaling(automaticScaling);
+		}
+
+		if (showCoordinates != null) {
+			panel.showCoordinateProperties.setValue(showCoordinates);
 		}
 		return panel;
 	}


### PR DESCRIPTION
Choose a particular coordinate for display in the ElectricFieldPanel.

Try the following values in the new field "show coordinate":
- "x, i, 0": show x-axis along the abscissa, loop through y, and show it for z = 0.
- "x, 63, 0": show x-axis along the abscissa, and show it for y = 63 and z = 0.
- "63, x, 0": show y-axis along the abscissa, and show it for x = 63 and z = 0.
- "i, 63, 0": show y-axis along the abscissa, loop through x, and show it for z = 0.
