### PR TITLE
Bug fixes for occupation numbers

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -469,7 +469,14 @@ public class OccupationNumbersInTime implements Diagnostics {
 
 				cells[newGridIndex] = grid.getCell(i).copy();
 				cells[mirroredIndex] = grid.getCell(i).copy();
+
+				// Switch gauge links in the mirrored direction.
+				cellPos[mirroredDirection]--;
+				int shiftedIndex = grid.getCellIndex(cellPos);
+				cells[mirroredIndex].setU(mirroredDirection, grid.getU(shiftedIndex, mirroredDirection).copy());
 			}
+
+
 
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -471,7 +471,10 @@ public class OccupationNumbersInTime implements Diagnostics {
 				cells[mirroredIndex] = grid.getCell(i).copy();
 
 				// Switch gauge links in the mirrored direction.
-				cellPos[mirroredDirection]--;
+				// TODO: This shift of the gauge links is a bit ambiguous. Not sure what would be the correct way to do it.
+				if(cellPos[mirroredDirection] > 0) {
+					cellPos[mirroredDirection]--;
+				}
 				int shiftedIndex = grid.getCellIndex(cellPos);
 				cells[mirroredIndex].setU(mirroredDirection, grid.getU(shiftedIndex, mirroredDirection).copy());
 			}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -135,7 +135,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 				grid = new Grid(grid_reference);	// Copy grid.
 			}
 			CoulombGauge coulombGauge = new CoulombGauge(grid);
-			//coulombGauge.applyGaugeTransformation(grid);
+			coulombGauge.applyGaugeTransformation(grid);
 
 
 			// Fill arrays for FFT.
@@ -157,7 +157,6 @@ public class OccupationNumbersInTime implements Diagnostics {
 						double gaugeFieldComponent0 = gaugeFieldAsAlgebraElement0.get(k) * gainv;
 						double gaugeFieldComponent1 = gaugeFieldAsAlgebraElement1.get(k) * gainv;
 						aFFTdata[j][k][fftIndex] = 0.5 * (gaugeFieldComponent0 + gaugeFieldComponent1);
-						//aFFTdata[j][k][fftIndex] = gaugeFieldComponent0;
 						aFFTdata[j][k][fftIndex + 1] = 0.0;
 					}
 				}
@@ -470,12 +469,6 @@ public class OccupationNumbersInTime implements Diagnostics {
 
 				cells[newGridIndex] = grid.getCell(i).copy();
 				cells[mirroredIndex] = grid.getCell(i).copy();
-				/*
-				for (int j = 0; j < grid.getNumberOfDimensions(); j++) {
-					AlgebraElement E = grid.getCell(i).getE(j).copy().mult(-1.0);
-					cells[mirroredIndex].setE(j, E);
-				}
-				*/
 			}
 
 		}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -135,7 +135,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 				grid = new Grid(grid_reference);	// Copy grid.
 			}
 			CoulombGauge coulombGauge = new CoulombGauge(grid);
-			coulombGauge.applyGaugeTransformation(grid);
+			//coulombGauge.applyGaugeTransformation(grid);
 
 
 			// Fill arrays for FFT.
@@ -157,6 +157,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 						double gaugeFieldComponent0 = gaugeFieldAsAlgebraElement0.get(k) * gainv;
 						double gaugeFieldComponent1 = gaugeFieldAsAlgebraElement1.get(k) * gainv;
 						aFFTdata[j][k][fftIndex] = 0.5 * (gaugeFieldComponent0 + gaugeFieldComponent1);
+						//aFFTdata[j][k][fftIndex] = gaugeFieldComponent0;
 						aFFTdata[j][k][fftIndex + 1] = 0.0;
 					}
 				}
@@ -464,11 +465,17 @@ public class OccupationNumbersInTime implements Diagnostics {
 				int newGridIndex = this.getCellIndex(cellPos);
 
 				int[] newMirroredGridPos = cellPos.clone();
-				newMirroredGridPos[mirroredDirection] = 2 * grid.getNumCells(mirroredDirection) - cellPos[mirroredDirection];
+				newMirroredGridPos[mirroredDirection] = 2 * grid.getNumCells(mirroredDirection) - cellPos[mirroredDirection] - 1;
 				int mirroredIndex = this.getCellIndex(newMirroredGridPos);
 
 				cells[newGridIndex] = grid.getCell(i).copy();
 				cells[mirroredIndex] = grid.getCell(i).copy();
+				/*
+				for (int j = 0; j < grid.getNumberOfDimensions(); j++) {
+					AlgebraElement E = grid.getCell(i).getE(j).copy().mult(-1.0);
+					cells[mirroredIndex].setE(j, E);
+				}
+				*/
 			}
 
 		}

--- a/pixi/src/main/java/org/openpixi/pixi/parallel/cellaccess/CellIterator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/parallel/cellaccess/CellIterator.java
@@ -28,4 +28,6 @@ public abstract class CellIterator {
 		dimensions = new IntBox(length, min, max);
 	}
 
