### PR TITLE
Adjoint action for SU(2) and SU(3)

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/math/AlgebraElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/AlgebraElement.java
@@ -87,5 +87,27 @@ public interface AlgebraElement {
 	 */
 	double proj(int c);
 
+	/**
+	 * Returns the adjoint action of a group element on an algebra element (which is again an algbra element).
+	 * Let X be an algebra element and g an element of the group then we define
+	 *
+	 * 		ad_g(X) = g X g^(-1).
+	 *
+	 * This method does not change the original AlgebraElement instance.
+	 *
+	 * @param g	Group element to act on algebra element
+	 * @return  AlgebraElement instance of the adjoint action
+	 */
+	AlgebraElement act(GroupElement g);
+
+	/**
+	 * Returns the adjoint action of a group element on an algebra element (which is again an algbra element).
+	 * Same as AlgebraElement.act() but changes the original AlgebraElement instance.
+	 *
+	 * @param g Group element to act on algebra element
+	 * @return  AlgebraElement instance of the adjoint action
+	 */
+	void actAssign(GroupElement g);
+
 	AlgebraElement copy();
 }

--- a/pixi/src/main/java/org/openpixi/pixi/math/GroupElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/GroupElement.java
@@ -36,7 +36,7 @@ public interface GroupElement {
 	 *
 	 * @return  Hermitian conjugate of the current instance.
 	 */
-	void selfadj();
+	void adjAssign();
 
 	/**
 	 * Computes the scalar product of the GroupElement instance with a real number and returns a copy.

--- a/pixi/src/main/java/org/openpixi/pixi/math/SU2AlgebraElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/SU2AlgebraElement.java
@@ -139,6 +139,26 @@ public class SU2AlgebraElement implements AlgebraElement {
 		return 0.5 * v[c];
 	}
 
+	public AlgebraElement act(GroupElement g) {
+		SU2GroupElement u = (SU2GroupElement) g;
+		SU2AlgebraElement X = new SU2AlgebraElement();
+
+		double factor1 = 2.0 * u.get(0) * u.get(0) - 1.0;
+		double factor2 = 0.0;
+		for(int i = 0; i < 3; i++) {
+			factor2 += 2.0 * v[i] * u.get(i+1);
+		}
+
+		for(int i = 0; i < 3; i++) {
+			X.v[i] = factor1 * v[i] + factor2 * u.get(i+1);
+		}
+		return X;
+	}
+
+	public void actAssign(GroupElement g) {
+		this.set(this.act(g));
+	}
+
 	public AlgebraElement copy() {
 		return new SU2AlgebraElement(v[0], v[1], v[2]);
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/math/SU2AlgebraElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/SU2AlgebraElement.java
@@ -116,7 +116,7 @@ public class SU2AlgebraElement implements AlgebraElement {
 	public GroupElement getLinearizedLink() {
 		
 		double sum = (v[0]*v[0]+v[1]*v[1]+v[2]*v[2])/4;
-		SU2GroupElement b = new SU2GroupElement(Math.sqrt(1.0-sum), v[0]/2, v[1]/2, v[2]/2);
+		SU2GroupElement b = new SU2GroupElement(Math.sqrt(1.0 - sum), v[0]/2, v[1]/2, v[2]/2);
 		return b;
 	}
 	
@@ -140,19 +140,18 @@ public class SU2AlgebraElement implements AlgebraElement {
 	}
 
 	public AlgebraElement act(GroupElement g) {
+
 		SU2GroupElement u = (SU2GroupElement) g;
-		SU2AlgebraElement X = new SU2AlgebraElement();
+		SU2GroupElement Xm = new SU2GroupElement();
 
-		double factor1 = 2.0 * u.get(0) * u.get(0) - 1.0;
-		double factor2 = 0.0;
-		for(int i = 0; i < 3; i++) {
-			factor2 += 2.0 * v[i] * u.get(i+1);
-		}
+		Xm.set(0, 0.0);
+		Xm.set(1, v[0] / 2);
+		Xm.set(2, v[1] / 2);
+		Xm.set(3, v[2] / 2);
 
-		for(int i = 0; i < 3; i++) {
-			X.v[i] = factor1 * v[i] + factor2 * u.get(i+1);
-		}
-		return X;
+		Xm = (SU2GroupElement) u.mult(Xm.mult(u.adj()));
+		return Xm.proj();
+
 	}
 
 	public void actAssign(GroupElement g) {

--- a/pixi/src/main/java/org/openpixi/pixi/math/SU2GroupElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/SU2GroupElement.java
@@ -131,7 +131,7 @@ public class SU2GroupElement implements GroupElement {
 		return b;
 	}
 
-	public void selfadj() {
+	public void adjAssign() {
 		for (int i = 1; i < 4; i++)
 		{
 			this.set(i, -this.get(i));

--- a/pixi/src/main/java/org/openpixi/pixi/math/SU2GroupElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/SU2GroupElement.java
@@ -200,7 +200,8 @@ public class SU2GroupElement implements GroupElement {
 		SU2AlgebraElement field = new SU2AlgebraElement();
 		
 		if(norm < 1.E-15) {
-			field = new SU2AlgebraElement(0,0,0);
+			//return new SU2AlgebraElement();
+			return this.proj();
 		} else {
 			for(int i = 0; i < 3; i++)
 			{

--- a/pixi/src/main/java/org/openpixi/pixi/math/SU3AlgebraElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/SU3AlgebraElement.java
@@ -132,6 +132,36 @@ public class SU3AlgebraElement implements AlgebraElement {
 
 	}
 
+	public AlgebraElement act(GroupElement arg) {
+
+		SU3GroupElement a = (SU3GroupElement) arg;
+
+		// temporarily store algebra element as group element so we can use the multiplication method
+		SU3GroupElement temp = new SU3GroupElement(new double[]{v[0],v[1],v[2],v[1],v[4],v[5],v[2],v[5],v[8],0,v[3],v[6],-v[3],0,v[7],-v[6],-v[7],0});
+
+		double[] values = ((SU3GroupElement) a.mult(temp.mult(a.adj()))).get();
+
+		double[] fieldValues = new double[9];
+
+		fieldValues[0] = values[0];
+		fieldValues[4] = values[4];
+		fieldValues[8] = values[8];
+		// off-diagonal real values are symmetric averages of pairs
+		fieldValues[1] = (values[1] + values[3])/2;
+		fieldValues[2] = (values[2] + values[6])/2;
+		fieldValues[5] = (values[5] + values[7])/2;
+		// off-diagonal imag. values are asymmetric averages of pairs
+		fieldValues[3] = (values[10] - values[12])/2;
+		fieldValues[6] = (values[11] - values[15])/2;
+		fieldValues[7] = (values[14] - values[16])/2;
+
+		return new SU3AlgebraElement(fieldValues);
+	}
+
+	public void actAssign(GroupElement arg) {
+		v = ((SU3AlgebraElement) act(arg)).get();
+	}
+
 	public double square () {
 		return 2*(v[0]*v[0]+v[4]*v[4]+v[8]*v[8]+2*(v[1]*v[1]+v[2]*v[2]+v[3]*v[3]+v[5]*v[5]+v[6]*v[6]+v[7]*v[7]));
 		

--- a/pixi/src/main/java/org/openpixi/pixi/math/SU3GroupElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/SU3GroupElement.java
@@ -119,7 +119,7 @@ public class SU3GroupElement implements GroupElement {
 		return b;
 	}
 
-	public void selfadj() {
+	public void adjAssign() {
 		double temp;
 		// real diag is good
 

--- a/pixi/src/test/java/org/openpixi/pixi/math/SU2FieldTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/math/SU2FieldTest.java
@@ -9,7 +9,7 @@ import org.openpixi.pixi.math.SU2GroupElement;
 public class SU2FieldTest {
 
 
-	private final double accuracy = 1.E-13;
+	private final double accuracy = 1.E-14;
 
 	@Test
 	public void testGetterAndSetter() {
@@ -95,34 +95,39 @@ public class SU2FieldTest {
 	@Test
 	public void testConversionToMatrixAndBack() {
 
+		for(int t = 0; t < 10; t++) {
 		/*
-		Create random SU2 field.
-	 */
-		double[] vec = new double[3];
-		double scaling = 1.0;
-		for (int i = 0; i < 3; i++) {
-			vec[i] = (Math.random() - 0.5)*scaling;
-		}
-		SU2AlgebraElement firstField = new SU2AlgebraElement(vec[0], vec[1], vec[2]);
+			Create random SU2 field.
+	 	*/
+			double[] vec = new double[3];
+			double scaling = 1.0;
+			for (int i = 0; i < 3; i++) {
+				vec[i] = (Math.random() - 0.5) * scaling;
+			}
+			SU2AlgebraElement firstField = new SU2AlgebraElement(vec[0], vec[1], vec[2]);
 		
 		/*
-		Transform to a SU2 matrix exactly and in linear approximation.
-	 */
-		SU2GroupElement matSimple = (SU2GroupElement) firstField.getLinearizedLink();
-		SU2GroupElement matExact = (SU2GroupElement) firstField.getLink();
+			Transform to a SU2 matrix exactly and in linear approximation.
+		 */
+			SU2GroupElement matSimple = (SU2GroupElement) firstField.getLinearizedLink();
+			SU2GroupElement matExact = (SU2GroupElement) firstField.getLink();
 
 		/*
-		Transform back to a SU2 field exactly and in linear approximation (proj).
-	 */
-		SU2AlgebraElement fieldSimple = (SU2AlgebraElement) matSimple.proj();
-		SU2AlgebraElement fieldExact = (SU2AlgebraElement) matExact.getAlgebraElement();
+			Transform back to a SU2 field exactly and in linear approximation (proj).
+	 	*/
+			SU2AlgebraElement fieldSimple = (SU2AlgebraElement) matSimple.proj();
+			SU2AlgebraElement fieldExact = (SU2AlgebraElement) matExact.getAlgebraElement();
 		
 		/*
-		Compare results.
-	 */
-		for (int i = 0; i < 3; i++) {
-			Assert.assertEquals(fieldSimple.get(i), firstField.get(i), accuracy);
-			Assert.assertEquals(fieldExact.get(i), firstField.get(i), accuracy);
+			Compare results.
+	 	*/
+			for (int i = 0; i < 3; i++) {
+				double simpleRelDifference = Math.abs((fieldSimple.get(i) - firstField.get(i)) / firstField.get(i));
+				double exactRelDifference = Math.abs((fieldExact.get(i) - firstField.get(i)) / firstField.get(i));
+				//System.out.println(simpleRelDifference + ", " + exactRelDifference);
+				Assert.assertEquals(0.0, simpleRelDifference, accuracy);
+				Assert.assertEquals(0.0, exactRelDifference, accuracy);
+			}
 		}
 		
 	}

