### PR TITLE
Display components of Poynting's Theorem

### DIFF
--- a/pixi/input/current/Poynting_Theorem_Test.yaml
+++ b/pixi/input/current/Poynting_Theorem_Test.yaml
@@ -89,14 +89,14 @@ panels:
       leftPanel:
         energyDensity2DGLPanel:
           automaticScaling: false
-          data: nabla S
+          data: div S
           scaleFactor: 100.0
           showCoordinates: x, y, 0
       orientation: 0
       rightPanel:
         energyDensity2DGLPanel:
           automaticScaling: false
-          data: dE/dt + nabla S
+          data: dE/dt + div S
           scaleFactor: 100.0
           showCoordinates: x, y, 0
     orientation: 1
@@ -112,7 +112,7 @@ panels:
       rightPanel:
         energyDensity2DGLPanel:
           automaticScaling: false
-          data: dE/dt + nabla S + j*E
+          data: dE/dt + div S + j*E
           scaleFactor: 100.0
           showCoordinates: x, y, 0
   windowHeight: 832

--- a/pixi/input/current/Poynting_Theorem_Test.yaml
+++ b/pixi/input/current/Poynting_Theorem_Test.yaml
@@ -1,0 +1,119 @@
+# Poynting's theorem test
+#
+# Please execute at least 2 time steps
+# so that dE/dt can be generated properly.
+#
+# By superimposing the moving currents with
+# an electromagnetic wave that travels orthogonal
+# to the current, one can obtain a nonvanishing
+# j*E contribution for testing.
+
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: 1
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 12
+gridCells: [64, 64, 1]
+timeStep: 0.1
+duration: 1000
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+currents:
+  pointChargeLCCurrents:
+    - direction: 0
+      orientation: 1
+      location: 24
+      longitudinalWidth: 4
+      useMonopoleRemoval: false
+      useDipoleRemoval: false
+      charges:
+        - location: [40, 0]
+          amplitudeColorDirection: [1.0, 0.0, 0.0]
+          magnitude: 1
+        - location: [30, 0]
+          amplitudeColorDirection: [1.0, 0.0, 0.0]
+          magnitude: -1
+        - location: [20, 0]
+          amplitudeColorDirection: [1.0, 0.0, 0.0]
+          magnitude: -1
+        - location: [10, 0]
+          amplitudeColorDirection: [1.0, 0.0, 0.0]
+          magnitude: 1
+
+fields:
+  SU2PlaneWaves:
+      # wave vector of the plane wave
+    - k: [0, 0.098174770, 0.0]
+
+      # spatial part of the wave amplitude
+      aSpatial: [1.0, 0.0,0.0]
+
+      # color part of the wave amplitude
+      aColor: [1.0, 0.0, 0.0]
+
+      # magnitude of the wave amplitude
+      a: 0.01
+
+
+# Generated panel code:
+panels:
+  dividerLocation: 351
+  leftPanel:
+    dividerLocation: 373
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        data: Energy density
+        scaleFactor: 100.0
+        showCoordinates: x, y, 0
+    orientation: 0
+    rightPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        data: dE/dt
+        scaleFactor: 100.0
+        showCoordinates: x, y, 0
+  orientation: 1
+  rightPanel:
+    dividerLocation: 387
+    leftPanel:
+      dividerLocation: 375
+      leftPanel:
+        energyDensity2DGLPanel:
+          automaticScaling: false
+          data: nabla S
+          scaleFactor: 100.0
+          showCoordinates: x, y, 0
+      orientation: 0
+      rightPanel:
+        energyDensity2DGLPanel:
+          automaticScaling: false
+          data: dE/dt + nabla S
+          scaleFactor: 100.0
+          showCoordinates: x, y, 0
+    orientation: 1
+    rightPanel:
+      dividerLocation: 375
+      leftPanel:
+        energyDensity2DGLPanel:
+          automaticScaling: false
+          data: j*E
+          scaleFactor: 100.0
+          showCoordinates: x, y, 0
+      orientation: 0
+      rightPanel:
+        energyDensity2DGLPanel:
+          automaticScaling: false
+          data: dE/dt + nabla S + j*E
+          scaleFactor: 100.0
+          showCoordinates: x, y, 0
+  windowHeight: 832
+  windowWidth: 1452

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremBuffer.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremBuffer.java
@@ -369,4 +369,60 @@ public class PoyntingTheoremBuffer implements Diagnostics {
 		}
 		return value / (as * g * as * g);
 	}
+
+	public double getTotalEnergyDensity() {
+		double result = 0;
+		int evaluatableCells = 0;
+		for (int i = 0; i < s.grid.getTotalNumberOfCells(); i++) {
+			if (s.grid.isEvaluatable(i)) {
+				result += getEnergyDensity2(i);
+				evaluatableCells++;
+			}
+		}
+		//double norm = evaluatableCells;
+		double norm = s.grid.getTotalNumberOfCells();
+		return result / norm;
+	}
+
+	public double getTotalEnergyDensityDerivative() {
+		double result = 0;
+		int evaluatableCells = 0;
+		for (int i = 0; i < s.grid.getTotalNumberOfCells(); i++) {
+			if (s.grid.isEvaluatable(i)) {
+				result += getEnergyDensityDerivative(i);
+				evaluatableCells++;
+			}
+		}
+		//double norm = evaluatableCells;
+		double norm = s.grid.getTotalNumberOfCells();
+		return result / norm;
+	}
+
+	public double getTotalDivS() {
+		double result = 0;
+		int evaluatableCells = 0;
+		for (int i = 0; i < s.grid.getTotalNumberOfCells(); i++) {
+			if (s.grid.isEvaluatable(i)) {
+				result += getDivPoyntingVector3(i);
+				evaluatableCells++;
+			}
+		}
+		//double norm = evaluatableCells;
+		double norm = s.grid.getTotalNumberOfCells();
+		return result / norm;
+	}
+
+	public double getTotalJE() {
+		double result = 0;
+		int evaluatableCells = 0;
+		for (int i = 0; i < s.grid.getTotalNumberOfCells(); i++) {
+			if (s.grid.isEvaluatable(i)) {
+				result += getCurrentElectricField2(i);
+				evaluatableCells++;
+			}
+		}
+		//double norm = evaluatableCells;
+		double norm = s.grid.getTotalNumberOfCells();
+		return result / norm;
+	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremBuffer.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremBuffer.java
@@ -393,6 +393,8 @@ public class PoyntingTheoremBuffer implements Diagnostics {
 				evaluatableCells++;
 			}
 		}
+		// TODO: Use "evaluatableCells" here and below, but only if it
+		// is also used in physics.measurements.FieldMeasurements.
 		//double norm = evaluatableCells;
 		double norm = s.grid.getTotalNumberOfCells();
 		return result / norm;

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremBuffer.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremBuffer.java
@@ -120,10 +120,6 @@ public class PoyntingTheoremBuffer implements Diagnostics {
 			Jcurrent[i] = new AlgebraElement[dimensions];
 			RotEcurrent[i] = new AlgebraElement[dimensions];
 			// Fields are copied when they are used
-			//for (int d = 0; d < dimensions; d++) {
-			//	Ecurrent[i][d] = s.grid.getE(i, d).copy();
-			//	Jcurrent[i][d] = s.grid.getJ(i, d).copy();
-			//}
 		}
 	}
 
