### PR TITLE
Adjust color index selection to available number of colors.

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -96,6 +96,8 @@ public class ElectricFieldPanel extends AnimationPanel {
 
 		super.paintComponent(graph1);
 
+		colorProperties.checkConsistency();
+
 		Simulation s = getSimulationAnimation().getSimulation();
 		/** Scaling factor for the displayed panel in x-direction*/
 		double sx = getWidth() / s.getWidth();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -101,9 +101,8 @@ public class ElectricFieldPanel extends AnimationPanel {
 		Simulation s = getSimulationAnimation().getSimulation();
 		/** Scaling factor for the displayed panel in x-direction*/
 		double sx = getWidth() / s.getWidth();
-		/** Scaling factor for the displayed panel in y-direction*/
-		double sy = getHeight() / s.getHeight();
 
+		double panelWidth = getWidth();
 		double panelHeight = getHeight();
 
 		boolean useCoulombGauge = gaugeProperties.isCoulombGauge();
@@ -121,6 +120,8 @@ public class ElectricFieldPanel extends AnimationPanel {
 //			randomGauge.applyGaugeTransformation(gridCopy);
 //			drawGrid = gridCopy;
 		}
+
+		// TODO: display particles according to showCoordinateProperties (see below)
 
 		// Draw particles on a central line:
 		for (int i = 0; i < s.particles.size(); i++) {
@@ -144,7 +145,7 @@ public class ElectricFieldPanel extends AnimationPanel {
 
 		for (int i = 0; i < fieldLabel.length; i++) {
 			if (showFieldProperties.getValue(i)) {
-				drawGraph(graph, s, sx, panelHeight, drawGrid, scale, i);
+				drawGraph(graph, s, panelWidth, panelHeight, drawGrid, scale, i);
 			}
 		}
 
@@ -152,7 +153,7 @@ public class ElectricFieldPanel extends AnimationPanel {
 
 	}
 
-	private void drawGraph(Graphics2D graph, Simulation s, double sx,
+	private void drawGraph(Graphics2D graph, Simulation s, double panelWidth,
 			double panelHeight, Grid drawGrid, double scale, int type) {
 
 		// Lattice spacing and coupling constant
@@ -193,6 +194,7 @@ public class ElectricFieldPanel extends AnimationPanel {
 			kmin = 0;
 			kmax = s.grid.getNumCells(loopIndex);
 		}
+		double sx = panelWidth / s.getSimulationBoxSize(abscissaIndex);
 		for(int k = kmin; k < kmax; k++)
 		{
 			int newPosition = 0;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -227,9 +227,11 @@ public class ElectricFieldPanel extends AnimationPanel {
 					value = drawGrid.getUnext(s.grid.getCellIndex(pos), directionIndex).proj().get(colorIndex) / (as * g);
 					break;
 				case INDEX_J:
+					newPosition = (int) (s.grid.getLatticeSpacing() * (i + .5) * sx);
 					value = drawGrid.getJ(s.grid.getCellIndex(pos), directionIndex).get(colorIndex) / (as * g);
 					break;
 				case INDEX_RHO:
+					newPosition = (int) (s.grid.getLatticeSpacing() * (i + .5) * sx);
 					value = drawGrid.getRho(s.grid.getCellIndex(pos)).get(colorIndex) / (as * g);
 					break;
 				}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle2DPanel.java
@@ -67,6 +67,8 @@ public class Particle2DPanel extends AnimationPanel {
 		graph.scale(1, -1);
 		double scale = 10;
 
+		colorProperties.checkConsistency();
+
 		if (traceProperties.isCallSuper()) {
 			super.paintComponent(graph1);
 		}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/Particle3DPanel.java
@@ -91,6 +91,8 @@ public class Particle3DPanel extends AnimationPanel {
 
 		super.paintComponent(graph1);
 
+		colorProperties.checkConsistency();
+
 		Simulation s = getSimulationAnimation().getSimulation();
 
 		/** Scaling factor for the displayed panel in x-direction*/

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ColorProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ColorProperties.java
@@ -19,11 +19,9 @@ public class ColorProperties {
 	private SimulationAnimation simulationAnimation;
 	private int colorIndex = 0;
 	private int directionIndex = 1;
+	JComboBox colorIndexComboBox;
 
-	String[] colorString = {
-			"1",
-			"2",
-			"3"};
+	String[] colorString;
 
 	String[] directionString = {
 			"x",
@@ -32,6 +30,45 @@ public class ColorProperties {
 
 	public ColorProperties(SimulationAnimation simulationAnimation) {
 		this.simulationAnimation = simulationAnimation;
+		updateColorEntries();
+	}
+
+	/**
+	 * Updates the entries for the color selection.
+	 */
+	private void updateColorEntries() {
+		int colors = simulationAnimation.getSimulation().getNumberOfColors();
+		int generators = colors * colors - 1; // Number of SU(N) generators
+		colorString = new String[generators];
+		for (int i = 0; i < generators; i++) {
+			colorString[i] = "" + (i+1);
+		}
+
+		if (colorIndexComboBox == null) {
+			colorIndexComboBox = new JComboBox(colorString);
+		} else {
+			colorIndexComboBox.removeAllItems();
+			for (int i = 0; i < generators; i++) {
+				colorIndexComboBox.addItem(colorString[i]);
+			}
+		}
+
+		if (colorIndex > generators) {
+			colorIndex = generators - 1;
+		}
+		colorIndexComboBox.setSelectedIndex(colorIndex);
+	}
+
+	/**
+	 * Checks whether the selectable number of colors coincides with the number of colors
+	 * of the simulation. If not, update the number of selectable colors.
+	 */
+	public void checkConsistency() {
+		int colors = simulationAnimation.getSimulation().getNumberOfColors();
+		int generators = colors * colors - 1; // Number of SU(N) generators
+		if (generators != colorString.length) {
+			updateColorEntries();
+		}
 	}
 
 	public int getColorIndex() {
@@ -56,8 +93,6 @@ public class ColorProperties {
 
 		Box settingControls = Box.createVerticalBox();
 
-		JComboBox colorIndexComboBox;
-		colorIndexComboBox = new JComboBox(colorString);
 		colorIndexComboBox.addActionListener(new ColorListener());
 		colorIndexComboBox.setSelectedIndex(colorIndex);
 		colorIndexComboBox.setPreferredSize(new Dimension(colorIndexComboBox.getPreferredSize().width, 5));


### PR DESCRIPTION
The color property applies to ElectricFieldPanel, Particle2DPanel and Particle3DPanel.
It now shows 8 different selectable entries if numberOfColors = 3 in the YAML file (instead of 3 entries for SU(2)).

It is testable with the following YAML file:
Dual_Focused_Gaussian_Pulse_with_EnergyDensity_OpenGL_SU3.yaml