--- a/pixi/src/test/java/org/openpixi/pixi/math/SU2FieldTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/math/SU2FieldTest.java
@@ -13,9 +13,7 @@ public class SU2FieldTest {
 
 	@Test
 	public void testGetterAndSetter() {
-				/*
-			Create random SU2 field.
-		 */
+		// Create random SU2 field.
 		double[] vec = new double[3];
 		double square = 0.0;
 		for (int i = 0; i < 3; i++) {
@@ -23,35 +21,29 @@ public class SU2FieldTest {
 			square += vec[i] * vec[i];
 		}
 
-		/*
-			We construct two fields. One from the constructor and another using setter methods.
-		 */
 
+		// We construct two fields. One from the constructor and another using setter methods.
 		SU2AlgebraElement firstField = new SU2AlgebraElement(vec[0], vec[1], vec[2]);
 		SU2AlgebraElement secondField = new SU2AlgebraElement();
 		for (int i = 0; i < 3; i++) {
 			secondField.set(i, vec[i]);
 		}
 
-		/*
-			Now we test if the values have been set correctly.
-		 */
+		// Now we test if the values have been set correctly.
 		for (int i = 0; i < 3; i++) {
 			Assert.assertEquals(firstField.get(i), vec[i], accuracy);
 			Assert.assertEquals(secondField.get(i), vec[i], accuracy);
 		}
-		/*
-		Here the square method is tested.
-	 */
+
+		// Here the square method is tested.
 		Assert.assertEquals(firstField.square(), square, accuracy);
 		Assert.assertEquals(secondField.square(), square, accuracy);
 	}
 
 	@Test
 	public void testAdditionAndSubtraction() {
-		/*
-			Prepare some variables.
-		 */
+
+		// Prepare some variables.
 		double[] aVec = new double[3];
 		double[] bVec = new double[3];
 		double[] rVec1 = new double[3];
@@ -67,9 +59,7 @@ public class SU2FieldTest {
 			rVec2[i] = aVec[i] - bVec[i];
 		}
 
-		/*
-			Create two fields.
-		 */
+		// Create two fields.
 		SU2AlgebraElement a = new SU2AlgebraElement();
 		SU2AlgebraElement b = new SU2AlgebraElement();
 		for (int i = 0; i < 3; i++) {
@@ -77,15 +67,13 @@ public class SU2FieldTest {
 			b.set(i, bVec[i]);
 		}
 
-		/*
-			Use add and sub methods.
-		 */
+
+		// Use add and sub methods.
 		SU2AlgebraElement r1 = (SU2AlgebraElement) a.add(b);
 		SU2AlgebraElement r2 = (SU2AlgebraElement) a.sub(b);
 
-		/*
-			Compare results.
-		 */
+
+		// Compare results.
 		for (int i = 0; i < 3; i++) {
 			Assert.assertEquals(r1.get(i), rVec1[i], accuracy);
 			Assert.assertEquals(r2.get(i), rVec2[i], accuracy);
@@ -96,9 +84,7 @@ public class SU2FieldTest {
 	public void testConversionToMatrixAndBack() {
 
 		for(int t = 0; t < 10; t++) {
-		/*
-			Create random SU2 field.
-	 	*/
+			// Create random SU2 field.
 			double[] vec = new double[3];
 			double scaling = 1.0;
 			for (int i = 0; i < 3; i++) {
@@ -106,21 +92,18 @@ public class SU2FieldTest {
 			}
 			SU2AlgebraElement firstField = new SU2AlgebraElement(vec[0], vec[1], vec[2]);
 		
-		/*
-			Transform to a SU2 matrix exactly and in linear approximation.
-		 */
+
+			// Transform to a SU2 matrix exactly and in linear approximation.
 			SU2GroupElement matSimple = (SU2GroupElement) firstField.getLinearizedLink();
 			SU2GroupElement matExact = (SU2GroupElement) firstField.getLink();
 
-		/*
-			Transform back to a SU2 field exactly and in linear approximation (proj).
-	 	*/
+
+			// Transform back to a SU2 field exactly and in linear approximation (proj).
 			SU2AlgebraElement fieldSimple = (SU2AlgebraElement) matSimple.proj();
 			SU2AlgebraElement fieldExact = (SU2AlgebraElement) matExact.getAlgebraElement();
 		
-		/*
-			Compare results.
-	 	*/
+
+			// Compare results.
 			for (int i = 0; i < 3; i++) {
 				double simpleRelDifference = Math.abs((fieldSimple.get(i) - firstField.get(i)) / firstField.get(i));
 				double exactRelDifference = Math.abs((fieldExact.get(i) - firstField.get(i)) / firstField.get(i));
@@ -136,9 +119,8 @@ public class SU2FieldTest {
 	public void testScalarMultiplication() {
 		int numberOfTests = 10;
 		for (int t = 0; t < numberOfTests; t++) {
-			/*
-				Create a random field.
-			 */
+
+			// Create a random field.
 			double[] vec1 = new double[3];
 			double[] vec2 = new double[3];
 			double value = Math.random() - 0.5;
@@ -147,13 +129,11 @@ public class SU2FieldTest {
 				vec2[i] = value*vec1[i];
 			}
 			SU2AlgebraElement firstField = new SU2AlgebraElement(vec1[0], vec1[1], vec1[2]);
-			/*
-			Multiply with a scalar.
-		 */
+
+			// Multiply with a scalar.
 			SU2AlgebraElement secondField = (SU2AlgebraElement) firstField.mult(value);
-			/*
-				Compare results.
-			 */
+
+			// Compare results.
 			for (int i = 0; i < 3; i++) {
 				Assert.assertEquals(secondField.get(i), vec2[i], accuracy);
 			}

--- a/pixi/src/test/java/org/openpixi/pixi/math/SU3EverythingTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/math/SU3EverythingTest.java
@@ -337,7 +337,7 @@ public class SU3EverythingTest {
 			/*
 				Test Hermiticity
 			 */
-			compareMatrices(ff1,ff2);
+			compareMatrices(ff1, ff2);
 
 			/*
 				Test if traceless
@@ -346,6 +346,51 @@ public class SU3EverythingTest {
 			double trImag = ff1.getEntry(0,0).getImaginary() + ff1.getEntry(1,1).getImaginary() + ff1.getEntry(2,2).getImaginary();
 			Assert.assertEquals(0, trReal, accuracy);
 			Assert.assertEquals(0, trImag, accuracy);
+		}
+	}
+
+	@Test
+	public void testAct() {
+		int numberOfTests = 10;
+		for (int t = 0; t < numberOfTests; t++) {
+			/*
+				Create a random algebra element
+			 */
+			SU3GroupElement m1 = createRandomSU3Matrix();
+			SU3AlgebraElement f1 = (SU3AlgebraElement) m1.getAlgebraElement();
+			Array2DRowFieldMatrix<Complex> ff1 = convertToMatrix(f1);
+
+			/*
+				Create a random matrix.
+			 */
+			m1 = createRandomSU3Matrix();
+			Array2DRowFieldMatrix<Complex> mm1 = convertToMatrix(m1);
+
+
+			/*
+				Get adjoint of mm1
+			 */
+			Array2DRowFieldMatrix<Complex> mm2 = (Array2DRowFieldMatrix<Complex>) mm1.transpose();
+			for (int i = 0; i < 3; i++) {
+				for (int j = 0; j < 3; j++) {
+					Complex v = mm2.getEntry(i, j).conjugate();
+					mm2.setEntry(i, j, v);
+				}
+			}
+
+			/*
+				Do act method
+			 */
+			SU3AlgebraElement f2 = (SU3AlgebraElement) f1.act(m1);
+			f1.actAssign(m1);
+
+			Array2DRowFieldMatrix<Complex> ff2 = convertToMatrix(f2);
+			Array2DRowFieldMatrix<Complex> ff3 = convertToMatrix(f1);
+
+			Array2DRowFieldMatrix<Complex> ff4 = mm1.multiply(ff1).multiply(mm2);
+
+			compareMatrices(ff4,ff3);
+			compareMatrices(ff4,ff2);
 		}
 	}
 

--- a/pixi/src/test/java/org/openpixi/pixi/physics/grid/GridTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/physics/grid/GridTest.java
@@ -41,7 +41,7 @@ public class GridTest {
 
 			GroupElement l1 = g.getLink(index, dir, 1, 0);
 			GroupElement l2 = g.getLink(shiftedIndex, dir, -1, 0);
-			l2.selfadj();
+			l2.adjAssign();
 
 			// This code is specific to SU2
 			for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
New methods act() and actAssign() for the AlgebraElement classes which implement the adjoint action of a group element on an algebra element. The adjoint action of a group element g acting on an algebra element X is defined by ![image](https://cloud.githubusercontent.com/assets/8561167/9504656/0edf9448-4c3e-11e5-9e3f-f6ec7db4debf.png). This can be used to parallel transport electric fields.
