### PR TITLE
Normalization factor for the MV model

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
@@ -71,10 +71,11 @@ public class MVModel implements ICurrentGenerator {
 		// Initialize transversal charge density with random charges from a Gaussian distribution with zero mean and width \mu.
 		AlgebraElement[] transversalChargeDensity = new AlgebraElement[totalTransversalCells];
 		AlgebraElement totalCharge = s.grid.getElementFactory().algebraZero();
+		double gaussianWidth = mu * s.getCouplingConstant() / s.grid.getLatticeSpacing();
 		for (int i = 0; i < totalTransversalCells; i++) {
 			AlgebraElement charge = s.grid.getElementFactory().algebraZero();
 			for (int c = 0; c < numberOfComponents; c++) {
-				double value = rand.nextGaussian() * mu;
+				double value = rand.nextGaussian() * gaussianWidth;
 				charge.set(c, value);
 			}
 			totalCharge.addAssign(charge);


### PR DESCRIPTION
The MV model now uses the convention

![](https://latex.codecogs.com/gif.latex?%5Cleft%5Clangle%20%5Crho%5E%7Ba%7D%28%5Cvec%7Bx%7D_%7B%5Cperp%7D%29%5Crho%5E%7Bb%7D%28%5Cvec%7By%7D_%7B%5Cperp%7D%29%5Cright%5Crangle%20%3Dg%5E%7B2%7D%5Cmu%5E%7B2%7D%5Cdelta%5E%7Bab%7D%5Cdelta%5E%7B%282%29%7D%28%5Cvec%7Bx%7D_%7B%5Cperp%7D-%5Cvec%7By%7D_%7B%5Cperp%7D%29).

On the lattice I argue that this translates to

![](https://latex.codecogs.com/gif.latex?%5Cleft%5Clangle%20%5Crho%5E%7Ba%7D%28%5Cvec%7Bx%7D_%7B%5Cperp%7D%29%5Crho%5E%7Bb%7D%28%5Cvec%7By%7D_%7B%5Cperp%7D%29%5Cright%5Crangle%20_%7BL%7D%3D%5Cfrac%7Bg%5E%7B2%7D%5Cmu%5E%7B2%7D%7D%7Ba%5E%7B2%7D%7D%5Cdelta%5E%7Bab%7D%5Cdelta_%7B%5Cvec%7Bx%7D_%7B%5Cperp%7D%2C%5Cvec%7By%7D_%7B%5Cperp%7D%7D%5E%7B%282%29%7D),

where the delta distribution is replaced by a Kronecker delta and as a consequence there is an additional factor involving the lattice spacing.