@@ -264,10 +260,6 @@ public class PoyntingTheoremBuffer implements Diagnostics {
 			// TODO: Implement for arbitrary dimensions
 			// return 0;
 		}
-//		if (!s.grid.isRotBEvaluatable(index) || !s.grid.isRotBEvaluatable(index)) {
-//			// One of the neighbouring cells is not evaluatable.
-//			return 0;
-//		}
 		for (int direction = 0; direction < s.grid.getNumberOfDimensions(); direction++) {
 			AlgebraElement rotE = s.grid.getRotE(index, direction);
 			AlgebraElement rotB0 = s.grid.getRotB(index, direction, 0);
@@ -300,16 +292,12 @@ public class PoyntingTheoremBuffer implements Diagnostics {
 			// TODO: Implement for arbitrary dimensions
 			// return 0;
 		}
-//		if (!s.grid.isRotBEvaluatable(index) || !s.grid.isRotBEvaluatable(index)) {
-//			// One of the neighbouring cells is not evaluatable.
-//			return 0;
-//		}
 		for (int direction = 0; direction < s.grid.getNumberOfDimensions(); direction++) {
 			// Time-averaged at time of B-field
 			AlgebraElement rotE = s.grid.getRotE(index, direction);
 			if (RotEcurrent != null) {
 				RotEcurrent[index][direction] = rotE.copy();
-				if (RotEold[index][direction] != null) {
+				if (RotEold != null && RotEold[index] != null && RotEold[index][direction] != null) {
 					// Form average
 					rotE = (rotE.add(RotEold[index][direction])).mult(0.5);
 				}
@@ -318,7 +306,7 @@ public class PoyntingTheoremBuffer implements Diagnostics {
 			AlgebraElement E = s.grid.getE(index, direction);
 			if (Ecurrent != null) {
 				Ecurrent[index][direction] = E.copy();
-				if (Eold[index][direction] != null) {
+				if (Eold != null && Eold[index] != null && Eold[index][direction] != null) {
 					// Form average
 					E = (E.add(Eold[index][direction])).mult(0.5);
 				}
@@ -354,6 +342,7 @@ public class PoyntingTheoremBuffer implements Diagnostics {
 	 * @return current times electric field J*E
 	 */
 	public double getCurrentElectricField2(int index) {
+		storeOldEJ = true;
 		double as = s.grid.getLatticeSpacing();
 		double g = s.getCouplingConstant();
 
@@ -363,7 +352,7 @@ public class PoyntingTheoremBuffer implements Diagnostics {
 			AlgebraElement J = s.grid.getJ(index, direction);
 			if (Jcurrent != null) {
 				Jcurrent[index][direction] = J.copy();
-				if (Jold[index][direction] != null) {
+				if (Jold != null && Jold[index] != null && Jold[index][direction] != null) {
 					// Use previous value
 					J = Jold[index][direction];
 				}
@@ -371,7 +360,7 @@ public class PoyntingTheoremBuffer implements Diagnostics {
 			AlgebraElement E = s.grid.getE(index, direction);
 			if (Ecurrent != null) {
 				Ecurrent[index][direction] = E.copy();
-				if (Eold[index][direction] != null) {
+				if (Eold != null && Eold[index] != null && Eold[index][direction] != null) {
 					// Form average
 					E = (E.add(Eold[index][direction])).mult(0.5);
 				}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremBuffer.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremBuffer.java
@@ -1,0 +1,197 @@
+package org.openpixi.pixi.diagnostics.methods;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.openpixi.pixi.diagnostics.Diagnostics;
+import org.openpixi.pixi.math.AlgebraElement;
+import org.openpixi.pixi.physics.Simulation;
+import org.openpixi.pixi.physics.grid.Grid;
+import org.openpixi.pixi.physics.particles.IParticle;
+
+/**
+ * Shared buffer that stores previous values of the grid for calculating pieces of
+ * the Poynting Theorem.
+ *
+ */
+public class PoyntingTheoremBuffer implements Diagnostics {
+
+	Simulation s;
+	private double[] oldEnergyDensity;
+	private int[] oldTime;
+	private double[] currentEnergyDensity;
+	private int[] currentTime;
+
+	PoyntingTheoremBuffer(Simulation s) {
+		this.s = s;
+	}
+
+	@Override
+	public void initialize(Simulation s) {
+		System.out.println("initialize");
+		this.s = s;
+		// Initialize arrays
+		int cells = s.grid.getTotalNumberOfCells();
+		oldEnergyDensity = new double[cells];
+		oldTime = new int[cells];
+		currentEnergyDensity = new double[cells];
+		currentTime = new int[cells];
+	}
+
+	@Override
+	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps)
+			throws IOException {
+		// TODO Auto-generated method stub
+		System.out.println("calculate");
+
+	}
+
+	/**
+	 * Gets an instance of PoyntingTheoremBuffer from the list of diagnostics
+	 * objects of the simulation object. If no instance existed previously,
+	 * a new instance is created and added to the list of diagnostics objects.
+	 * @param s Simulation object
+	 * @return Existing or new PoyntingTheoremBuffer
+	 */
+	public static PoyntingTheoremBuffer getOrAppendInstance(Simulation s) {
+		ArrayList<Diagnostics> diagnostics = s.getDiagnosticsList();
+		for (Diagnostics d : diagnostics) {
+			if (d instanceof PoyntingTheoremBuffer) {
+				return (PoyntingTheoremBuffer) d;
+			}
+		}
+		PoyntingTheoremBuffer p = new PoyntingTheoremBuffer(s);
+		diagnostics.add(p);
+		return p;
+	}
+
+	public double getEnergyDensity(int index) {
+		double value = 0;
+
+		// Lattice spacing and coupling constant
+		double as = s.grid.getLatticeSpacing();
+		double g = s.getCouplingConstant();
+
+		for (int w = 0; w < s.getNumberOfDimensions(); w++) {
+			value += s.grid.getEsquaredFromLinks(index, w);
+			// Time averaging for B field.
+			value += 0.5 * s.grid.getBsquaredFromLinks(index, w, 0);
+			value += 0.5 * s.grid.getBsquaredFromLinks(index, w, 1);
+		};
+		return value / (as * g * as * g) / 2;
+	}
+
+	public double getEnergyDensityDerivative(int index) {
+		double value = 0;
+		if (currentTime == null) {
+			// Buffer has not been initialized yet
+			return 0;
+		}
+		if (currentTime[index] > s.totalSimulationSteps) {
+			// Reset values (in case of a simulation reset)
+			oldEnergyDensity[index] = 0;
+			oldTime[index] = 0;
+			currentEnergyDensity[index] = getEnergyDensity(index);
+			currentTime[index] = s.totalSimulationSteps;
+		}
+		if (currentTime[index] < s.totalSimulationSteps) {
+			// Update values
+			oldEnergyDensity[index] = currentEnergyDensity[index];
+			oldTime[index] = currentTime[index];
+			currentEnergyDensity[index] = getEnergyDensity(index);
+			currentTime[index] = s.totalSimulationSteps;
+		}
+		if (oldTime[index] != 0) {
+			// Calculate derivative
+			double deltaTime = (currentTime[index] - oldTime[index]) * s.tstep;
+			value = (currentEnergyDensity[index] - oldEnergyDensity[index]) / deltaTime;
+		}
+		return value;
+	}
+
+	public double getDivPoyntingVector(int index) {
+		double as = s.grid.getLatticeSpacing();
+
+		double value = 0;
+		if (s.getNumberOfDimensions() != 3) {
+			throw new RuntimeException("Dimension other than 3 has not been implemented yet.");
+			// TODO: Implement for arbitrary dimensions
+			// return 0;
+		}
+		for (int direction = 0; direction < s.grid.getNumberOfDimensions(); direction++) {
+			int indexShifted1 = s.grid.shift(index, direction, 1);
+			if (!s.grid.isEvaluatable(indexShifted1)) {
+				return 0;
+			}
+			int indexShifted2 = s.grid.shift(index, direction, -1);
+			if (!s.grid.isEvaluatable(indexShifted2)) {
+				return 0;
+			}
+			value += getPoyntingVector(indexShifted1, direction)
+					- getPoyntingVector(indexShifted2, direction);
+		}
+		return value / (2*as);
+	}
+
+	public double getPoyntingVector(int index, int direction) {
+		double as = s.grid.getLatticeSpacing();
+		double g = s.getCouplingConstant();
+
+		// Indices for cross product:
+		int dir1 = (direction + 1) % 3;
+		int dir2 = (direction + 2) % 3;
+
+		// fields at same time:
+		AlgebraElement E1 = s.grid.getE(index, dir1);
+		AlgebraElement E2 = s.grid.getE(index, dir2);
+		// time averaged B-field:
+		AlgebraElement B1 = s.grid.getB(index, dir1, 0).add(s.grid.getB(index, dir1, 1)).mult(0.5);
+		AlgebraElement B2 = s.grid.getB(index, dir2, 0).add(s.grid.getB(index, dir2, 1)).mult(0.5);
+		double S = E1.mult(B2) - E2.mult(B1);
+		return S / (as * g * as * g);
+	}
+
+	public double getDivPoyntingVector2(int index) {
+		double as = s.grid.getLatticeSpacing();
+		double g = s.getCouplingConstant();
+
+		double value = 0;
+		if (s.getNumberOfDimensions() != 3) {
+			throw new RuntimeException("Dimension other than 3 has not been implemented yet.");
+			// TODO: Implement for arbitrary dimensions
+			// return 0;
+		}
+		if (!s.grid.isRotBEvaluatable(index) || !s.grid.isRotBEvaluatable(index)) {
+			// One of the neighbouring cells is not evaluatable.
+			return 0;
+		}
+		for (int direction = 0; direction < s.grid.getNumberOfDimensions(); direction++) {
+			AlgebraElement rotE = s.grid.getRotE(index, direction);
+			AlgebraElement rotB0 = s.grid.getRotB(index, direction, 0);
+			AlgebraElement rotB1 = s.grid.getRotB(index, direction, 1);
+
+			AlgebraElement E = s.grid.getE(index, direction);
+			// time averaged B-fields:
+			AlgebraElement B = (s.grid.getB(index, direction, 0).add(s.grid.getB(index, direction, 0))).mult(0.5);
+			AlgebraElement rotB = (rotB0.add(rotB1)).mult(0.5);
+
+			value += B.mult(rotE) - E.mult(rotB);
+		}
+		return value / (as * g * as * g);
+	}
+
+	public double getCurrentElectricField(int index) {
+		double as = s.grid.getLatticeSpacing();
+		double g = s.getCouplingConstant();
+
+		double value = 0;
+
+		for (int direction = 0; direction < s.grid.getNumberOfDimensions(); direction++) {
+			AlgebraElement J = s.grid.getJ(index, direction);
+			AlgebraElement E = s.grid.getE(index, direction);
+			value += J.mult(E);
+		}
+		return value / (as * g * as * g);
+	}
+
+}

--- a/pixi/src/main/java/org/openpixi/pixi/math/AlgebraElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/AlgebraElement.java
@@ -55,7 +55,16 @@ public interface AlgebraElement {
 	AlgebraElement mult (double number);
 
 	void multAssign(double number);
-	
+
+	/**
+	 * Computes the product of the AlgebraElement instance with another AlgebraElement and returns a copy.
+	 * This method does not change the original AlgebraElement instance.
+	 *
+	 * @param a         algebra element to be multiplied with.
+	 * @return          2 tr (A B).
+	 */
+	double mult (AlgebraElement a);
+
 	void set (AlgebraElement a);
 	
 	void reset ();

--- a/pixi/src/main/java/org/openpixi/pixi/math/SU2AlgebraElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/SU2AlgebraElement.java
@@ -102,7 +102,12 @@ public class SU2AlgebraElement implements AlgebraElement {
 		this.v[2] *= number;
 
 	}
-	
+
+	public double mult (AlgebraElement arg) {
+		SU2AlgebraElement a = (SU2AlgebraElement) arg;
+		return v[0]*a.v[0]+v[1]*a.v[1]+v[2]*a.v[2];
+	}
+
 	public void set (AlgebraElement arg) {
 
 		SU2AlgebraElement a = (SU2AlgebraElement) arg;

--- a/pixi/src/main/java/org/openpixi/pixi/math/SU3AlgebraElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/SU3AlgebraElement.java
@@ -193,6 +193,13 @@ public class SU3AlgebraElement implements AlgebraElement {
 
 	}
 
+	public double mult (AlgebraElement arg) {
+		throw new RuntimeException("SU(3) code has not been tested yet.");
+		// TODO: Check if the following code is correct for SU(3):
+		// SU3AlgebraElement a = (SU3AlgebraElement) arg;
+		// return 2*(v[0]*a.v[0]+v[4]*a.v[4]+v[8]*a.v[8]+2*(v[1]*a.v[1]+v[2]*a.v[2]+v[3]*a.v[3]+v[5]*a.v[5]+v[6]*a.v[6]+v[7]*a.v[7]));
+	}
+
 	public void set (AlgebraElement arg) {
 
 		SU3AlgebraElement a = (SU3AlgebraElement) arg;

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
@@ -167,7 +167,11 @@ public class Settings {
 
 
 	public ArrayList<Diagnostics> getDiagnostics() {
-		return diagnostics;
+		ArrayList<Diagnostics> diagnosticsCopy = new ArrayList<Diagnostics>();
+		for (Diagnostics d : diagnostics) {
+			diagnosticsCopy.add(d);
+		}
+		return diagnosticsCopy;
 	}
 
 	public GeneralBoundaryType getBoundaryType() {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
@@ -429,6 +429,14 @@ public class Simulation {
         }
 	}
 
+	/**
+	 * Return list of diagnostics objects.
+	 * @return list of diagnostics objects
+	 */
+	public ArrayList<Diagnostics> getDiagnosticsList() {
+		return diagnostics;
+	}
+
 	/*
 	Not used right now.
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -901,34 +901,6 @@ public class Grid {
 	}
 
 	/**
-	 * Check whether rotor is evaluatable at the given position.
-	 * This is true if all neighboring cells for the forward or backward derivative
-	 * are also evaluatable.
-	 * @param index       Lattice index
-	 * @param orientation +1 for forward derivative rotor; -1 for backward derivative rotor.
-	 * @return            True if evaluatable, false otherwise
-	 */
-	private boolean isRotorEvaluatable(int index, int orientation) {
-		for (int direction = 0; direction < numDim; direction++) {
-			int indexShifted = shift(index, direction, orientation);
-			if (!isEvaluatable(indexShifted)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
-	 * Check whether rot B is evaluatable at the given position.
-	 * This is true if all neighboring cells for the backward derivative are also evaluatable.
-	 * @param index Lattice index
-	 * @return      True if evaluatable, false otherwise
-	 */
-	public boolean isRotBEvaluatable(int index) {
-		return isRotorEvaluatable(index, -1);
-	}
-
-	/**
 	 * Calculate rot B using a backward derivative.
 	 * @param index    	Lattice index
 	 * @param direction	Index of the direction
@@ -961,16 +933,6 @@ public class Grid {
 
 		// dBz/dy - dBy/dz
 		return (dBzdy.add(dBydz.mult(-1))).mult(-1 / as);
-	}
-
-	/**
-	 * Check whether rot E is evaluatable at the given position.
-	 * This is true if all neighboring cells for the forward derivative are also evaluatable.
-	 * @param index Lattice index
-	 * @return      True if evaluatable, false otherwise
-	 */
-	public boolean isRotEEvaluatable(int index) {
-		return isRotorEvaluatable(index, 1);
 	}
 
 	/**

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -810,8 +810,8 @@ public class Grid {
 			break;
 
 		case 1:
-			j = 0;
-			k = 2;
+			j = 2;
+			k = 0;
 			break;
 
 		case 2:

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -899,4 +899,112 @@ public class Grid {
 			}
 		}
 	}
+
+	/**
+	 * Check whether rotor is evaluatable at the given position.
+	 * This is true if all neighboring cells for the forward or backward derivative
+	 * are also evaluatable.
+	 * @param index       Lattice index
+	 * @param orientation +1 for forward derivative rotor; -1 for backward derivative rotor.
+	 * @return            True if evaluatable, false otherwise
+	 */
+	private boolean isRotorEvaluatable(int index, int orientation) {
+		for (int direction = 0; direction < numDim; direction++) {
+			int indexShifted = shift(index, direction, orientation);
+			if (!isEvaluatable(indexShifted)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Check whether rot B is evaluatable at the given position.
+	 * This is true if all neighboring cells for the backward derivative are also evaluatable.
+	 * @param index Lattice index
+	 * @return      True if evaluatable, false otherwise
+	 */
+	public boolean isRotBEvaluatable(int index) {
+		return isRotorEvaluatable(index, -1);
+	}
+
+	/**
+	 * Calculate rot B using a backward derivative.
+	 * @param index    	Lattice index
+	 * @param direction	Index of the direction
+	 * @param timeIndex	Option to compute B from U (timeIndex = 0) or Unext (timeIndex != 0)
+	 * @return          Result of rot B, or null if not all cells are evaluatable.
+	 */
+	public AlgebraElement getRotB(int index, int direction, int timeIndex) {
+		// Indices for cross product:
+		// Labels are for direction == 0 (X-direction), and cyclically rotated.
+		int dirY = (direction + 1) % 3;
+		int dirZ = (direction + 2) % 3;
+
+		int indexShiftedY = shift(index, dirY, -1);
+		int indexShiftedZ = shift(index, dirZ, -1);
+
+		AlgebraElement By = getB(index, dirY, timeIndex); // By(y, z)
+		AlgebraElement Byz1 = getB(indexShiftedZ, dirY, timeIndex); // By(y, z+1)
+		AlgebraElement Bz = getB(index, dirZ, timeIndex); // Bz(y, z)
+		AlgebraElement Bzy1 = getB(indexShiftedY, dirZ, timeIndex); // Bz(y+1, z)
+
+		// Parallel transport all quantities to same position
+		Byz1 = Byz1.act(getLink(index, dirZ, -1, timeIndex));
+		Bzy1 = Bzy1.act(getLink(index, dirY, -1, timeIndex));
+
+		// dBy/dz = By(y, z+1) - By(y, z)
+		AlgebraElement dBydz = (Byz1.add(By.mult(-1)));
+
+		// dBz/dy = Bz(y+1, z) - Bz(y, z)
+		AlgebraElement dBzdy = (Bzy1.add(Bz.mult(-1)));
+
+		// dBz/dy - dBy/dz
+		return (dBzdy.add(dBydz.mult(-1))).mult(-1 / as);
+	}
+
+	/**
+	 * Check whether rot E is evaluatable at the given position.
+	 * This is true if all neighboring cells for the forward derivative are also evaluatable.
+	 * @param index Lattice index
+	 * @return      True if evaluatable, false otherwise
+	 */
+	public boolean isRotEEvaluatable(int index) {
+		return isRotorEvaluatable(index, 1);
+	}
+
+	/**
+	 * Calculate rot E using a forward derivative.
+	 * @param index    	Lattice index
+	 * @param direction	Index of the direction
+	 * @return          Result of rot E.
+	 */
+	public AlgebraElement getRotE(int index, int direction) {
+		// Indices for cross product:
+		// Labels are for direction == 0 (X-direction), and cyclically rotated.
+		int dirY = (direction + 1) % 3;
+		int dirZ = (direction + 2) % 3;
+
+		int indexShiftedY = shift(index, dirY, 1);
+		int indexShiftedZ = shift(index, dirZ, 1);
+
+		AlgebraElement Ey = getE(index, dirY); // Ey(y, z)
+		AlgebraElement Eyz1 = getE(indexShiftedZ, dirY); // Ey(y, z+1)
+		AlgebraElement Ez = getE(index, dirZ); // Ez(y, z)
+		AlgebraElement Ezy1 = getE(indexShiftedY, dirZ); // Ez(y+1, z)
+
+		// Parallel transport all quantities to same position
+		Eyz1 = Eyz1.act(getLink(index, dirZ, 1, 0));
+		Ezy1 = Ezy1.act(getLink(index, dirY, 1, 0));
+
+		// dEy/dz = Ey(y, z+1) - Ey(y, z)
+		AlgebraElement dEydz = (Eyz1.add(Ey.mult(-1)));
+
+		// dEz/dy = Ez(y+1, z) - Ez(y, z)
+		AlgebraElement dEzdy = (Ezy1.add(Ez.mult(-1)));
+
+		// dEz/dy - dEy/dz
+		return (dEzdy.add(dEydz.mult(-1))).mult(1 / as);
+	}
+
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -39,6 +39,9 @@ public class ElectricFieldPanel extends AnimationPanel {
 	public final int INDEX_J = 7;
 	public final int INDEX_RHO = 8;
 	public final int INDEX_GAUSS = 9;
+	public final int INDEX_ROT_E = 10;
+	public final int INDEX_ROT_B = 11;
+	public final int INDEX_ROT_B_NEXT = 12;
 
 	String[] fieldLabel = new String[] {
 			"E",
@@ -50,7 +53,10 @@ public class ElectricFieldPanel extends AnimationPanel {
 			"U0 next",
 			"j",
 			"rho",
-			"Gauss"
+			"Gauss",
+			"rot E",
+			"rot B",
+			"rot B next"
 	};
 
 	Color[] fieldColors = new Color[] {
@@ -63,7 +69,10 @@ public class ElectricFieldPanel extends AnimationPanel {
 			Color.gray,
 			Color.red,
 			Color.blue,
-			Color.magenta
+			Color.magenta,
+			Color.cyan,
+			Color.pink,
+			Color.yellow
 	};
 
 	boolean[] fieldInit = new boolean[] {
@@ -71,6 +80,9 @@ public class ElectricFieldPanel extends AnimationPanel {
 			false,
 			false,
 			true,
+			false,
+			false,
+			false,
 			false,
 			false,
 			false,
@@ -248,6 +260,15 @@ public class ElectricFieldPanel extends AnimationPanel {
 					} else {
 						value = 0.0;
 					}
+					break;
+				case INDEX_ROT_E:
+					value = drawGrid.getRotE(index, directionIndex).get(colorIndex) / (as * g);
+					break;
+				case INDEX_ROT_B:
+					value = drawGrid.getRotB(index, directionIndex, 0).get(colorIndex) / (as * g);
+					break;
+				case INDEX_ROT_B_NEXT:
+					value = drawGrid.getRotB(index, directionIndex, 1).get(colorIndex) / (as * g);
 					break;
 				}
 				scaleProperties.putValue(value);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
@@ -15,6 +15,7 @@ import java.text.DecimalFormat;
 import javax.swing.Box;
 
 import org.openpixi.pixi.diagnostics.methods.OccupationNumbersInTime;
+import org.openpixi.pixi.diagnostics.methods.PoyntingTheoremBuffer;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.measurements.FieldMeasurements;
 import org.openpixi.pixi.ui.SimulationAnimation;
@@ -39,6 +40,12 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 	public final int INDEX_ENERGY_DENSITY_2 = 7;
 	public final int INDEX_TOTAL_CHARGE = 8;
 	public final int INDEX_TOTAL_CHARGE_SQUARED = 9;
+	public final int INDEX_ENERGY_DENSITY_DERIVATIVE = 10;
+	public final int INDEX_DIV_S = 11;
+	public final int INDEX_JE = 12;
+	public final int INDEX_POYNTING_THEOREM = 13;
+	public final int INDEX_INTEGRATED_DIV_S = 14;
+	public final int INDEX_INTEGRATED_JE = 15;
 
 	String[] chartLabel = new String[] {
 			"Gauss law violation",
@@ -50,7 +57,13 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 			"pz",
 			"Energy density (occupation numbers)",
 			"Total charge",
-			"Total charge squared"
+			"Total charge squared",
+			"dE/dt",
+			"div S",
+			"J*E",
+			"dE/dt + div S + J*E",
+			"Integrated div S",
+			"Integrated J*E"
 	};
 
 	Color[] traceColors = new Color[] {
@@ -63,7 +76,13 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 			Color.blue,
 			Color.magenta,
 			Color.darkGray,
-			Color.darkGray
+			Color.darkGray,
+			Color.orange,
+			Color.cyan,
+			Color.blue,
+			Color.black,
+			Color.red,
+			Color.green
 	};
 
 	public BooleanProperties logarithmicProperty;
@@ -74,6 +93,8 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 	private FieldMeasurements fieldMeasurements;
 
 	private OccupationNumbersInTime occupationNumbers;
+
+	private PoyntingTheoremBuffer poyntingTheorem;
 
 	/** Constructor */
 	public Chart2DPanel(SimulationAnimation simulationAnimation) {
@@ -124,6 +145,7 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 
 		Simulation s = getSimulationAnimation().getSimulation();
 		double time = s.totalSimulationTime;
+		poyntingTheorem = PoyntingTheoremBuffer.getOrAppendInstance(s);
 
 		//TODO Make this method d-dimensional!!
 		// The values computed from fieldMeasurements already come in "physical units", i.e. the factor g*a is accounted for.
@@ -146,6 +168,13 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 		double totalCharge = fieldMeasurements.calculateTotalCharge(s.grid);
 		double totalChargeSquared = fieldMeasurements.calculateTotalChargeSquared(s.grid);
 
+		double energyDensityDerivative = poyntingTheorem.getTotalEnergyDensityDerivative();
+		double divS = poyntingTheorem.getTotalDivS();
+		double jS = poyntingTheorem.getTotalJE();
+		double poyntingTheorem = energyDensityDerivative + divS + jS;
+		double integratedDivS = 0;//poyntingTheorem.getIntegratedTotalDivS();
+		double integratedJS = 0;//poyntingTheorem.getIntegratedTotalJE();
+
 		traces[INDEX_E_SQUARED].addPoint(time, eSquared);
 		traces[INDEX_B_SQUARED].addPoint(time, bSquared);
 		traces[INDEX_GAUSS_VIOLATION].addPoint(time, gaussViolation);
@@ -155,6 +184,12 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 		traces[INDEX_PZ].addPoint(time, pz);
 		traces[INDEX_TOTAL_CHARGE].addPoint(time, totalCharge);
 		traces[INDEX_TOTAL_CHARGE_SQUARED].addPoint(time, totalChargeSquared);
+		traces[INDEX_ENERGY_DENSITY_DERIVATIVE].addPoint(time, energyDensityDerivative);
+		traces[INDEX_DIV_S].addPoint(time, divS);
+		traces[INDEX_JE].addPoint(time, jS);
+		traces[INDEX_POYNTING_THEOREM].addPoint(time, poyntingTheorem);
+		traces[INDEX_INTEGRATED_DIV_S].addPoint(time, integratedDivS);
+		traces[INDEX_INTEGRATED_JE].addPoint(time, integratedJS);
 
 		if (showChartsProperty.getValue(INDEX_ENERGY_DENSITY_2)) {
 			occupationNumbers.initialize(s);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
@@ -65,7 +65,7 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 			"dE/dt + div S + J*E",
 			"Integrated div S",
 			"Integrated J*E",
-			"Integrated dE/dt + div S + J*E"
+			"E + Integrated(div S + J*E)"
 	};
 
 	Color[] traceColors = new Color[] {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
@@ -46,6 +46,7 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 	public final int INDEX_POYNTING_THEOREM = 13;
 	public final int INDEX_INTEGRATED_DIV_S = 14;
 	public final int INDEX_INTEGRATED_JE = 15;
+	public final int INDEX_INTEGRATED_POYNTING_THEOREM = 16;
 
 	String[] chartLabel = new String[] {
 			"Gauss law violation",
@@ -63,7 +64,8 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 			"J*E",
 			"dE/dt + div S + J*E",
 			"Integrated div S",
-			"Integrated J*E"
+			"Integrated J*E",
+			"Integrated dE/dt + div S + J*E"
 	};
 
 	Color[] traceColors = new Color[] {
@@ -82,7 +84,8 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 			Color.blue,
 			Color.black,
 			Color.red,
-			Color.green
+			Color.green,
+			Color.pink
 	};
 
 	public BooleanProperties logarithmicProperty;
@@ -171,9 +174,11 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 		double energyDensityDerivative = poyntingTheorem.getTotalEnergyDensityDerivative();
 		double divS = poyntingTheorem.getTotalDivS();
 		double jS = poyntingTheorem.getTotalJE();
-		double poyntingTheorem = energyDensityDerivative + divS + jS;
-		double integratedDivS = 0;//poyntingTheorem.getIntegratedTotalDivS();
-		double integratedJS = 0;//poyntingTheorem.getIntegratedTotalJE();
+		double poyntingTheoremSum = energyDensityDerivative + divS + jS;
+		double integratedDivS = poyntingTheorem.getIntegratedTotalDivS();
+		double integratedJS = poyntingTheorem.getIntegratedTotalJE();
+		double integratedPoyntingTheorem = poyntingTheorem.getTotalEnergyDensity()
+				+ integratedDivS + integratedJS;
 
 		traces[INDEX_E_SQUARED].addPoint(time, eSquared);
 		traces[INDEX_B_SQUARED].addPoint(time, bSquared);
@@ -187,9 +192,10 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 		traces[INDEX_ENERGY_DENSITY_DERIVATIVE].addPoint(time, energyDensityDerivative);
 		traces[INDEX_DIV_S].addPoint(time, divS);
 		traces[INDEX_JE].addPoint(time, jS);
-		traces[INDEX_POYNTING_THEOREM].addPoint(time, poyntingTheorem);
+		traces[INDEX_POYNTING_THEOREM].addPoint(time, poyntingTheoremSum);
 		traces[INDEX_INTEGRATED_DIV_S].addPoint(time, integratedDivS);
 		traces[INDEX_INTEGRATED_JE].addPoint(time, integratedJS);
+		traces[INDEX_INTEGRATED_POYNTING_THEOREM].addPoint(time, integratedPoyntingTheorem);
 
 		if (showChartsProperty.getValue(INDEX_ENERGY_DENSITY_2)) {
 			occupationNumbers.initialize(s);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -38,11 +38,13 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 
 	public static final int INDEX_ENERGY_DENSITY = 0;
 	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE = 1;
-	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_POYNTING = 2;
+	public static final int INDEX_NABLA_POYNTING = 2;
+	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_NABLA_POYNTING = 3;
 
 	String[] typeLabel = new String[] {
 			"Energy density",
 			"dE/dt",
+			"nabla S",
 			"dE/dt + nabla S"
 	};
 
@@ -120,7 +122,10 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 					case INDEX_ENERGY_DENSITY_DERIVATIVE:
 						value = getEnergyDensityDerivative(s, index);
 						break;
-					case INDEX_ENERGY_DENSITY_DERIVATIVE_POYNTING:
+					case INDEX_NABLA_POYNTING:
+						value = getNablaPoyntingVector(s, index);
+						break;
+					case INDEX_ENERGY_DENSITY_DERIVATIVE_NABLA_POYNTING:
 						value = getEnergyDensityDerivative(s, index)
 							+ getNablaPoyntingVector(s, index);
 						break;
@@ -217,15 +222,15 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 
 	private double getPoyntingVector(Simulation s, int index, int direction) {
 		// Indices for cross product:
-		int id1 = (index + 1) % 3;
-		int id2 = (index + 2) % 3;
+		int dir1 = (direction + 1) % 3;
+		int dir2 = (direction + 2) % 3;
 
 		// fields at same time:
-		AlgebraElement E1 = s.grid.getE(index, id1);
-		AlgebraElement E2 = s.grid.getE(index, id2);
+		AlgebraElement E1 = s.grid.getE(index, dir1);
+		AlgebraElement E2 = s.grid.getE(index, dir2);
 		// time averaged B-field:
-		AlgebraElement B1 = s.grid.getB(index, id1, 0).add(s.grid.getB(index, id1, 1)).mult(0.5);
-		AlgebraElement B2 = s.grid.getB(index, id2, 0).add(s.grid.getB(index, id2, 1)).mult(0.5);
+		AlgebraElement B1 = s.grid.getB(index, dir1, 0).add(s.grid.getB(index, dir1, 1)).mult(0.5);
+		AlgebraElement B2 = s.grid.getB(index, dir2, 0).add(s.grid.getB(index, dir2, 1)).mult(0.5);
 		double S = E1.mult(B2) - E2.mult(B1);
 		return S;
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -38,18 +38,18 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 
 	public static final int INDEX_ENERGY_DENSITY = 0;
 	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE = 1;
-	public static final int INDEX_NABLA_POYNTING = 2;
-	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_NABLA_POYNTING = 3;
+	public static final int INDEX_DIV_POYNTING = 2;
+	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_DIV_POYNTING = 3;
 	public static final int INDEX_CURRENT_ELECTRIC_FIELD = 4;
-	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_NABLA_POYNTING_CURRENT = 5;
+	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_DIV_POYNTING_CURRENT = 5;
 
 	String[] dataLabel = new String[] {
 			"Energy density",
 			"dE/dt",
-			"nabla S",
-			"dE/dt + nabla S",
+			"div S",
+			"dE/dt + div S",
 			"j*E",
-			"dE/dt + nabla S + j*E"
+			"dE/dt + div S + j*E"
 	};
 
 	public static final int RED = 0;
@@ -126,19 +126,19 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 					case INDEX_ENERGY_DENSITY_DERIVATIVE:
 						value = getEnergyDensityDerivative(s, index);
 						break;
-					case INDEX_NABLA_POYNTING:
-						value = getNablaPoyntingVector2(s, index);
+					case INDEX_DIV_POYNTING:
+						value = getDivPoyntingVector2(s, index);
 						break;
-					case INDEX_ENERGY_DENSITY_DERIVATIVE_NABLA_POYNTING:
+					case INDEX_ENERGY_DENSITY_DERIVATIVE_DIV_POYNTING:
 						value = getEnergyDensityDerivative(s, index)
-							+ getNablaPoyntingVector2(s, index);
+							+ getDivPoyntingVector2(s, index);
 						break;
 					case INDEX_CURRENT_ELECTRIC_FIELD:
 						value = getCurrentElectricField(s, index);
 						break;
-					case INDEX_ENERGY_DENSITY_DERIVATIVE_NABLA_POYNTING_CURRENT:
+					case INDEX_ENERGY_DENSITY_DERIVATIVE_DIV_POYNTING_CURRENT:
 						value = getEnergyDensityDerivative(s, index)
-							+ getNablaPoyntingVector2(s, index)
+							+ getDivPoyntingVector2(s, index)
 							+ getCurrentElectricField(s, index);
 						break;
 					}
@@ -214,7 +214,7 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 		return value;
 	}
 
-	private double getNablaPoyntingVector(Simulation s, int index) {
+	private double getDivPoyntingVector(Simulation s, int index) {
 		double as = s.grid.getLatticeSpacing();
 
 		double value = 0;
@@ -256,7 +256,7 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 		return S / (as * g * as * g);
 	}
 
-	private double getNablaPoyntingVector2(Simulation s, int index) {
+	private double getDivPoyntingVector2(Simulation s, int index) {
 		double as = s.grid.getLatticeSpacing();
 		double g = s.getCouplingConstant();
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -119,25 +119,25 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 				if(s.grid.isEvaluatable(index)) {
 					switch(dataIndex) {
 					case INDEX_ENERGY_DENSITY:
-						value = poyntingTheorem.getEnergyDensity(index);
+						value = poyntingTheorem.getEnergyDensity2(index);
 						break;
 					case INDEX_ENERGY_DENSITY_DERIVATIVE:
 						value = poyntingTheorem.getEnergyDensityDerivative(index);
 						break;
 					case INDEX_DIV_POYNTING:
-						value = poyntingTheorem.getDivPoyntingVector2(index);
+						value = poyntingTheorem.getDivPoyntingVector3(index);
 						break;
 					case INDEX_ENERGY_DENSITY_DERIVATIVE_DIV_POYNTING:
 						value = poyntingTheorem.getEnergyDensityDerivative(index)
-							+ poyntingTheorem.getDivPoyntingVector2(index);
+							+ poyntingTheorem.getDivPoyntingVector3(index);
 						break;
 					case INDEX_CURRENT_ELECTRIC_FIELD:
-						value = poyntingTheorem.getCurrentElectricField(index);
+						value = poyntingTheorem.getCurrentElectricField2(index);
 						break;
 					case INDEX_ENERGY_DENSITY_DERIVATIVE_DIV_POYNTING_CURRENT:
 						value = poyntingTheorem.getEnergyDensityDerivative(index)
-							+ poyntingTheorem.getDivPoyntingVector2(index)
-							+ poyntingTheorem.getCurrentElectricField(index);
+							+ poyntingTheorem.getDivPoyntingVector3(index)
+							+ poyntingTheorem.getCurrentElectricField2(index);
 						break;
 					}
 					getColorFromEField(s, index, color);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -309,6 +309,9 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 		AlgebraElement Bz1 = s.grid.getB(index, dir2, timeIndex);
 		AlgebraElement Bz2 = s.grid.getB(indexShifted1, dir2, timeIndex);
 
+		By2 = By2.act(s.grid.getLink(index, dir2, -1, timeIndex));
+		Bz2 = Bz2.act(s.grid.getLink(index, dir1, -1, timeIndex));
+
 		// By2 - By1
 		AlgebraElement dBy = (By2.add(By1.mult(-1)));
 
@@ -341,6 +344,9 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 		AlgebraElement Ey2 = s.grid.getE(indexShifted2, dir1);
 		AlgebraElement Ez1 = s.grid.getE(index, dir2);
 		AlgebraElement Ez2 = s.grid.getE(indexShifted1, dir2);
+
+		Ey2 = Ey2.act(s.grid.getLink(index, dir2, 1, 0));
+		Ez2 = Ez2.act(s.grid.getLink(index, dir1, 1, 0));
 
 		// Ey2 - Ey1
 		AlgebraElement dEy = (Ey2.add(Ey1.mult(-1)));

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -40,12 +40,16 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE = 1;
 	public static final int INDEX_NABLA_POYNTING = 2;
 	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_NABLA_POYNTING = 3;
+	public static final int INDEX_CURRENT_ELECTRIC_FIELD = 4;
+	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_NABLA_POYNTING_CURRENT = 5;
 
 	String[] dataLabel = new String[] {
 			"Energy density",
 			"dE/dt",
 			"nabla S",
-			"dE/dt + nabla S"
+			"dE/dt + nabla S",
+			"j*E",
+			"dE/dt + nabla S + j*E"
 	};
 
 	public static final int RED = 0;
@@ -128,6 +132,14 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 					case INDEX_ENERGY_DENSITY_DERIVATIVE_NABLA_POYNTING:
 						value = getEnergyDensityDerivative(s, index)
 							+ getNablaPoyntingVector(s, index);
+						break;
+					case INDEX_CURRENT_ELECTRIC_FIELD:
+						value = getCurrentElectricField(s, index);
+						break;
+					case INDEX_ENERGY_DENSITY_DERIVATIVE_NABLA_POYNTING_CURRENT:
+						value = getEnergyDensityDerivative(s, index)
+							+ getNablaPoyntingVector(s, index)
+							+ getCurrentElectricField(s, index);
 						break;
 					}
 					getColorFromEField(s, index, color);
@@ -242,6 +254,20 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 		AlgebraElement B2 = s.grid.getB(index, dir2, 0).add(s.grid.getB(index, dir2, 1)).mult(0.5);
 		double S = E1.mult(B2) - E2.mult(B1);
 		return S / (as * g * as * g);
+	}
+
+	private double getCurrentElectricField(Simulation s, int index) {
+		double as = s.grid.getLatticeSpacing();
+		double g = s.getCouplingConstant();
+
+		double value = 0;
+
+		for (int direction = 0; direction < s.grid.getNumberOfDimensions(); direction++) {
+			AlgebraElement J = s.grid.getJ(index, direction);
+			AlgebraElement E = s.grid.getE(index, direction);
+			value += J.mult(E);
+		}
+		return value / (as * g * as * g);
 	}
 
 	private void getColorFromEField(Simulation s, int index,

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -212,14 +212,18 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 			// return 0;
 		}
 		for (int direction = 0; direction < s.grid.getNumberOfDimensions(); direction++) {
-			int indexShifted = s.grid.shift(index, direction, 1);
-			if (!s.grid.isEvaluatable(indexShifted)) {
+			int indexShifted1 = s.grid.shift(index, direction, 1);
+			if (!s.grid.isEvaluatable(indexShifted1)) {
 				return 0;
 			}
-			value += getPoyntingVector(s, indexShifted, direction)
-					- getPoyntingVector(s, index, direction);
+			int indexShifted2 = s.grid.shift(index, direction, -1);
+			if (!s.grid.isEvaluatable(indexShifted2)) {
+				return 0;
+			}
+			value += getPoyntingVector(s, indexShifted1, direction)
+					- getPoyntingVector(s, indexShifted2, direction);
 		}
-		return value / as;
+		return value / (2*as);
 	}
 
 	private double getPoyntingVector(Simulation s, int index, int direction) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -24,7 +24,6 @@ import javax.media.opengl.GLAutoDrawable;
 import javax.swing.Box;
 
 import org.openpixi.pixi.diagnostics.methods.PoyntingTheoremBuffer;
-import org.openpixi.pixi.math.AlgebraElement;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.ui.SimulationAnimation;
 import org.openpixi.pixi.ui.panel.properties.ComboBoxProperties;
@@ -70,7 +69,6 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 		scaleProperties = new ScaleProperties(simulationAnimation);
 		scaleProperties.setAutomaticScaling(true);
 		showCoordinateProperties = new CoordinateProperties(simulationAnimation, CoordinateProperties.Mode.MODE_2D);
-		poyntingTheorem = PoyntingTheoremBuffer.getOrAppendInstance(simulationAnimation.getSimulation());
 	}
 
 	@Override
@@ -84,6 +82,7 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 		double scale = scaleProperties.getScale();
 		scaleProperties.resetAutomaticScale();
 		Simulation s = getSimulationAnimation().getSimulation();
+		poyntingTheorem = PoyntingTheoremBuffer.getOrAppendInstance(s);
 
 		int xAxisIndex = showCoordinateProperties.getXAxisIndex();
 		int yAxisIndex = showCoordinateProperties.getYAxisIndex();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -267,11 +267,19 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 			// return 0;
 		}
 		for (int direction = 0; direction < s.grid.getNumberOfDimensions(); direction++) {
-			AlgebraElement E = s.grid.getE(index, direction);
 			AlgebraElement rotE = rotE(s, index, direction);
+			AlgebraElement rotB0 = rotB(s, index, direction, 0);
+			AlgebraElement rotB1 = rotB(s, index, direction, 1);
+
+			if (rotE == null || rotB0 == null || rotB1 == null) {
+				// One of the neighbouring cells is not evaluatable.
+				return 0;
+			}
+
+			AlgebraElement E = s.grid.getE(index, direction);
 			// time averaged B-fields:
 			AlgebraElement B = (s.grid.getB(index, direction, 0).add(s.grid.getB(index, direction, 0))).mult(0.5);
-			AlgebraElement rotB = (rotB(s, index, direction, 0).add(rotB(s, index, direction, 1))).mult(0.5);
+			AlgebraElement rotB = (rotB0.add(rotB1)).mult(0.5);
 
 			value += E.mult(rotB) - B.mult(rotE);
 		}
@@ -288,12 +296,12 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 
 		int indexShifted1 = s.grid.shift(index, dir1, -1);
 		if (!s.grid.isEvaluatable(indexShifted1)) {
-			//return 0;
+			return null;
 		}
 
 		int indexShifted2 = s.grid.shift(index, dir2, -1);
 		if (!s.grid.isEvaluatable(indexShifted2)) {
-			//return 0;
+			return null;
 		}
 
 		AlgebraElement By1 = s.grid.getB(index, dir1, timeIndex);
@@ -321,12 +329,12 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 
 		int indexShifted1 = s.grid.shift(index, dir1, 1);
 		if (!s.grid.isEvaluatable(indexShifted1)) {
-			//return 0;
+			return null;
 		}
 
 		int indexShifted2 = s.grid.shift(index, dir2, 1);
 		if (!s.grid.isEvaluatable(indexShifted2)) {
-			//return 0;
+			return null;
 		}
 
 		AlgebraElement Ey1 = s.grid.getE(index, dir1);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -60,7 +60,7 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 	public ScaleProperties scaleProperties;
 	public CoordinateProperties showCoordinateProperties;
 
-	PoyntingTheoremBuffer poyntingTheorem;
+	private PoyntingTheoremBuffer poyntingTheorem;
 
 	/** Constructor */
 	public EnergyDensity2DGLPanel(SimulationAnimation simulationAnimation) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -203,6 +203,8 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 	}
 
 	private double getNablaPoyntingVector(Simulation s, int index) {
+		double as = s.grid.getLatticeSpacing();
+
 		double value = 0;
 		if (s.getNumberOfDimensions() != 3) {
 			throw new RuntimeException("Dimension other than 3 has not been implemented yet.");
@@ -217,10 +219,13 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 			value += getPoyntingVector(s, indexShifted, direction)
 					- getPoyntingVector(s, index, direction);
 		}
-		return value;
+		return value / as;
 	}
 
 	private double getPoyntingVector(Simulation s, int index, int direction) {
+		double as = s.grid.getLatticeSpacing();
+		double g = s.getCouplingConstant();
+
 		// Indices for cross product:
 		int dir1 = (direction + 1) % 3;
 		int dir2 = (direction + 2) % 3;
@@ -232,7 +237,7 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 		AlgebraElement B1 = s.grid.getB(index, dir1, 0).add(s.grid.getB(index, dir1, 1)).mult(0.5);
 		AlgebraElement B2 = s.grid.getB(index, dir2, 0).add(s.grid.getB(index, dir2, 1)).mult(0.5);
 		double S = E1.mult(B2) - E2.mult(B1);
-		return S;
+		return S / (as * g * as * g);
 	}
 
 	private void getColorFromEField(Simulation s, int index,

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -41,7 +41,7 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 	public static final int INDEX_NABLA_POYNTING = 2;
 	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_NABLA_POYNTING = 3;
 
-	String[] typeLabel = new String[] {
+	String[] dataLabel = new String[] {
 			"Energy density",
 			"dE/dt",
 			"nabla S",
@@ -52,7 +52,7 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 	public static final int GREEN = 1;
 	public static final int BLUE = 2;
 
-	public ComboBoxProperties typeProperties;
+	public ComboBoxProperties dataProperties;
 	public ScaleProperties scaleProperties;
 	public CoordinateProperties showCoordinateProperties;
 
@@ -64,7 +64,7 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 	/** Constructor */
 	public EnergyDensity2DGLPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
-		typeProperties = new ComboBoxProperties(simulationAnimation, "Type", typeLabel, 0);
+		dataProperties = new ComboBoxProperties(simulationAnimation, "Data", dataLabel, 0);
 		scaleProperties = new ScaleProperties(simulationAnimation);
 		scaleProperties.setAutomaticScaling(true);
 		showCoordinateProperties = new CoordinateProperties(simulationAnimation, CoordinateProperties.Mode.MODE_2D);
@@ -93,7 +93,7 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 
 		double[] color = new double[3];
 
-		int typeIndex = typeProperties.getIndex();
+		int dataIndex = dataProperties.getIndex();
 
 		for(int i = 0; i < s.grid.getNumCells(xAxisIndex); i++) {
 
@@ -115,7 +115,7 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 				color[GREEN] = 0;
 				color[BLUE] = 0;
 				if(s.grid.isEvaluatable(index)) {
-					switch(typeIndex) {
+					switch(dataIndex) {
 					case INDEX_ENERGY_DENSITY:
 						value = getEnergyDensity(s, index);
 						break;
@@ -270,7 +270,7 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 
 	public void addPropertyComponents(Box box) {
 		addLabel(box, "Energy density 2D (OpenGL) panel");
-		typeProperties.addComponents(box);
+		dataProperties.addComponents(box);
 		scaleProperties.addComponents(box);
 		showCoordinateProperties.addComponents(box);
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensity2DGLPanel.java
@@ -14,6 +14,9 @@ public class YamlEnergyDensity2DGLPanel {
 	// Coordinate properties
 	public String showCoordinates;
 
+	// ComboBox properties
+	public String data;
+
 	/** Empty constructor called by SnakeYaml */
 	public YamlEnergyDensity2DGLPanel() {
 	}
@@ -24,6 +27,7 @@ public class YamlEnergyDensity2DGLPanel {
 			scaleFactor = panel.scaleProperties.getScaleFactor();
 			automaticScaling = panel.scaleProperties.getAutomaticScaling();
 			showCoordinates = panel.showCoordinateProperties.getValue();
+			data = panel.dataProperties.getStringFromEntry();
 		}
 	}
 
@@ -41,6 +45,10 @@ public class YamlEnergyDensity2DGLPanel {
 
 		if (showCoordinates != null) {
 			panel.showCoordinateProperties.setValue(showCoordinates);
+		}
+
+		if (data != null) {
+			panel.dataProperties.setEntryFromString(data);
 		}
 		return panel;
 	}


### PR DESCRIPTION
The panel "Energy density 2D (OpenGL)" can now display the following data:
- Energy density
- dE/dt (derivative of energy density)
- div S (divergence of Poynting vector)
- dE/dt + div S
- j*E
- dE/dt + div S + j*E (= 0 according to Poynting's theorem)

The last equality is violated at order O(t^2) and is better fulfilled at smaller time steps.

To test the new panels, load the settings input/current/Poynting_Theorem_Test.yaml .

The panel "Electric field" can display the following new data:
- rot E
- rot B
- rot B next

The panel "Chart panel" can display the following new data:
- dE/dt
- div S
- J*E
- dE/dt + div S + J*E
- Integrated div S
- Integrated J*E
- Integrated dE/dt + div S + J*E

A bug has been fixed in Grid.getB().