+	public abstract CellIterator copy();
+
 }

--- a/pixi/src/main/java/org/openpixi/pixi/parallel/cellaccess/ParallelCellIterator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/parallel/cellaccess/ParallelCellIterator.java
@@ -20,6 +20,7 @@ public class ParallelCellIterator extends CellIterator {
 	private Grid grid;
 	private CellAction action;
 	int numOfCells;
+	int numOfThreads;
 
 	private List<Callable<Object>> tasks = new ArrayList<Callable<Object>>();
 	private ExecutorService threadExecutor;
@@ -27,6 +28,7 @@ public class ParallelCellIterator extends CellIterator {
 
 	public ParallelCellIterator(int numOfThreads, ExecutorService threadExecutor) {
 		this.threadExecutor = threadExecutor;
+		this.numOfThreads = numOfThreads;
 		for (int i = 0; i < numOfThreads; ++i) {
 			tasks.add(new Task(i, numOfThreads));
 		}
@@ -43,6 +45,11 @@ public class ParallelCellIterator extends CellIterator {
 		}
 	}
 
+	public CellIterator copy(){
+		ParallelCellIterator copy = new ParallelCellIterator(this.numOfThreads, this.threadExecutor);
+		copy.dimensions = dimensions.copy();
+		return copy;
+	}
 
 	@Override
 	public void setNormalMode(int[] numCells) {

--- a/pixi/src/main/java/org/openpixi/pixi/parallel/cellaccess/ParallelCellIterator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/parallel/cellaccess/ParallelCellIterator.java
@@ -48,6 +48,8 @@ public class ParallelCellIterator extends CellIterator {
 	public CellIterator copy(){
 		ParallelCellIterator copy = new ParallelCellIterator(this.numOfThreads, this.threadExecutor);
 		copy.dimensions = dimensions.copy();
+		copy.numOfCells = this.numOfCells;
+
 		return copy;
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/parallel/cellaccess/SequentialCellIterator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/parallel/cellaccess/SequentialCellIterator.java
@@ -15,4 +15,10 @@ public class SequentialCellIterator extends CellIterator {
 			action.execute(grid, cellIdx);
 		}
 	}
+
+	public CellIterator copy() {
+		SequentialCellIterator copy = new SequentialCellIterator();
+		copy.dimensions = dimensions.copy();
+		return copy;
+	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -438,9 +438,8 @@ public class Grid {
 
 		copyValuesFrom(grid);
 
-		// TODO: Share iterators is ok?
 		this.fsolver = grid.fsolver;
-		this.cellIterator = grid.cellIterator;
+		this.cellIterator = grid.cellIterator.copy();
 	}
 
 	/**

--- a/pixi/src/main/java/org/openpixi/pixi/physics/util/IntBox.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/util/IntBox.java
@@ -60,6 +60,11 @@ public class IntBox implements Serializable
         return this.contains(new int[] {x,y,z});
 	}
 
+	public IntBox copy(){
+		IntBox copy = new IntBox(this.dim, this.min.clone(), this.max.clone());
+		return copy;
+	}
+
 	@Override
 	public String toString()
     {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -103,13 +103,14 @@ public class ElectricFieldPanel extends AnimationPanel {
 
 		Simulation s = getSimulationAnimation().getSimulation();
 		/** Scaling factor for the displayed panel in x-direction*/
-		double sx = getWidth() / s.getWidth();
+		double sx = getWidth() / s.getWidth() / 2.0;
 
 		double panelWidth = getWidth();
 		double panelHeight = getHeight();
 
 		boolean useCoulombGauge = gaugeProperties.getValue();
-		Grid drawGrid = s.grid;
+		//Grid drawGrid = s.grid;
+		Grid drawGrid = new MirroredGrid(s.grid, 0);
 		if (useCoulombGauge) {
 			CoulombGauge coulombGauge = new CoulombGauge(s.grid);
 			Grid gridCopy = new Grid(s.grid);
@@ -178,14 +179,14 @@ public class ElectricFieldPanel extends AnimationPanel {
 		if (loopIndex != -1) {
 			// Show all lines
 			kmin = 0;
-			kmax = s.grid.getNumCells(loopIndex);
+			kmax = drawGrid.getNumCells(loopIndex);
 		}
-		double sx = panelWidth / s.getSimulationBoxSize(abscissaIndex);
+		double sx = panelWidth / s.getSimulationBoxSize(abscissaIndex) / 2;
 		for(int k = kmin; k < kmax; k++)
 		{
 			int newPosition = 0;
 			int newValue = 0;
-			for(int i = 0; i < s.grid.getNumCells(abscissaIndex); i++)
+			for(int i = 0; i < drawGrid.getNumCells(abscissaIndex); i++)
 			{
 
 				int oldPosition = newPosition;
@@ -250,5 +251,34 @@ public class ElectricFieldPanel extends AnimationPanel {
 		showCoordinateProperties.addComponents(box);
 		scaleProperties.addComponents(box);
 		gaugeProperties.addComponents(box);
+	}
+
+	private class MirroredGrid extends Grid {
+		public MirroredGrid(Grid grid, int mirroredDirection) {
+			super(grid);
+			this.numCells[mirroredDirection] *= 2;
+			this.cellIterator = null;
+			createGrid();
+
+			// Copy and mirror cells.
+			for (int i = 0; i < grid.getTotalNumberOfCells(); i++) {
+				int[] cellPos = grid.getCellPos(i);
+				int newGridIndex = this.getCellIndex(cellPos);
+
+				int[] newMirroredGridPos = cellPos.clone();
+				newMirroredGridPos[mirroredDirection] = numCells[mirroredDirection] - cellPos[mirroredDirection] - 1;
+				int mirroredIndex = this.getCellIndex(newMirroredGridPos);
+
+				cells[newGridIndex] = grid.getCell(i).copy();
+				cells[mirroredIndex] = grid.getCell(i).copy();
+				/*
+				for (int j = 0; j < grid.getNumberOfDimensions(); j++) {
+					AlgebraElement E = grid.getCell(i).getE(j).copy().mult(-1.0);
+					cells[mirroredIndex].setE(j, E);
+				}
+				*/
+			}
+
+		}
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -103,14 +103,14 @@ public class ElectricFieldPanel extends AnimationPanel {
 
 		Simulation s = getSimulationAnimation().getSimulation();
 		/** Scaling factor for the displayed panel in x-direction*/
-		double sx = getWidth() / s.getWidth() / 2.0;
+		double sx = getWidth() / s.getWidth();
 
 		double panelWidth = getWidth();
 		double panelHeight = getHeight();
 
 		boolean useCoulombGauge = gaugeProperties.getValue();
 		//Grid drawGrid = s.grid;
-		Grid drawGrid = new MirroredGrid(s.grid, 0);
+		Grid drawGrid = new Grid(s.grid);
 		if (useCoulombGauge) {
 			CoulombGauge coulombGauge = new CoulombGauge(s.grid);
 			Grid gridCopy = new Grid(s.grid);
@@ -181,7 +181,7 @@ public class ElectricFieldPanel extends AnimationPanel {
 			kmin = 0;
 			kmax = drawGrid.getNumCells(loopIndex);
 		}
-		double sx = panelWidth / s.getSimulationBoxSize(abscissaIndex) / 2;
+		double sx = panelWidth / s.getSimulationBoxSize(abscissaIndex);
 		for(int k = kmin; k < kmax; k++)
 		{
 			int newPosition = 0;
@@ -251,34 +251,5 @@ public class ElectricFieldPanel extends AnimationPanel {
 		showCoordinateProperties.addComponents(box);
 		scaleProperties.addComponents(box);
 		gaugeProperties.addComponents(box);
-	}
-
-	private class MirroredGrid extends Grid {
-		public MirroredGrid(Grid grid, int mirroredDirection) {
-			super(grid);
-			this.numCells[mirroredDirection] *= 2;
-			this.cellIterator = null;
-			createGrid();
-
-			// Copy and mirror cells.
-			for (int i = 0; i < grid.getTotalNumberOfCells(); i++) {
-				int[] cellPos = grid.getCellPos(i);
-				int newGridIndex = this.getCellIndex(cellPos);
-
-				int[] newMirroredGridPos = cellPos.clone();
-				newMirroredGridPos[mirroredDirection] = numCells[mirroredDirection] - cellPos[mirroredDirection] - 1;
-				int mirroredIndex = this.getCellIndex(newMirroredGridPos);
-
-				cells[newGridIndex] = grid.getCell(i).copy();
-				cells[mirroredIndex] = grid.getCell(i).copy();
-				/*
-				for (int j = 0; j < grid.getNumberOfDimensions(); j++) {
-					AlgebraElement E = grid.getCell(i).getE(j).copy().mult(-1.0);
-					cells[mirroredIndex].setE(j, E);
-				}
-				*/
-			}
-
-		}
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -109,11 +109,10 @@ public class ElectricFieldPanel extends AnimationPanel {
 		double panelHeight = getHeight();
 
 		boolean useCoulombGauge = gaugeProperties.getValue();
-		//Grid drawGrid = s.grid;
-		Grid drawGrid = new Grid(s.grid);
+		Grid drawGrid = s.grid;
 		if (useCoulombGauge) {
-			CoulombGauge coulombGauge = new CoulombGauge(s.grid);
 			Grid gridCopy = new Grid(s.grid);
+			CoulombGauge coulombGauge = new CoulombGauge(gridCopy);
 			coulombGauge.applyGaugeTransformation(gridCopy);
 			drawGrid = gridCopy;
 


### PR DESCRIPTION
- Fixed some issues with the mirrored grid in the OccupationNumbersInTime diagnostic.
- Added copy() methods to the cell iterators. 

The diagnostic is now able to correctly mirror the field configurations and compute the occupation numbers. 
