### PR TITLE
Boost-invariance in MV collisions and python script for the VSC2

### DIFF
--- a/pixi/input/current/MV model/MV_boostinvariantComp.yaml
+++ b/pixi/input/current/MV model/MV_boostinvariantComp.yaml
@@ -25,7 +25,15 @@ currents:
       randomSeed1: 1
       randomSeed2: 2
       createInitialConditionsOutput: true
-      outputFile: "test.dat"
+      outputFile: "planarInitial.dat"
+
+output:
+  planarFields:
+    - interval: 1.0
+      startingTime: 16.0
+      path: "planarOutput.dat"
+      direction: 0
+      planarIndex: 32
 
 
 

--- a/pixi/input/current/MV model/MV_boostinvariantComp.yaml
+++ b/pixi/input/current/MV model/MV_boostinvariantComp.yaml
@@ -1,12 +1,12 @@
 simulationType: temporal cgc ngp
 gridStep: 1
-couplingConstant: .4
+couplingConstant: 1
 numberOfDimensions: 3
 numberOfColors: 2
 numberOfThreads: 8
-gridCells: [64, 40, 40]
+gridCells: [128, 32, 32]
 timeStep: 0.5
-duration: 96
+duration: 32
 evaluationRegion:
   enabled: true
   point1: [2, 0, 0]
@@ -19,9 +19,10 @@ activeRegion:
 currents:
   dualMVModels:
     - direction: 0
-      longitudinalLocation: 16
-      longitudinalWidth: 3.0
+      longitudinalLocation: 32
+      longitudinalWidth: 8.0
       mu: 0.1
+      lowPassCoefficient: 0.1
       randomSeed1: 1
       randomSeed2: 2
       createInitialConditionsOutput: true
@@ -30,7 +31,7 @@ currents:
 output:
   planarFields:
     - interval: 1.0
-      startingTime: 16.0
+      startingTime: 6.0
       path: "planarOutput.dat"
       direction: 0
       planarIndex: 32

--- a/pixi/input/current/MV model/MV_boostinvariantComp.yaml
+++ b/pixi/input/current/MV model/MV_boostinvariantComp.yaml
@@ -1,0 +1,80 @@
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: .4
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 8
+gridCells: [64, 40, 40]
+timeStep: 0.5
+duration: 96
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+currents:
+  dualMVModels:
+    - direction: 0
+      longitudinalLocation: 16
+      longitudinalWidth: 3.0
+      mu: 0.1
+      randomSeed1: 1
+      randomSeed2: 2
+      createInitialConditionsOutput: true
+      outputFile: "test.dat"
+
+
+
+# Generated panel code:
+panels:
+  dividerLocation: 800
+  leftPanel:
+    dividerLocation: 495
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 400000.0
+        showCoordinates: 48, y, x
+    orientation: 0
+    rightPanel:
+      dividerLocation: 394
+      leftPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 0
+          scaleFactor: 50.0
+          showCoordinates: x, i, 0
+          showFields:
+          - E
+          - B
+      orientation: 1
+      rightPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 1
+          scaleFactor: 50.0
+          showCoordinates: x, i, 4
+          showFields:
+          - E
+  orientation: 1
+  rightPanel:
+    dividerLocation: 499
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 4.0E10
+        showCoordinates: 32, y, x
+    orientation: 0
+    rightPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 400000.0
+        showCoordinates: 16, y, x
+  windowHeight: 1054
+  windowWidth: 1922

--- a/pixi/input/current/MV model/boost/MV_bi1.yaml
+++ b/pixi/input/current/MV model/boost/MV_bi1.yaml
@@ -4,9 +4,9 @@ couplingConstant: .2
 numberOfDimensions: 3
 numberOfColors: 2
 numberOfThreads: 8
-gridCells: [128, 32, 32]
-timeStep: 0.5
-duration: 64
+gridCells: [256, 32, 32]
+timeStep: 0.25
+duration: 128
 evaluationRegion:
   enabled: true
   point1: [2, 0, 0]
@@ -19,7 +19,7 @@ activeRegion:
 currents:
   dualMVModels:
     - direction: 0
-      longitudinalLocation: 32
+      longitudinalLocation: 40
       longitudinalWidth: 10
       mu: 0.3
       lowPassCoefficient: 0.05
@@ -34,7 +34,7 @@ output:
       startingTime: 0.0
       path: "planarOutput1.dat"
       direction: 0
-      planarIndex: 64
+      planarIndex: 128
 
 
 

--- a/pixi/input/current/MV model/boost/MV_bi1.yaml
+++ b/pixi/input/current/MV model/boost/MV_bi1.yaml
@@ -1,0 +1,90 @@
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: .2
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 8
+gridCells: [128, 32, 32]
+timeStep: 0.5
+duration: 64
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+currents:
+  dualMVModels:
+    - direction: 0
+      longitudinalLocation: 32
+      longitudinalWidth: 10
+      mu: 0.3
+      lowPassCoefficient: 0.05
+      randomSeed1: 3
+      randomSeed2: 4
+      createInitialConditionsOutput: true
+      outputFile: "planarInitial1.dat"
+
+output:
+  planarFields:
+    - interval: 1.0
+      startingTime: 0.0
+      path: "planarOutput1.dat"
+      direction: 0
+      planarIndex: 64
+
+
+
+# Generated panel code:
+panels:
+  dividerLocation: 800
+  leftPanel:
+    dividerLocation: 495
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 400000.0
+        showCoordinates: 96, y, x
+    orientation: 0
+    rightPanel:
+      dividerLocation: 394
+      leftPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 0
+          scaleFactor: 50.0
+          showCoordinates: x, i, 0
+          showFields:
+          - E
+          - B
+      orientation: 1
+      rightPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 1
+          scaleFactor: 50.0
+          showCoordinates: x, i, 4
+          showFields:
+          - E
+  orientation: 1
+  rightPanel:
+    dividerLocation: 499
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 4.0E10
+        showCoordinates: 64, y, x
+    orientation: 0
+    rightPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 400000.0
+        showCoordinates: 32, y, x
+  windowHeight: 1053
+  windowWidth: 1920
+

--- a/pixi/input/current/MV model/boost/MV_bi2.yaml
+++ b/pixi/input/current/MV model/boost/MV_bi2.yaml
@@ -1,0 +1,90 @@
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: .2
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 8
+gridCells: [128, 32, 32]
+timeStep: 0.5
+duration: 64
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+currents:
+  dualMVModels:
+    - direction: 0
+      longitudinalLocation: 32
+      longitudinalWidth: 8
+      mu: 0.3
+      lowPassCoefficient: 0.05
+      randomSeed1: 3
+      randomSeed2: 4
+      createInitialConditionsOutput: true
+      outputFile: "planarInitial2.dat"
+
+output:
+  planarFields:
+    - interval: 1.0
+      startingTime: 0.0
+      path: "planarOutput2.dat"
+      direction: 0
+      planarIndex: 64
+
+
+
+# Generated panel code:
+panels:
+  dividerLocation: 800
+  leftPanel:
+    dividerLocation: 495
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 400000.0
+        showCoordinates: 96, y, x
+    orientation: 0
+    rightPanel:
+      dividerLocation: 394
+      leftPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 0
+          scaleFactor: 50.0
+          showCoordinates: x, i, 0
+          showFields:
+          - E
+          - B
+      orientation: 1
+      rightPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 1
+          scaleFactor: 50.0
+          showCoordinates: x, i, 4
+          showFields:
+          - E
+  orientation: 1
+  rightPanel:
+    dividerLocation: 499
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 4.0E10
+        showCoordinates: 64, y, x
+    orientation: 0
+    rightPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 400000.0
+        showCoordinates: 32, y, x
+  windowHeight: 1053
+  windowWidth: 1920
+

--- a/pixi/input/current/MV model/boost/MV_bi2.yaml
+++ b/pixi/input/current/MV model/boost/MV_bi2.yaml
@@ -4,9 +4,9 @@ couplingConstant: .2
 numberOfDimensions: 3
 numberOfColors: 2
 numberOfThreads: 8
-gridCells: [128, 32, 32]
-timeStep: 0.5
-duration: 64
+gridCells: [256, 32, 32]
+timeStep: 0.25
+duration: 128
 evaluationRegion:
   enabled: true
   point1: [2, 0, 0]
@@ -19,7 +19,7 @@ activeRegion:
 currents:
   dualMVModels:
     - direction: 0
-      longitudinalLocation: 32
+      longitudinalLocation: 40
       longitudinalWidth: 8
       mu: 0.3
       lowPassCoefficient: 0.05
@@ -34,7 +34,7 @@ output:
       startingTime: 0.0
       path: "planarOutput2.dat"
       direction: 0
-      planarIndex: 64
+      planarIndex: 128
 
 
 

--- a/pixi/input/current/MV model/boost/MV_bi3.yaml
+++ b/pixi/input/current/MV model/boost/MV_bi3.yaml
@@ -1,0 +1,90 @@
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: .2
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 8
+gridCells: [128, 32, 32]
+timeStep: 0.5
+duration: 64
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+currents:
+  dualMVModels:
+    - direction: 0
+      longitudinalLocation: 32
+      longitudinalWidth: 6
+      mu: 0.3
+      lowPassCoefficient: 0.05
+      randomSeed1: 3
+      randomSeed2: 4
+      createInitialConditionsOutput: true
+      outputFile: "planarInitial3.dat"
+
+output:
+  planarFields:
+    - interval: 1.0
+      startingTime: 0.0
+      path: "planarOutput3.dat"
+      direction: 0
+      planarIndex: 64
+
+
+
+# Generated panel code:
+panels:
+  dividerLocation: 800
+  leftPanel:
+    dividerLocation: 495
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 400000.0
+        showCoordinates: 96, y, x
+    orientation: 0
+    rightPanel:
+      dividerLocation: 394
+      leftPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 0
+          scaleFactor: 50.0
+          showCoordinates: x, i, 0
+          showFields:
+          - E
+          - B
+      orientation: 1
+      rightPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 1
+          scaleFactor: 50.0
+          showCoordinates: x, i, 4
+          showFields:
+          - E
+  orientation: 1
+  rightPanel:
+    dividerLocation: 499
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 4.0E10
+        showCoordinates: 64, y, x
+    orientation: 0
+    rightPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 400000.0
+        showCoordinates: 32, y, x
+  windowHeight: 1053
+  windowWidth: 1920
+

--- a/pixi/input/current/MV model/boost/MV_bi3.yaml
+++ b/pixi/input/current/MV model/boost/MV_bi3.yaml
@@ -4,9 +4,9 @@ couplingConstant: .2
 numberOfDimensions: 3
 numberOfColors: 2
 numberOfThreads: 8
-gridCells: [128, 32, 32]
-timeStep: 0.5
-duration: 64
+gridCells: [256, 32, 32]
+timeStep: 0.25
+duration: 128
 evaluationRegion:
   enabled: true
   point1: [2, 0, 0]
@@ -19,7 +19,7 @@ activeRegion:
 currents:
   dualMVModels:
     - direction: 0
-      longitudinalLocation: 32
+      longitudinalLocation: 40
       longitudinalWidth: 6
       mu: 0.3
       lowPassCoefficient: 0.05
@@ -34,7 +34,7 @@ output:
       startingTime: 0.0
       path: "planarOutput3.dat"
       direction: 0
-      planarIndex: 64
+      planarIndex: 128
 
 
 

--- a/pixi/input/current/MV model/boost/MV_bi4.yaml
+++ b/pixi/input/current/MV model/boost/MV_bi4.yaml
@@ -4,9 +4,9 @@ couplingConstant: .2
 numberOfDimensions: 3
 numberOfColors: 2
 numberOfThreads: 8
-gridCells: [128, 32, 32]
-timeStep: 0.5
-duration: 64
+gridCells: [256, 32, 32]
+timeStep: 0.25
+duration: 128
 evaluationRegion:
   enabled: true
   point1: [2, 0, 0]
@@ -19,7 +19,7 @@ activeRegion:
 currents:
   dualMVModels:
     - direction: 0
-      longitudinalLocation: 32
+      longitudinalLocation: 40
       longitudinalWidth: 4
       mu: 0.3
       lowPassCoefficient: 0.05
@@ -34,7 +34,7 @@ output:
       startingTime: 0.0
       path: "planarOutput4.dat"
       direction: 0
-      planarIndex: 64
+      planarIndex: 128
 
 
 

--- a/pixi/input/current/MV model/boost/MV_bi4.yaml
+++ b/pixi/input/current/MV model/boost/MV_bi4.yaml
@@ -1,0 +1,90 @@
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: .2
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 8
+gridCells: [128, 32, 32]
+timeStep: 0.5
+duration: 64
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+currents:
+  dualMVModels:
+    - direction: 0
+      longitudinalLocation: 32
+      longitudinalWidth: 4
+      mu: 0.3
+      lowPassCoefficient: 0.05
+      randomSeed1: 3
+      randomSeed2: 4
+      createInitialConditionsOutput: true
+      outputFile: "planarInitial4.dat"
+
+output:
+  planarFields:
+    - interval: 1.0
+      startingTime: 0.0
+      path: "planarOutput4.dat"
+      direction: 0
+      planarIndex: 64
+
+
+
+# Generated panel code:
+panels:
+  dividerLocation: 800
+  leftPanel:
+    dividerLocation: 495
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 400000.0
+        showCoordinates: 96, y, x
+    orientation: 0
+    rightPanel:
+      dividerLocation: 394
+      leftPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 0
+          scaleFactor: 50.0
+          showCoordinates: x, i, 0
+          showFields:
+          - E
+          - B
+      orientation: 1
+      rightPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 1
+          scaleFactor: 50.0
+          showCoordinates: x, i, 4
+          showFields:
+          - E
+  orientation: 1
+  rightPanel:
+    dividerLocation: 499
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 4.0E10
+        showCoordinates: 64, y, x
+    orientation: 0
+    rightPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 400000.0
+        showCoordinates: 32, y, x
+  windowHeight: 1053
+  windowWidth: 1920
+

--- a/pixi/input/current/MV model/boost/MV_bi5.yaml
+++ b/pixi/input/current/MV model/boost/MV_bi5.yaml
@@ -1,0 +1,90 @@
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: .2
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 8
+gridCells: [128, 32, 32]
+timeStep: 0.5
+duration: 64
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+currents:
+  dualMVModels:
+    - direction: 0
+      longitudinalLocation: 32
+      longitudinalWidth: 2
+      mu: 0.3
+      lowPassCoefficient: 0.05
+      randomSeed1: 3
+      randomSeed2: 4
+      createInitialConditionsOutput: true
+      outputFile: "planarInitial5.dat"
+
+output:
+  planarFields:
+    - interval: 1.0
+      startingTime: 0.0
+      path: "planarOutput5.dat"
+      direction: 0
+      planarIndex: 64
+
+
+
+# Generated panel code:
+panels:
+  dividerLocation: 800
+  leftPanel:
+    dividerLocation: 495
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 400000.0
+        showCoordinates: 96, y, x
+    orientation: 0
+    rightPanel:
+      dividerLocation: 394
+      leftPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 0
+          scaleFactor: 50.0
+          showCoordinates: x, i, 0
+          showFields:
+          - E
+          - B
+      orientation: 1
+      rightPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 1
+          scaleFactor: 50.0
+          showCoordinates: x, i, 4
+          showFields:
+          - E
+  orientation: 1
+  rightPanel:
+    dividerLocation: 499
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 4.0E10
+        showCoordinates: 64, y, x
+    orientation: 0
+    rightPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 400000.0
+        showCoordinates: 32, y, x
+  windowHeight: 1053
+  windowWidth: 1920
+

--- a/pixi/input/current/MV model/boost/MV_bi5.yaml
+++ b/pixi/input/current/MV model/boost/MV_bi5.yaml
@@ -4,9 +4,9 @@ couplingConstant: .2
 numberOfDimensions: 3
 numberOfColors: 2
 numberOfThreads: 8
-gridCells: [128, 32, 32]
-timeStep: 0.5
-duration: 64
+gridCells: [256, 32, 32]
+timeStep: 0.25
+duration: 128
 evaluationRegion:
   enabled: true
   point1: [2, 0, 0]
@@ -19,7 +19,7 @@ activeRegion:
 currents:
   dualMVModels:
     - direction: 0
-      longitudinalLocation: 32
+      longitudinalLocation: 40
       longitudinalWidth: 2
       mu: 0.3
       lowPassCoefficient: 0.05
@@ -34,7 +34,7 @@ output:
       startingTime: 0.0
       path: "planarOutput5.dat"
       direction: 0
-      planarIndex: 64
+      planarIndex: 128
 
 
 

--- a/pixi/scripts/vsc2 batch/coupling
+++ b/pixi/scripts/vsc2 batch/coupling
@@ -1,0 +1,57 @@
+%range 0 8%
+%jar pixi-0.6-SNAPSHOT.jar%
+
+%yaml begin%
+# run simulations with varying coupling constants and record fields in the transverse plane.
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: %f 0.1 2.0%
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 16
+gridCells: [512, 64, 64]
+timeStep: 0.5
+duration: 256.0
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+currents:
+  dualMVModels:
+    - direction: 0
+      longitudinalLocation: 64
+      longitudinalWidth: 4.0
+      mu: 0.04
+      lowPassCoefficient: 0.15
+      randomSeed1: 564
+      randomSeed2: 213
+      createInitialConditionsOutput: true
+      outputFile: "coupling/initial%i%.dat"
+
+output:
+  planarFields:
+    - interval: 1.0
+      startingTime: 176.0
+      path: "coupling/planar%i%.dat"
+      direction: 0
+      planarIndex: 255
+
+%yaml end%
+
+%qjob begin%
+#$ -N %job_name%
+#$ -pe mpich 16
+#$ -V
+#$ -M your.email@adre.ess
+#$ -m e
+#$ -l h_rt=1:00:00
+#$ -o ./tmp_output/
+#$ -e ./tmp_output/
+
+java -Xmx16384m -cp %jar_path% org.openpixi.pixi.ui.MainBatch %input_path%
+%qjob end%

--- a/pixi/scripts/vsc2 batch/coupling
+++ b/pixi/scripts/vsc2 batch/coupling
@@ -47,7 +47,7 @@ output:
 #$ -N %job_name%
 #$ -pe mpich 16
 #$ -V
-#$ -M your.email@adre.ess
+#$ -M your.email@addr.ess
 #$ -m e
 #$ -l h_rt=1:00:00
 #$ -o ./tmp_output/

--- a/pixi/scripts/vsc2 batch/openpixi_batch.py
+++ b/pixi/scripts/vsc2 batch/openpixi_batch.py
@@ -1,0 +1,257 @@
+"""
+        OPENPIXI SGE BATCH SCRIPT
+
+    This script creates a batch of yaml files and job files based on the template files and submits them using qsub.
+
+    Example usage:
+    Parse the input file 'pancakewidths', create yaml and qjob files in 'pancake_widths/' and submit them.
+        python openpixi_batch.py -cs -i pancakewidths -o pancakewidths_files/
+
+    Parse the input file 'coupling' and create yaml and qjob files in 'pancake_widths/'.
+        python openpixi_batch.py -cs -i coupling -o coupling_files/
+
+    Submit all *.qjob files in the 'jobs' folder.
+        python openpixi_batch.py -s -o jobs/
+
+    Options:
+    -c or --create: create YAML and qjob files based on the input file path and write them to output path.
+    -s or --submit: submit qjob files in the output path.
+    -i INPUT or --input=INPUT: read yaml and qjob templates from INPUT
+    -o OUTPUT or --output=OUTPUT: path where yaml and qjob are files are stored
+
+    NOTE: when script is called to create yaml and qjob files, all of the files in the output path are deleted.
+
+    Some options for YAML/QJOB templates:
+
+    1) Defining the integer range
+    The first line must define the integer range for the simulations.
+    %range BEGIN END%
+
+    Example:
+    %range 0 9% for 10 simulations with integers 0, 1, .., 9.
+
+    2) Define path to jar file
+    After the first line include the path to the jar-file.
+
+    Example:
+    %jar pixi-0.6-SNAPSHOT.jar% uses the jar-file pixi-0.6-SNAPSHOT.jar in the same directory as the input file.
+
+    3) Using integer from range
+    Use %i% to insert the integer from the given range.
+
+    Example:
+    Use "output%i%.dat" to get output files "output0.dat", "output1.dat", ..., "output9.dat" given the range above.
+
+    4) Float intervals
+    Use %f BEGIN END% to define a linear range of floating point numbers.
+
+    Example:
+    %f 0.0 0.9% to get the values 0.0, 0.1, ... 0.9 using the integer range above.
+
+"""
+
+import re
+import os
+import errno
+from optparse import OptionParser
+
+
+def main():
+    """Main function of the script. Checks for given arguments and does whatever is to be done."""
+
+    parser = OptionParser()
+    parser.add_option("-c", "--create", action="store_true", dest="create", default=False,
+                      help="create YAML and qjob files based on input file.")
+
+    parser.add_option("-s", "--submit", action="store_true", dest="submit", default=False,
+                      help="submit all *.qjob files in output path.")
+
+    parser.add_option("-i", "--input", action="store", type="string", dest="input", metavar="INPUT",
+                      help="path to input file (yaml and qjob template)")
+
+    parser.add_option("-o", "--output", action="store", type="string", dest="output", metavar="OUTPUT",
+                      help="output path (where yaml and qjob files will be stored)")
+
+    (options, args) = parser.parse_args()
+
+    input_path = options.input
+    output_path = options.output
+
+    if options.create:
+        if input_path is not None:
+            if output_path is not None:
+                create_files(input_path, output_path)
+            else:
+                print("Error: Output path not defined.")
+                exit(-1)
+        else:
+            print("Error: Input path not defined.")
+            exit(-1)
+
+    if options.submit:
+        if output_path is not None:
+            submit_qjobs(output_path)
+        else:
+            print("Error: Path to job files not defined.")
+            exit(-1)
+
+
+def empty_path(path):
+    """
+    Empties the temporary path.
+    This function is called before new yaml and qjob files are created.
+    :param path: path to folder
+    :return:
+    """
+    make_sure_path_exists(path)
+    for f in os.listdir(path):
+        if os.path.isfile(path + f):
+            os.remove(path + f)
+
+
+def submit_qjobs(o_path):
+    """
+    Submits all *.qjob files in the given path.
+    :param o_path: path to output files
+    :return:
+    """
+    from subprocess import call
+    if os.path.exists(o_path):
+        qjob_files = []
+        for f in os.listdir(o_path):
+            if f.endswith(".qjob"):
+                qjob_files.append(os.path.join(o_path, f))
+        for f in qjob_files:
+            try:
+                print("Submitting " + f)
+                call(["qsub", f])
+            except OSError:
+                print("Error: Can not call qsub command. Are you on a cluster?")
+                exit(-1)
+
+
+def create_files(i_path, o_path):
+    """
+    Creates yaml and qjob files based on given script.
+    :param i_path: path to input script
+    :param o_path: path for output files
+    :return:
+    """
+    script_string = open(i_path, "r").read()
+
+    # find and read integer range line (should be first line, but doesnt really matter.)
+    (b, e) = re.search("%range.*%", script_string).span()
+    (range_begin, range_end) = re.sub("%", "", re.sub("%range\s", "", script_string[b:e])).split(" ")
+    int_range = range(int(range_begin), int(range_end) + 1)
+    int_range_len = len(int_range)
+    script_string = script_string.replace(script_string[b:e], "")
+
+    # find and read jar path
+    (b, e) = re.search("%jar\s.*%", script_string).span()
+    jar_path = re.sub("%", "", re.sub("%jar\s", "", script_string[b:e]))
+
+    # parse yaml and qjob template
+    r1 = re.compile("%yaml begin%([\S\s]*)%yaml end%")
+    r2 = re.compile("%qjob begin%([\S\s]*)%qjob end%")
+    if not r1.search(script_string):
+        print("Found no proper YAML template in " + i_path)
+        exit(-1)
+    if not r2.search(script_string):
+        print("Found no proper QJOB template in " + i_path)
+        exit(-1)
+
+    yaml_template_string = r1.search(script_string).group(1)
+    qjob_template_string = r2.search(script_string).group(1)
+
+    # find float ranges
+    i = 0
+    float_ranges_limits = []
+    for float_line in re.finditer("%f\s.*%", yaml_template_string):
+        current_string = float_line.group()
+        yaml_template_string = yaml_template_string.replace(current_string, "%f" + str(i) + "%")
+        (float_begin, float_end) = re.sub("%", "", re.sub("%f\s", "", current_string)).split(" ")
+        float_ranges_limits.append((float(float_begin), float(float_end)))
+        i += 1
+
+    float_ranges = []
+    for fl in float_ranges_limits:
+        b = fl[0]
+        e = fl[1]
+        float_ranges.append(frange(b, e, int_range_len))
+
+    # generate yaml files in output folder
+    make_sure_path_exists(o_path)
+    c = 0
+    yaml_files = []
+    for i in int_range:
+        file_name = "tmp" + str(i) + ".yaml"
+        path = os.path.join(o_path, file_name)
+        file_object = open(path, "w")
+        yaml_files.append(file_name)
+        current_yaml_string = str(yaml_template_string)
+
+        # replace all integers
+        current_yaml_string = current_yaml_string.replace("%i%", str(i))
+
+        # replace all float float ranges
+        float_index = 0
+        for fr in float_ranges:
+            value = fr[c]
+            current_yaml_string = current_yaml_string.replace("%f" + str(float_index) + "%", str(value))
+            float_index += 1
+        c += 1
+
+        # write finished yaml string to file.
+        file_object.write(current_yaml_string)
+        file_object.close()
+
+    # create SGE job files for each yaml file based on template
+    qjob_files = []
+    c = 0
+    for yf in yaml_files:
+        qjob_file_name = yf.replace(".yaml", ".qjob")
+        job_id = yf.replace(".yaml", "")
+        job_name = "openpixi_b_" + job_id
+        qjob_files.append(qjob_file_name)
+        path = os.path.join(o_path, qjob_file_name)
+        file_object = open(path, "w")
+        current_qjob_string = str(qjob_template_string)
+        current_qjob_string = current_qjob_string.replace("%job_name%", job_name)
+        current_qjob_string = current_qjob_string.replace("%jar_path%", jar_path)
+        current_qjob_string = current_qjob_string.replace("%input_path%", o_path + yf)
+        file_object.write(current_qjob_string)
+        c += 1
+
+
+# utility functions
+def frange(start, end, num):
+    """
+    Simple range function for floats.
+    :param start: float at start of range
+    :param end: float at end of range
+    :param num: total number of floats in range
+    :return: range array with floats
+    """
+    """"""
+    r = []
+    d = (end - start) / (num - 1)
+    for k in range(0, num):
+        r.append(start + k * d)
+    return r
+
+
+def make_sure_path_exists(path):
+    """
+    Creates directory if needed.
+    :param path: path to directory
+    :return:
+    """
+    try:
+        os.makedirs(path)
+    except OSError as exception:
+        if exception.errno != errno.EEXIST:
+            raise
+
+
+if __name__ == "__main__":
+    main()

--- a/pixi/scripts/vsc2 batch/openpixi_batch.py
+++ b/pixi/scripts/vsc2 batch/openpixi_batch.py
@@ -105,8 +105,9 @@ def empty_path(path):
     """
     make_sure_path_exists(path)
     for f in os.listdir(path):
-        if os.path.isfile(path + f):
-            os.remove(path + f)
+        p = os.path.join(path, f)
+        if os.path.isfile(p):
+            os.remove(p)
 
 
 def submit_qjobs(o_path):
@@ -180,6 +181,7 @@ def create_files(i_path, o_path):
         float_ranges.append(frange(b, e, int_range_len))
 
     # generate yaml files in output folder
+    empty_path(o_path)
     make_sure_path_exists(o_path)
     c = 0
     yaml_files = []
@@ -218,7 +220,8 @@ def create_files(i_path, o_path):
         current_qjob_string = str(qjob_template_string)
         current_qjob_string = current_qjob_string.replace("%job_name%", job_name)
         current_qjob_string = current_qjob_string.replace("%jar_path%", jar_path)
-        current_qjob_string = current_qjob_string.replace("%input_path%", o_path + yf)
+        path = os.path.join(o_path, yf)
+        current_qjob_string = current_qjob_string.replace("%input_path%", path)
         file_object.write(current_qjob_string)
         c += 1
 
@@ -232,7 +235,6 @@ def frange(start, end, num):
     :param num: total number of floats in range
     :return: range array with floats
     """
-    """"""
     r = []
     d = (end - start) / (num - 1)
     for k in range(0, num):

--- a/pixi/scripts/vsc2 batch/openpixi_batch.py
+++ b/pixi/scripts/vsc2 batch/openpixi_batch.py
@@ -236,8 +236,8 @@ def frange(start, end, num):
     :return: range array with floats
     """
     r = []
-    d = (end - start) / (num - 1)
-    for k in range(0, num):
+    d = (end - start) / num
+    for k in range(0, num + 1):
         r.append(start + k * d)
     return r
 

--- a/pixi/scripts/vsc2 batch/openpixi_batch.py
+++ b/pixi/scripts/vsc2 batch/openpixi_batch.py
@@ -236,8 +236,8 @@ def frange(start, end, num):
     :return: range array with floats
     """
     r = []
-    d = (end - start) / num
-    for k in range(0, num + 1):
+    d = (end - start) / (num - 1)
+    for k in range(0, num):
         r.append(start + k * d)
     return r
 

--- a/pixi/scripts/vsc2 batch/pancakewidths
+++ b/pixi/scripts/vsc2 batch/pancakewidths
@@ -46,7 +46,7 @@ output:
 #$ -N %job_name%
 #$ -pe mpich 16
 #$ -V
-#$ -M your.email@adre.ess
+#$ -M your.email@addr.ess
 #$ -m e
 #$ -l h_rt=1:00:00
 #$ -o ./tmp_output/

--- a/pixi/scripts/vsc2 batch/pancakewidths
+++ b/pixi/scripts/vsc2 batch/pancakewidths
@@ -1,0 +1,56 @@
+%range 0 20%
+%jar pixi-0.6-SNAPSHOT.jar%
+
+%yaml begin%
+# run simulations with varying longitudinal widths and record fields in the transverse plane.
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: 2
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 16
+gridCells: [512, 64, 64]
+timeStep: 0.5
+duration: 256.0
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+currents:
+  dualMVModels:
+    - direction: 0
+      longitudinalLocation: 64
+      longitudinalWidth: %f 2.0 12.0%
+      mu: 0.04
+      lowPassCoefficient: 0.15
+      randomSeed1: 564
+      randomSeed2: 213
+      createInitialConditionsOutput: true
+      outputFile: "widths/initial%i%.dat"
+
+output:
+  planarFields:
+    - interval: 1.0
+      startingTime: 176.0
+      path: "widths/planar%i%.dat"
+      direction: 0
+      planarIndex: 255
+%yaml end%
+
+%qjob begin%
+#$ -N %job_name%
+#$ -pe mpich 16
+#$ -V
+#$ -M your.email@adre.ess
+#$ -m e
+#$ -l h_rt=1:00:00
+#$ -o ./tmp_output/
+#$ -e ./tmp_output/
+
+java -Xmx16384m -cp %jar_path% org.openpixi.pixi.ui.MainBatch %input_path%
+%qjob end%

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/FileFunctions.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/FileFunctions.java
@@ -1,0 +1,40 @@
+package org.openpixi.pixi.diagnostics;
+
+import java.io.File;
+
+public class FileFunctions {
+
+	/**
+	 * Returns a File instance for a given path. Directories are created if they do not exist yet.
+	 *
+	 * @param path String with path or filename
+	 * @return     File instance
+	 */
+	public static File getFile(String path) {
+		File file = new File(path);
+		File folder = file.getParentFile();
+		if(!folder.exists()) {
+			boolean result = folder.mkdirs();
+			if(!result) {
+				System.out.println("FileFunctions: Error creating path for file " + path);
+			}
+		}
+		return file;
+	}
+
+	/**
+	 * Clear a file if it already exists.
+	 *
+	 * @param path String with path or filename
+	 */
+	public static void clearFile(String path) {
+		File file = new File(path);
+		if(file.exists()) {
+			boolean result = file.delete();
+			if(!result) {
+				System.out.println("FileFunctions: Error deleting file " + path);
+			}
+		}
+	}
+
+}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/BulkQuantitiesInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/BulkQuantitiesInTime.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.Locale;
 
 import org.openpixi.pixi.diagnostics.Diagnostics;
+import org.openpixi.pixi.diagnostics.FileFunctions;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.grid.Grid;
 import org.openpixi.pixi.physics.particles.IParticle;
@@ -55,10 +56,10 @@ public class BulkQuantitiesInTime implements Diagnostics {
 
 		if(!supressOutput) {
 			// Create/delete file.
-			clear();
+			FileFunctions.clearFile("output/" + path);
 
 			// Write first line.
-			File file = getOutputFile(path);
+			File file = FileFunctions.getFile("output/" + path);
 			try {
 				FileWriter pw = new FileWriter(file, true);
 				pw.write("#time \t E^2 \t B^2 \t P_x \t P_y \t P_z \t G");
@@ -97,7 +98,7 @@ public class BulkQuantitiesInTime implements Diagnostics {
 			gaussViolation = fieldMeasurements.calculateGaussConstraint(grid);
 
 			if(!supressOutput) {
-				File file = getOutputFile(path);
+				File file = FileFunctions.getFile("output/" + path);
 				FileWriter pw = new FileWriter(file, true);
 				DecimalFormat formatter = new DecimalFormat("0.################E0");
 
@@ -114,30 +115,5 @@ public class BulkQuantitiesInTime implements Diagnostics {
 			}
 			
 		}
-	}
-
-	/**
-	 * 	Checks if the files are already existent and deletes them
-	 */
-	public void clear() {
-		File particlesfile = getOutputFile(path);
-		boolean fileExists1 = particlesfile.exists();
-		if(fileExists1 == true) {
-			particlesfile.delete();
-		}
-	}
-
-	/**
-	 * Creates a file with a given name in the output folder.
-	 * @param filename	Filename of the output file.
-	 * @return			File object of the opened file.
-	 */
-	private File getOutputFile(String filename) {
-		// Default output path is
-		// 'output/' + filename
-		File fullpath = new File("output");
-		if(!fullpath.exists()) fullpath.mkdir();
-
-		return new File(fullpath, filename);
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -1,6 +1,7 @@
 package org.openpixi.pixi.diagnostics.methods;
 
 import org.openpixi.pixi.diagnostics.Diagnostics;
+import org.openpixi.pixi.diagnostics.FileFunctions;
 import org.openpixi.pixi.math.AlgebraElement;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.gauge.CoulombGauge;
@@ -61,7 +62,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 		this.outputFileName = filename;
 		this.colorful = colorful;
 
-		this.clear(filename);
+		FileFunctions.clearFile("output/" + outputFileName);
 
 		if (!Arrays.asList(supportedOutputTypes).contains(outputType)) {
 			System.out.print("OccupationNumbersInTime: unsupported output type. Allowed types are ");
@@ -291,7 +292,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 	 * @param path	Path to output file
 	 */
 	public void writeHeader(String path) {
-		File file = this.getOutputFile(path);
+		File file = FileFunctions.getFile("output/" + path);
 
 		try {
 			FileWriter pw = new FileWriter(file, true);
@@ -319,7 +320,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 	 * @param path	Path to the output file
 	 */
 	private void writeMomentumVectors(String path) {
-		File file = this.getOutputFile(path);
+		File file = FileFunctions.getFile("output/" + path);
 		try {
 			FileWriter pw = new FileWriter(file, true);
 			for(int i = 0; i < s.grid.getTotalNumberOfCells(); i++) {
@@ -357,7 +358,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 	 */
 	private void writeCSVFile(String path, boolean includeOccupationNumbers)
 	{
-		File file = this.getOutputFile(path);
+		File file = FileFunctions.getFile("output/" + path);
 		try {
 			FileWriter pw = new FileWriter(file, true);
 			pw.write(this.generateCSVString(includeOccupationNumbers));
@@ -407,30 +408,6 @@ public class OccupationNumbersInTime implements Diagnostics {
 			}
 		}
 		return outputStringBuilder.toString();
-	}
-
-	/**
-	 * 	Checks if the files are already existent and deletes them
-	 */
-	public void clear(String path) {
-		File file = getOutputFile(path);
-		if(file.exists()) {
-			file.delete();
-		}
-	}
-
-	/**
-	 * Creates a file with a given name in the output folder.
-	 * @param filename	Filename of the output file.
-	 * @return			File object of the opened file.
-	 */
-	private File getOutputFile(String filename) {
-		// Default output path is
-		// 'output/' + filename
-		File fullpath = new File("output");
-		if(!fullpath.exists()) fullpath.mkdir();
-
-		return new File(fullpath, filename);
 	}
 
 	/**

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ParticlesInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ParticlesInTime.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.io.IOException;
 
 import org.openpixi.pixi.diagnostics.Diagnostics;
+import org.openpixi.pixi.diagnostics.FileFunctions;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.grid.Grid;
 import org.openpixi.pixi.physics.particles.IParticle;
@@ -35,11 +36,11 @@ public class ParticlesInTime implements Diagnostics {
 		stepInterval =  (int) (this.timeInterval / s.getTimeStep());
 
 		// Create/delete file.
-		clear();
+		FileFunctions.clearFile("output/" + path);
 
 		// Write first line.
 		String[] directionNames = new String[] {"x", "y", "z"};
-		File file = getOutputFile(path);
+		File file = FileFunctions.getFile("output/" + path);
 		try {
 			FileWriter pw = new FileWriter(file, true);
 			pw.write("#time\t");
@@ -76,7 +77,7 @@ public class ParticlesInTime implements Diagnostics {
 	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps) throws IOException {
 		if(steps % stepInterval == 0) {
 
-			File file = getOutputFile(path);
+			File file = FileFunctions.getFile("output/" + path);;
 			FileWriter pw = new FileWriter(file, true);
 			pw.write(steps * s.getTimeStep() + "\t");
 
@@ -98,24 +99,5 @@ public class ParticlesInTime implements Diagnostics {
 			pw.write("\n");
 			pw.close();
 		}
-	}
-	
-	/** Checks if the files are already existent and deletes them*/
-	public void clear() {
-		File particlesfile = getOutputFile(path);
-		boolean fileExists1 = particlesfile.exists();
-		if(fileExists1 == true) {
-			particlesfile.delete();
-		}
-	}
-	
-	/** Creates a file with a given name in the output folder*/
-	private File getOutputFile(String filename) {
-		// Default output path is
-		// 'output/' + filename
-		File fullpath = new File("output");
-		if(!fullpath.exists()) fullpath.mkdir();
-
-		return new File(fullpath, filename);
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
@@ -61,7 +61,7 @@ public class PlanarFields implements Diagnostics {
 		if(steps > startingStep) {
 			if (steps % stepInterval == 0) {
 				// do stuff
-
+				double normalizationFactor = 1.0 / s.getCouplingConstant() * grid.getLatticeSpacing();
 				AlgebraElement[][]  transverseGaugeFields = new AlgebraElement[effDimensions][totalTransCells];
 				AlgebraElement[]  longitudinalElectricFields = new AlgebraElement[totalTransCells];
 				for (int i = 0; i < totalTransCells; i++) {
@@ -71,9 +71,9 @@ public class PlanarFields implements Diagnostics {
 					int ts = 0;
 					for (int j = 0; j < effDimensions; j++) {
 						if(j == direction) {
-							longitudinalElectricFields[i] = grid.getE(cellIndex, j);
+							longitudinalElectricFields[i] = grid.getE(cellIndex, j).mult(normalizationFactor);
 						} else {
-							transverseGaugeFields[ts][i] = grid.getLink(cellIndex, j, 1, 0).getAlgebraElement();
+							transverseGaugeFields[ts][i] = grid.getLink(cellIndex, j, 1, 0).getAlgebraElement().mult(normalizationFactor);
 							ts++;
 						}
 					}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
@@ -1,6 +1,7 @@
 package org.openpixi.pixi.diagnostics.methods;
 
 import org.openpixi.pixi.diagnostics.Diagnostics;
+import org.openpixi.pixi.diagnostics.FileFunctions;
 import org.openpixi.pixi.math.AlgebraElement;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.grid.Grid;
@@ -45,7 +46,7 @@ public class PlanarFields implements Diagnostics {
 	}
 
 	public void initialize(Simulation s) {
-		clear();
+		FileFunctions.clearFile("output/" + outputName);
 
 		this.s = s;
 		this.transNumCells = GridFunctions.reduceGridPos(s.grid.getNumCells(), direction);
@@ -82,7 +83,7 @@ public class PlanarFields implements Diagnostics {
 					}
 				}
 
-				File file = this.getOutputFile(outputName);
+				File file = FileFunctions.getFile("output/" + outputName);
 				try {
 					FileWriter pw = new FileWriter(file, true);
 
@@ -108,31 +109,6 @@ public class PlanarFields implements Diagnostics {
 				}
 
 			}
-		}
-	}
-
-	/**
-	 * Creates a file with a given name in the output folder.
-	 * @param filename	Filename of the output file.
-	 * @return			File object of the opened file.
-	 */
-	private File getOutputFile(String filename) {
-		// Default output path is
-		// 'output/' + filename
-		File fullpath = new File("output");
-		if(!fullpath.exists()) fullpath.mkdir();
-
-		return new File(fullpath, filename);
-	}
-
-	/**
-	 * 	Checks if the files are already existent and deletes them
-	 */
-	private void clear() {
-		File file = getOutputFile(outputName);
-		boolean fileExists1 = file.exists();
-		if(fileExists1 == true) {
-			file.delete();
 		}
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
@@ -20,6 +20,8 @@ public class PlanarFields implements Diagnostics {
 	private String outputName;
 	private double startingTime;
 	private int startingStep;
+	private double finalTime;
+	private int finalStep;
 
 	private int direction;
 	private int planarIndex;
@@ -32,13 +34,13 @@ public class PlanarFields implements Diagnostics {
 	private Simulation s;
 	private int numberOfComponents;
 
-	public PlanarFields(double timeInterval, String outputName, double startingTime, int direction, int planarIndex) {
+	public PlanarFields(double timeInterval, String outputName, double startingTime, double finalTime, int direction, int planarIndex) {
 		this.timeInterval = timeInterval;
 		this.outputName = outputName;
 		this.startingTime =  startingTime;
+		this.finalTime = finalTime;
 		this.direction = direction;
 		this.planarIndex = planarIndex;
-
 
 	}
 
@@ -51,6 +53,7 @@ public class PlanarFields implements Diagnostics {
 
 		this.stepInterval = (int) (timeInterval / s.getTimeStep());
 		this.startingStep = (int) (startingTime / s.getTimeStep());
+		this.finalStep = (int) (finalTime / s.getTimeStep());
 		this.effDimensions = GridFunctions.getEffectiveNumberOfDimensions(s.grid.getNumCells());
 
 		this.numberOfComponents = s.grid.getElementFactory().numberOfComponents;
@@ -58,7 +61,7 @@ public class PlanarFields implements Diagnostics {
 
 
 	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps) throws IOException {
-		if(steps > startingStep) {
+		if(steps > startingStep && steps < finalStep) {
 			if (steps % stepInterval == 0) {
 				// do stuff
 				double normalizationFactor = 1.0 / s.getCouplingConstant() * grid.getLatticeSpacing();

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
@@ -83,7 +83,7 @@ public class PlanarFields implements Diagnostics {
 				try {
 					FileWriter pw = new FileWriter(file, true);
 
-					pw.write(s.getIterations() + "\t" + s.getIterations() * s.getTimeStep() + "\n");
+					//pw.write(s.getIterations() + "\t" + s.getIterations() * s.getTimeStep() + "\n");
 
 					// Transverse fields
 					for (int i = 0; i < effDimensions-1; i++) {

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
@@ -1,6 +1,7 @@
 package org.openpixi.pixi.diagnostics.methods;
 
 import org.openpixi.pixi.diagnostics.Diagnostics;
+import org.openpixi.pixi.diagnostics.FileFunctions;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.grid.Grid;
 import org.openpixi.pixi.physics.particles.IParticle;
@@ -55,7 +56,7 @@ public class ProjectedEnergyDensity implements Diagnostics {
 		numberOfCells = s.grid.getNumCells(direction);
 		this.stepInterval = (int) (timeInterval / s.getTimeStep());
 
-		clear();
+		FileFunctions.clearFile("output/" + path);
 	}
 
 	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps) throws IOException {
@@ -103,7 +104,7 @@ public class ProjectedEnergyDensity implements Diagnostics {
 			}
 
 			// Write to file
-			File file = this.getOutputFile(path);
+			File file = FileFunctions.getFile("output/" + path);
 			try {
 				FileWriter pw = new FileWriter(file, true);
 				Double time = steps * grid.getTemporalSpacing();
@@ -116,31 +117,6 @@ public class ProjectedEnergyDensity implements Diagnostics {
 			} catch (IOException ex) {
 				System.out.println("ProjectedEnergyDensity: Error writing to file.");
 			}
-		}
-	}
-
-	/**
-	 * Creates a file with a given name in the output folder.
-	 * @param filename	Filename of the output file.
-	 * @return			File object of the opened file.
-	 */
-	private File getOutputFile(String filename) {
-		// Default output path is
-		// 'output/' + filename
-		File fullpath = new File("output");
-		if(!fullpath.exists()) fullpath.mkdir();
-
-		return new File(fullpath, filename);
-	}
-
-	/**
-	 * 	Checks if the files are already existent and deletes them
-	 */
-	public void clear() {
-		File particlesfile = getOutputFile(path);
-		boolean fileExists1 = particlesfile.exists();
-		if(fileExists1 == true) {
-			particlesfile.delete();
 		}
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
@@ -14,6 +14,7 @@ import javax.media.opengl.GLDrawableFactory;
 import javax.media.opengl.GLProfile;
 
 import org.openpixi.pixi.diagnostics.Diagnostics;
+import org.openpixi.pixi.diagnostics.FileFunctions;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.grid.Grid;
 import org.openpixi.pixi.physics.particles.IParticle;
@@ -114,7 +115,7 @@ public class ScreenshotInTime implements Diagnostics {
 				int counter = steps / stepInterval;
 				String counterString = String.format("%05d", counter);
 				String pathWithNumber = path.replace("{counter}", counterString);
-				File file = getOutputFile(pathWithNumber);
+				File file = FileFunctions.getFile("output/" + pathWithNumber);
 				ImageIO.write(im, "png", file);
 			}
 		}
@@ -125,16 +126,6 @@ public class ScreenshotInTime implements Diagnostics {
 			// Create movie using e.g.
 			// ffmpeg -r 25 -sameq -i img-%05d.png test_1.mov
 		}
-	}
-
-	/** Creates a file with a given name in the output folder*/
-	private File getOutputFile(String filename) {
-		// Default output path is
-		// 'output/' + filename
-		File fullpath = new File("output");
-		if(!fullpath.exists()) fullpath.mkdir();
-
-		return new File(fullpath, filename);
 	}
 
 	class SimulationAnimationDummy extends SimulationAnimation {

--- a/pixi/src/main/java/org/openpixi/pixi/math/SU2GroupElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/SU2GroupElement.java
@@ -244,8 +244,7 @@ public class SU2GroupElement implements GroupElement {
 	public SU2GroupElement inv() {
 		double n = computeParameterNorm();
 		SU2GroupElement v = (SU2GroupElement) this.adj();
-		v.mult(1.0/n);
 
-		return v;
+		return (SU2GroupElement) v.mult(1.0/n);
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/math/SU2GroupElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/SU2GroupElement.java
@@ -236,4 +236,16 @@ public class SU2GroupElement implements GroupElement {
 	public GroupElement copy() {
 		return new SU2GroupElement(e[0], e[1], e[2], e[3]);
 	}
+
+	/**
+	 * Computes the inverse matrix.
+	 * @return inverse matrix
+	 */
+	public SU2GroupElement inv() {
+		double n = computeParameterNorm();
+		SU2GroupElement v = (SU2GroupElement) this.adj();
+		v.mult(1.0/n);
+
+		return v;
+	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
@@ -206,6 +206,11 @@ public class NewLCPoissonSolver {
 		return phi[transversalIndex].mult(- g).getLink();
 	}
 
+	public GroupElement getU(int transversalIndex, int direction) {
+		int shiftedIndex = GridFunctions.shift(transversalIndex, direction, 1 , transversalNumCells);
+		return getV(transversalIndex).mult(getV(shiftedIndex).adj());
+	}
+
 	private double integratedShapeFunction(double z, double t, int o, double width) {
 
 		double arg = (t - o*z)/(width*Math.sqrt(2));

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
@@ -76,7 +76,7 @@ public class NewLCPoissonSolver {
 
 		// UV Regulator
 		double psqrMax = 4.0 * effTransversalDimensions / (as * as);
-		double lambda = 1.0;
+		double lambda = 0.05;
 
 		// First step: compute transversal potential phi
 		for (int i = 0; i < factory.numberOfComponents; i++) {
@@ -197,6 +197,10 @@ public class NewLCPoissonSolver {
 		double z = longitudinalPosition - location;
 		double shape = integratedShapeFunction(z, t, orientation, longitudinalWidth);
 		return phi[transversalIndex].mult(- shape * g).getLink();
+	}
+
+	public GroupElement getV(int transversalIndex) {
+		return phi[transversalIndex].mult(- g).getLink();
 	}
 
 	private double integratedShapeFunction(double z, double t, int o, double width) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
@@ -31,6 +31,9 @@ public class NewLCPoissonSolver {
 	private double at;
 	private double g;
 
+	public double infraredRegulator = 0.0;
+	public double lowPassCoefficient = 1.0;
+
 	private ElementFactory factory;
 	private Simulation s;
 
@@ -72,11 +75,11 @@ public class NewLCPoissonSolver {
 		DoubleFFTWrapper fft = new DoubleFFTWrapper(transversalNumCells);
 
 		// IR Regulator
-		double m = 0.0;
+		double m = infraredRegulator;
 
 		// UV Regulator
 		double psqrMax = 4.0 * effTransversalDimensions / (as * as);
-		double lambda = 0.05;
+		double lambda = lowPassCoefficient;
 
 		// First step: compute transversal potential phi
 		for (int i = 0; i < factory.numberOfComponents; i++) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
@@ -143,8 +143,8 @@ public class DualMVModel implements ICurrentGenerator {
 
 						int is_b = GridFunctions.shift(i, ts, -1, transNumCells);
 						SU2GroupElement Um2 = (SU2GroupElement) transverseLinks[ts][is_b].adj().sub(identity);
-						SU2GroupElement U3 = (SU2GroupElement) ps1.getV(i).mult(ps1.getV(is_b).adj());
-						SU2GroupElement U4 = (SU2GroupElement) ps2.getV(i).mult(ps2.getV(is_b).adj());
+						SU2GroupElement U3 = (SU2GroupElement) ps1.getV(is_b).mult(ps1.getV(i).adj());
+						SU2GroupElement U4 = (SU2GroupElement) ps2.getV(is_b).mult(ps2.getV(i).adj());
 						SU2GroupElement diff2 = (SU2GroupElement) U4.sub(U3);
 
 						temp.addAssign(Um1.mult(diff1).add(Um2.mult(diff2)));

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
@@ -55,12 +55,19 @@ public class DualMVModel implements ICurrentGenerator {
 	private String outputFile;
 	private boolean createInitialConditionsOutput;
 
+	/**
+	 * Option whether to use the \mu^2 (true) or the g^2 \mu^2 (false) normalization for the Gaussian
+	 * probability distribution of the color charge densities.
+	 */
+	private boolean useAlternativeNormalization;
+
 	private MVModel mv1;
 	private MVModel mv2;
 
 
 	public DualMVModel(int direction, double location, double longitudinalWidth, double mu, double lowPassCoefficient,
-					   boolean useSeed, int seed1, int seed2, boolean createInitialConditionsOutput, String outputFile){
+					   boolean useSeed, int seed1, int seed2, boolean createInitialConditionsOutput, String outputFile,
+					   boolean useAlternativeNormalization){
 		this.direction = direction;
 		this.location = location;
 		this.longitudinalWidth = longitudinalWidth;
@@ -73,15 +80,17 @@ public class DualMVModel implements ICurrentGenerator {
 
 		this.createInitialConditionsOutput = createInitialConditionsOutput;
 		this.outputFile = outputFile;
+
+		this.useAlternativeNormalization = useAlternativeNormalization;
 	}
 
 	public void initializeCurrent(Simulation s, int totalInstances) {
 		if(useSeed){
-			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, seed1, lowPassCoefficient);
-			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu, seed2, lowPassCoefficient);
+			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, seed1, lowPassCoefficient, useAlternativeNormalization);
+			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu, seed2, lowPassCoefficient, useAlternativeNormalization);
 		} else {
-			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, lowPassCoefficient);
-			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu, lowPassCoefficient);
+			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, lowPassCoefficient, useAlternativeNormalization);
+			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu, lowPassCoefficient, useAlternativeNormalization);
 		}
 
 		mv1.initializeCurrent(s, totalInstances);

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
@@ -42,6 +42,12 @@ public class DualMVModel implements ICurrentGenerator {
 	private int seed1;
 	private int seed2;
 
+
+	/**
+	 * Low pass filter for the Poisson solver.
+	 */
+	private double lowPassCoefficient;
+
 	/**
 	 * Initial condition output
 	 */
@@ -52,12 +58,13 @@ public class DualMVModel implements ICurrentGenerator {
 	private MVModel mv2;
 
 
-	public DualMVModel(int direction, double location, double longitudinalWidth, double mu,
+	public DualMVModel(int direction, double location, double longitudinalWidth, double mu, double lowPassCoefficient,
 					   boolean useSeed, int seed1, int seed2, boolean createInitialConditionsOutput, String outputFile){
 		this.direction = direction;
 		this.location = location;
 		this.longitudinalWidth = longitudinalWidth;
 		this.mu = mu;
+		this.lowPassCoefficient = lowPassCoefficient;
 
 		this.useSeed = useSeed;
 		this.seed1 = seed1;
@@ -69,11 +76,11 @@ public class DualMVModel implements ICurrentGenerator {
 
 	public void initializeCurrent(Simulation s, int totalInstances) {
 		if(useSeed){
-			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, seed1);
-			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu, seed2);
+			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, seed1, lowPassCoefficient);
+			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu, seed2, lowPassCoefficient);
 		} else {
-			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu);
-			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu);
+			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, lowPassCoefficient);
+			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu, lowPassCoefficient);
 		}
 
 		mv1.initializeCurrent(s, totalInstances);

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
@@ -132,7 +132,7 @@ public class DualMVModel implements ICurrentGenerator {
 			// Compute longitudinal fields
 			for (int i = 0; i < transverseNumberOfCells; i++) {
 				SU2GroupElement temp = (SU2GroupElement) zero.copy();
-				SU2AlgebraElement temp2 = (SU2AlgebraElement) s.grid.getElementFactory().algebraZero(2);
+				//SU2AlgebraElement temp2 = (SU2AlgebraElement) s.grid.getElementFactory().algebraZero(2);
 
 				int ts = 0;
 				for (int j = 0; j < effDimensions; j++) {
@@ -154,7 +154,7 @@ public class DualMVModel implements ICurrentGenerator {
 						temp.addAssign(Um1.mult(diff1).add(Um2.mult(diff2)));
 						*/
 
-						/*
+
 						// Lattice calculation 2
 						int is = GridFunctions.shift(i, ts, -1, transNumCells);
 						SU2GroupElement Um1 = (SU2GroupElement) transverseLinks[ts][i].adj().sub(identity);
@@ -162,18 +162,20 @@ public class DualMVModel implements ICurrentGenerator {
 						SU2GroupElement Um2 = (SU2GroupElement) transverseLinks[ts][is].adj().sub(identity);
 						SU2GroupElement diff2 = (SU2GroupElement) ps1.getU(is, ts).sub(ps2.getU(is, ts));
 						temp.addAssign(diff1.mult(Um1).sub(Um2.mult(diff2)));
-						*/
+
 
 						// Continuum calculation
+						/*
 						SU2AlgebraElement A1 = (SU2AlgebraElement) ps1.getU(i, ts).getAlgebraElement().mult(normalizationFactor);
 						SU2AlgebraElement A2 = (SU2AlgebraElement) ps2.getU(i, ts).getAlgebraElement().mult(normalizationFactor);
 						temp2.addAssign(comm(A1,A2));
+						*/
 						ts++;
 					}
 				}
 
 				longitudinalFields[i] = (SU2AlgebraElement) temp.proj().mult(normalizationFactor / (2.0 * g));
-				longitudinalFields[i] = temp2;
+				//longitudinalFields[i] = temp2;
 			}
 
 			// File output ((d-1)x3 transversal gauge field components, 1x3 longitudinal electric field component)

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
@@ -91,6 +91,7 @@ public class DualMVModel implements ICurrentGenerator {
 		// Compute boost-invariant initial conditions. Note: this only works for SU2.
 		if(createInitialConditionsOutput && s.getNumberOfColors() == 2) {
 
+			double normalizationFactor = 1.0 / s.getCouplingConstant() * s.grid.getLatticeSpacing();
 			int[] transNumCells = GridFunctions.reduceGridPos(s.grid.getNumCells(), direction);
 			int transverseNumberOfCells = GridFunctions.getTotalNumberOfCells(transNumCells);
 			int effDimensions = GridFunctions.getEffectiveNumberOfDimensions(s.grid.getNumCells());
@@ -122,7 +123,7 @@ public class DualMVModel implements ICurrentGenerator {
 						SU2GroupElement sumInv = ((SU2GroupElement) sum.adj()).inv();
 
 						transverseLinks[ts][i] = (SU2GroupElement) sum.mult(sumInv);
-						transverseFields[ts][i] = (SU2AlgebraElement) transverseLinks[ts][i].getAlgebraElement();
+						transverseFields[ts][i] = (SU2AlgebraElement) transverseLinks[ts][i].getAlgebraElement().mult(normalizationFactor);
 						ts++;
 					}
 				}
@@ -152,7 +153,7 @@ public class DualMVModel implements ICurrentGenerator {
 					}
 				}
 
-				longitudinalFields[i] = (SU2AlgebraElement) temp.proj().mult(1.0 / (2.0 * g));
+				longitudinalFields[i] = (SU2AlgebraElement) temp.proj().mult(normalizationFactor / (2.0 * g));
 			}
 
 			// File output ((d-1)x3 transversal gauge field components, 1x3 longitudinal electric field component)

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
@@ -1,0 +1,231 @@
+package org.openpixi.pixi.physics.fields.currentgenerators;
+
+import org.openpixi.pixi.math.AlgebraElement;
+import org.openpixi.pixi.math.GroupElement;
+import org.openpixi.pixi.math.SU2AlgebraElement;
+import org.openpixi.pixi.math.SU2GroupElement;
+import org.openpixi.pixi.physics.Simulation;
+import org.openpixi.pixi.physics.fields.NewLCPoissonSolver;
+import org.openpixi.pixi.physics.util.GridFunctions;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.DecimalFormat;
+
+public class DualMVModel implements ICurrentGenerator {
+
+	/**
+	 * Direction of movement of the charge density. Values range from 0 to numberOfDimensions-1.
+	 */
+	private int direction;
+
+	/**
+	 * Longitudinal location of the initial charge density in the simulation box.
+	 */
+	private double location;
+
+	/**
+	 * Longitudinal width of the charge density.
+	 */
+	private double longitudinalWidth;
+
+	/**
+	 * \mu parameter of the MV model.
+	 */
+	private double mu;
+
+	/**
+	 * Seed for the random variables.
+	 */
+	private boolean useSeed = false;
+	private int seed1;
+	private int seed2;
+
+	/**
+	 * Initial condition output
+	 */
+	private String outputFile;
+	private boolean createInitialConditionsOutput;
+
+	private MVModel mv1;
+	private MVModel mv2;
+
+
+	public DualMVModel(int direction, double location, double longitudinalWidth, double mu,
+					   boolean useSeed, int seed1, int seed2, boolean createInitialConditionsOutput, String outputFile){
+		this.direction = direction;
+		this.location = location;
+		this.longitudinalWidth = longitudinalWidth;
+		this.mu = mu;
+
+		this.useSeed = useSeed;
+		this.seed1 = seed1;
+		this.seed2 = seed2;
+
+		this.createInitialConditionsOutput = createInitialConditionsOutput;
+		this.outputFile = outputFile;
+	}
+
+	public void initializeCurrent(Simulation s, int totalInstances) {
+		if(useSeed){
+			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, seed1);
+			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu, seed2);
+		} else {
+			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu);
+			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu);
+		}
+
+		mv1.initializeCurrent(s, totalInstances);
+		mv2.initializeCurrent(s, totalInstances);
+
+		double g = s.getCouplingConstant();
+
+		// Compute boost-invariant initial conditions. Note: this only works for SU2.
+		if(createInitialConditionsOutput && s.getNumberOfColors() == 2) {
+
+			int[] transNumCells = GridFunctions.reduceGridPos(s.grid.getNumCells(), direction);
+			int transverseNumberOfCells = GridFunctions.getTotalNumberOfCells(transNumCells);
+			int effDimensions = GridFunctions.getEffectiveNumberOfDimensions(s.grid.getNumCells());
+
+			GroupElement zero = (SU2GroupElement) s.grid.getElementFactory().groupZero(2);
+			GroupElement identity = (SU2GroupElement) s.grid.getElementFactory().groupIdentity(2);
+
+			// Transverse links
+			SU2GroupElement[][] transverseLinks = new SU2GroupElement[effDimensions - 1][transverseNumberOfCells];
+			SU2AlgebraElement[][] transverseFields = new SU2AlgebraElement[effDimensions - 1][transverseNumberOfCells];
+
+			// Longitudinal E-Fields
+			SU2AlgebraElement[] longitudinalFields = new SU2AlgebraElement[transverseNumberOfCells];
+
+			NewLCPoissonSolver ps1 = mv1.particleLCCurrent.poissonSolver;
+			NewLCPoissonSolver ps2 = mv2.particleLCCurrent.poissonSolver;
+
+			// Compute transverse link elements
+			for (int i = 0; i < transverseNumberOfCells; i++) {
+				int ts = 0;
+				for (int j = 0; j < effDimensions; j++) {
+					if(j != direction) {
+						// Compute initial condition for transverse fields
+						int is = GridFunctions.shift(i, ts, 1, transNumCells);
+						SU2GroupElement U1 = (SU2GroupElement) ps1.getV(i).mult(ps1.getV(is).adj());
+						SU2GroupElement U2 = (SU2GroupElement) ps2.getV(i).mult(ps2.getV(is).adj());
+
+						SU2GroupElement sum = (SU2GroupElement) U1.add(U2);
+						SU2GroupElement sumInv = ((SU2GroupElement) sum.adj()).inv();
+
+						transverseLinks[ts][i] = (SU2GroupElement) sum.mult(sumInv);
+						transverseFields[ts][i] = (SU2AlgebraElement) transverseLinks[ts][i].getAlgebraElement();
+						ts++;
+					}
+				}
+			}
+
+			// Compute longitudinal fields
+			for (int i = 0; i < transverseNumberOfCells; i++) {
+				SU2GroupElement temp = (SU2GroupElement) zero.copy();
+
+				int ts = 0;
+				for (int j = 0; j < effDimensions; j++) {
+					if(j != direction) {
+						int is_a = GridFunctions.shift(i, ts, 1, transNumCells);
+						SU2GroupElement Um1 = (SU2GroupElement) transverseLinks[ts][i].sub(identity);
+						SU2GroupElement U1 = (SU2GroupElement) ps1.getV(i).mult(ps1.getV(is_a).adj());
+						SU2GroupElement U2 = (SU2GroupElement) ps2.getV(i).mult(ps2.getV(is_a).adj());
+						SU2GroupElement diff1 = (SU2GroupElement) U2.sub(U1);
+
+						int is_b = GridFunctions.shift(i, ts, -1, transNumCells);
+						SU2GroupElement Um2 = (SU2GroupElement) transverseLinks[ts][is_b].adj().sub(identity);
+						SU2GroupElement U3 = (SU2GroupElement) ps1.getV(i).mult(ps1.getV(is_b).adj());
+						SU2GroupElement U4 = (SU2GroupElement) ps2.getV(i).mult(ps2.getV(is_b).adj());
+						SU2GroupElement diff2 = (SU2GroupElement) U4.sub(U3);
+
+						temp.addAssign(Um1.mult(diff1).add(Um2.mult(diff2)));
+						ts++;
+					}
+				}
+
+				longitudinalFields[i] = (SU2AlgebraElement) temp.proj().mult(1.0 / (2.0 * g));
+			}
+
+			// File output ((d-1)x3 transversal gauge field components, 1x3 longitudinal electric field component)
+			clear();
+			File file = this.getOutputFile(outputFile);
+			try {
+				FileWriter pw = new FileWriter(file, true);
+
+				// Transverse fields
+				for (int i = 0; i < effDimensions-1; i++) {
+					double[][] output = convertToDoubleArray(transverseFields[i]);
+					pw.write(generateTSVString(output[0]) + "\n");
+					pw.write(generateTSVString(output[1]) + "\n");
+					pw.write(generateTSVString(output[2]) + "\n");
+				}
+
+				// Longitudinal fields
+				double[][] output = convertToDoubleArray(longitudinalFields);
+				pw.write(generateTSVString(output[0]) + "\n");
+				pw.write(generateTSVString(output[1]) + "\n");
+				pw.write(generateTSVString(output[2]) + "\n");
+
+				pw.close();
+			} catch (IOException ex) {
+				System.out.println("DualMVModel: Error writing to file.");
+			}
+
+		}
+	}
+
+	public void applyCurrent(Simulation s) {
+		mv1.applyCurrent(s);
+		mv2.applyCurrent(s);
+	}
+
+	/**
+	 * Creates a file with a given name in the output folder.
+	 * @param filename	Filename of the output file.
+	 * @return			File object of the opened file.
+	 */
+	private File getOutputFile(String filename) {
+		// Default output path is
+		// 'output/' + filename
+		File fullpath = new File("output");
+		if(!fullpath.exists()) fullpath.mkdir();
+
+		return new File(fullpath, filename);
+	}
+
+	/**
+	 * 	Checks if the files are already existent and deletes them
+	 */
+	private void clear() {
+		File particlesfile = getOutputFile(outputFile);
+		boolean fileExists1 = particlesfile.exists();
+		if(fileExists1 == true) {
+			particlesfile.delete();
+		}
+	}
+
+	private String generateTSVString(double[] array) {
+		StringBuilder outputStringBuilder = new StringBuilder();
+		DecimalFormat formatter = new DecimalFormat("0.################E0");
+		for (int i = 0; i < array.length; i++) {
+			outputStringBuilder.append(formatter.format(array[i]));
+			if(i < array.length - 1) {
+				outputStringBuilder.append("\t");
+			}
+		}
+		return outputStringBuilder.toString();
+	}
+
+	private double[][] convertToDoubleArray(AlgebraElement[] array) {
+		double[][] output = new double[3][array.length];
+		for (int i = 0; i < array.length; i++) {
+			output[0][i] = array[i].get(0);
+			output[1][i] = array[i].get(1);
+			output[2][i] = array[i].get(2);
+		}
+		return output;
+	}
+
+}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
@@ -136,6 +136,7 @@ public class DualMVModel implements ICurrentGenerator {
 				int ts = 0;
 				for (int j = 0; j < effDimensions; j++) {
 					if(j != direction) {
+						/*
 						int is_a = GridFunctions.shift(i, ts, 1, transNumCells);
 						SU2GroupElement Um1 = (SU2GroupElement) transverseLinks[ts][i].sub(identity);
 						SU2GroupElement U1 = (SU2GroupElement) ps1.getV(i).mult(ps1.getV(is_a).adj());
@@ -149,6 +150,15 @@ public class DualMVModel implements ICurrentGenerator {
 						SU2GroupElement diff2 = (SU2GroupElement) U4.sub(U3);
 
 						temp.addAssign(Um1.mult(diff1).add(Um2.mult(diff2)));
+						*/
+
+						int is = GridFunctions.shift(i, ts, -1, transNumCells);
+						SU2GroupElement Um1 = (SU2GroupElement) transverseLinks[ts][i].adj().sub(identity);
+						SU2GroupElement diff1 = (SU2GroupElement) ps1.getU(i, ts).sub(ps2.getU(i, ts));
+						SU2GroupElement Um2 = (SU2GroupElement) transverseLinks[ts][is].adj().sub(identity);
+						SU2GroupElement diff2 = (SU2GroupElement) ps1.getU(is, ts).sub(ps2.getU(is, ts));
+						temp.addAssign(diff1.mult(Um1).sub(Um2.mult(diff2)));
+
 						ts++;
 					}
 				}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
@@ -139,7 +139,7 @@ public class DualMVModel implements ICurrentGenerator {
 						SU2GroupElement Um1 = (SU2GroupElement) transverseLinks[ts][i].sub(identity);
 						SU2GroupElement U1 = (SU2GroupElement) ps1.getV(i).mult(ps1.getV(is_a).adj());
 						SU2GroupElement U2 = (SU2GroupElement) ps2.getV(i).mult(ps2.getV(is_a).adj());
-						SU2GroupElement diff1 = (SU2GroupElement) U2.sub(U1);
+						SU2GroupElement diff1 = (SU2GroupElement) U2.adj().sub(U1.adj());
 
 						int is_b = GridFunctions.shift(i, ts, -1, transNumCells);
 						SU2GroupElement Um2 = (SU2GroupElement) transverseLinks[ts][is_b].adj().sub(identity);

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
@@ -199,10 +199,10 @@ public class DualMVModel implements ICurrentGenerator {
 	 * 	Checks if the files are already existent and deletes them
 	 */
 	private void clear() {
-		File particlesfile = getOutputFile(outputFile);
-		boolean fileExists1 = particlesfile.exists();
+		File file = getOutputFile(outputFile);
+		boolean fileExists1 = file.exists();
 		if(fileExists1 == true) {
-			particlesfile.delete();
+			file.delete();
 		}
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
@@ -1,5 +1,6 @@
 package org.openpixi.pixi.physics.fields.currentgenerators;
 
+import org.openpixi.pixi.diagnostics.FileFunctions;
 import org.openpixi.pixi.math.AlgebraElement;
 import org.openpixi.pixi.math.GroupElement;
 import org.openpixi.pixi.math.SU2AlgebraElement;
@@ -137,25 +138,6 @@ public class DualMVModel implements ICurrentGenerator {
 				int ts = 0;
 				for (int j = 0; j < effDimensions; j++) {
 					if(j != direction) {
-						/*
-						// Lattice calculation 1
-						int is_a = GridFunctions.shift(i, ts, 1, transNumCells);
-						SU2GroupElement Um1 = (SU2GroupElement) transverseLinks[ts][i].sub(identity);
-						SU2GroupElement U1 = (SU2GroupElement) ps1.getV(i).mult(ps1.getV(is_a).adj());
-						SU2GroupElement U2 = (SU2GroupElement) ps2.getV(i).mult(ps2.getV(is_a).adj());
-						SU2GroupElement diff1 = (SU2GroupElement) U2.adj().sub(U1.adj());
-
-						int is_b = GridFunctions.shift(i, ts, -1, transNumCells);
-						SU2GroupElement Um2 = (SU2GroupElement) transverseLinks[ts][is_b].adj().sub(identity);
-						SU2GroupElement U3 = (SU2GroupElement) ps1.getV(is_b).mult(ps1.getV(i).adj());
-						SU2GroupElement U4 = (SU2GroupElement) ps2.getV(is_b).mult(ps2.getV(i).adj());
-						SU2GroupElement diff2 = (SU2GroupElement) U4.sub(U3);
-
-						temp.addAssign(Um1.mult(diff1).add(Um2.mult(diff2)));
-						*/
-
-
-						// Lattice calculation 2
 						int is = GridFunctions.shift(i, ts, -1, transNumCells);
 						SU2GroupElement Um1 = (SU2GroupElement) transverseLinks[ts][i].adj().sub(identity);
 						SU2GroupElement diff1 = (SU2GroupElement) ps1.getU(i, ts).sub(ps2.getU(i, ts));
@@ -163,24 +145,16 @@ public class DualMVModel implements ICurrentGenerator {
 						SU2GroupElement diff2 = (SU2GroupElement) ps1.getU(is, ts).sub(ps2.getU(is, ts));
 						temp.addAssign(diff1.mult(Um1).sub(Um2.mult(diff2)));
 
-
-						// Continuum calculation
-						/*
-						SU2AlgebraElement A1 = (SU2AlgebraElement) ps1.getU(i, ts).getAlgebraElement().mult(normalizationFactor);
-						SU2AlgebraElement A2 = (SU2AlgebraElement) ps2.getU(i, ts).getAlgebraElement().mult(normalizationFactor);
-						temp2.addAssign(comm(A1,A2));
-						*/
 						ts++;
 					}
 				}
 
 				longitudinalFields[i] = (SU2AlgebraElement) temp.proj().mult(normalizationFactor / (2.0 * g));
-				//longitudinalFields[i] = temp2;
 			}
 
 			// File output ((d-1)x3 transversal gauge field components, 1x3 longitudinal electric field component)
-			clear();
-			File file = this.getOutputFile(outputFile);
+			FileFunctions.clearFile("output/" + outputFile);
+			File file = FileFunctions.getFile("output/" + outputFile);
 			try {
 				FileWriter pw = new FileWriter(file, true);
 
@@ -209,38 +183,6 @@ public class DualMVModel implements ICurrentGenerator {
 	public void applyCurrent(Simulation s) {
 		mv1.applyCurrent(s);
 		mv2.applyCurrent(s);
-	}
-
-	private SU2AlgebraElement comm(SU2AlgebraElement A, SU2AlgebraElement B) {
-		SU2GroupElement a = new SU2GroupElement(0.0, A.get(0), A.get(1), A.get(2));
-		SU2GroupElement b = new SU2GroupElement(0.0, B.get(0), B.get(1), B.get(2));
-		SU2GroupElement c = (SU2GroupElement) a.mult(b).sub(b.mult(a));
-		return (SU2AlgebraElement) c.proj().mult(1.0);
-	}
-
-	/**
-	 * Creates a file with a given name in the output folder.
-	 * @param filename	Filename of the output file.
-	 * @return			File object of the opened file.
-	 */
-	private File getOutputFile(String filename) {
-		// Default output path is
-		// 'output/' + filename
-		File fullpath = new File("output");
-		if(!fullpath.exists()) fullpath.mkdir();
-
-		return new File(fullpath, filename);
-	}
-
-	/**
-	 * 	Checks if the files are already existent and deletes them
-	 */
-	private void clear() {
-		File file = getOutputFile(outputFile);
-		boolean fileExists1 = file.exists();
-		if(fileExists1 == true) {
-			file.delete();
-		}
 	}
 
 	private String generateTSVString(double[] array) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
@@ -40,15 +40,20 @@ public class MVModel implements ICurrentGenerator {
 	private boolean useSeed = false;
 	private int seed;
 
+	/**
+	 *
+	 */
+	private double lowPassCoefficient = 1.0;
+
 	protected ParticleLCCurrent particleLCCurrent;
 
 
-	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu) {
-		this(direction, orientation, location, longitudinalWidth, mu, 0);
+	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu, double lowPassCoefficient) {
+		this(direction, orientation, location, longitudinalWidth, mu, 0, lowPassCoefficient);
 		this.useSeed = false;
 	}
 
-	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu, int seed){
+	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu, int seed, double lowPassCoefficient){
 		this.direction = direction;
 		this.orientation = orientation;
 		this.location = location;
@@ -56,7 +61,7 @@ public class MVModel implements ICurrentGenerator {
 		this.mu = mu;
 		this.seed = seed;
 		this.useSeed = true;
-
+		this.lowPassCoefficient = lowPassCoefficient;
 	}
 
 	public void initializeCurrent(Simulation s, int totalInstances) {
@@ -104,6 +109,7 @@ public class MVModel implements ICurrentGenerator {
 		} else if(s.getSimulationType() == SimulationType.TemporalCGCNGP) {
 			this.particleLCCurrent = new ParticleLCCurrentNGP(direction, orientation, location, longitudinalWidth);
 		}
+		particleLCCurrent.lowPassCoefficient = lowPassCoefficient;
 		particleLCCurrent.setTransversalChargeDensity(transversalChargeDensity);
 		particleLCCurrent.initializeCurrent(s, totalInstances);
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
@@ -40,7 +40,7 @@ public class MVModel implements ICurrentGenerator {
 	private boolean useSeed = false;
 	private int seed;
 
-	private ParticleLCCurrent particleLCCurrent;
+	protected ParticleLCCurrent particleLCCurrent;
 
 
 	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
@@ -77,7 +77,8 @@ public class MVModel implements ICurrentGenerator {
 		// Initialize transversal charge density with random charges from a Gaussian distribution with zero mean and width \mu.
 		AlgebraElement[] transversalChargeDensity = new AlgebraElement[totalTransversalCells];
 		AlgebraElement totalCharge = s.grid.getElementFactory().algebraZero();
-		double gaussianWidth = mu * s.getCouplingConstant() / s.grid.getLatticeSpacing();
+		//double gaussianWidth = mu * s.getCouplingConstant() / s.grid.getLatticeSpacing();
+		double gaussianWidth = mu / s.grid.getLatticeSpacing();
 		for (int i = 0; i < totalTransversalCells; i++) {
 			AlgebraElement charge = s.grid.getElementFactory().algebraZero();
 			for (int c = 0; c < numberOfComponents; c++) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
@@ -45,15 +45,21 @@ public class MVModel implements ICurrentGenerator {
 	 */
 	private double lowPassCoefficient = 1.0;
 
+	/**
+	 * Option whether to use the \mu^2 (true) or the g^2 \mu^2 (false) normalization for the Gaussian
+	 * probability distribution of the color charge densities.
+	 */
+	private boolean useAlternativeNormalization;
+
 	protected ParticleLCCurrent particleLCCurrent;
 
 
-	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu, double lowPassCoefficient) {
-		this(direction, orientation, location, longitudinalWidth, mu, 0, lowPassCoefficient);
+	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu, double lowPassCoefficient, boolean useAlternativeNormalization) {
+		this(direction, orientation, location, longitudinalWidth, mu, 0, lowPassCoefficient, useAlternativeNormalization);
 		this.useSeed = false;
 	}
 
-	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu, int seed, double lowPassCoefficient){
+	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu, int seed, double lowPassCoefficient, boolean useAlternativeNormalization){
 		this.direction = direction;
 		this.orientation = orientation;
 		this.location = location;
@@ -62,6 +68,7 @@ public class MVModel implements ICurrentGenerator {
 		this.seed = seed;
 		this.useSeed = true;
 		this.lowPassCoefficient = lowPassCoefficient;
+		this.useAlternativeNormalization = useAlternativeNormalization;
 	}
 
 	public void initializeCurrent(Simulation s, int totalInstances) {
@@ -77,8 +84,14 @@ public class MVModel implements ICurrentGenerator {
 		// Initialize transversal charge density with random charges from a Gaussian distribution with zero mean and width \mu.
 		AlgebraElement[] transversalChargeDensity = new AlgebraElement[totalTransversalCells];
 		AlgebraElement totalCharge = s.grid.getElementFactory().algebraZero();
-		//double gaussianWidth = mu * s.getCouplingConstant() / s.grid.getLatticeSpacing();
-		double gaussianWidth = mu / s.grid.getLatticeSpacing();
+
+		double gaussianWidth;
+		if(useAlternativeNormalization) {
+			gaussianWidth = mu / s.grid.getLatticeSpacing();
+		} else {
+			gaussianWidth = mu * s.getCouplingConstant() / s.grid.getLatticeSpacing();
+		}
+
 		for (int i = 0; i < totalTransversalCells; i++) {
 			AlgebraElement charge = s.grid.getElementFactory().algebraZero();
 			for (int c = 0; c < numberOfComponents; c++) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/ParticleLCCurrent.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/ParticleLCCurrent.java
@@ -76,6 +76,11 @@ public class ParticleLCCurrent implements ICurrentGenerator {
 	protected int particlesPerCell = 1;
 
 	/**
+	 * Low pass filter for the Poisson solver
+	 */
+	public double lowPassCoefficient = 1.0;
+
+	/**
 	 * Standard constructor for the ParticleLCCurrent class.
 	 *
 	 * @param direction Direction of the transversal charge density movement.
@@ -126,6 +131,7 @@ public class ParticleLCCurrent implements ICurrentGenerator {
 		// 2) Initialize the NewLCPoissonSolver with the transversal charge density and solve for the fields U and E.
 		poissonSolver = new NewLCPoissonSolver(direction, orientation, location, longitudinalWidth,
 				transversalChargeDensity, transversalNumCells);
+		poissonSolver.lowPassCoefficient = lowPassCoefficient;
 		poissonSolver.initialize(s);
 		poissonSolver.solve(s);
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/ParticleLCCurrentNGP.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/ParticleLCCurrentNGP.java
@@ -30,7 +30,7 @@ public class ParticleLCCurrentNGP extends ParticleLCCurrent {
 		CGCParticle[][] longitudinalParticleArray = new CGCParticle[totalTransversalCells][longitudinalCells * particlesPerLink];
 
 
-		double cutoffCharge = 10E-20 * Math.pow( g * as, 2) / (Math.pow(as, 3) * particlesPerLink);
+		double cutoffCharge = 10E-22 * Math.pow( g * as, 2) / (Math.pow(as, 3) * particlesPerLink);
 
 		ArrayList<ArrayList<CGCParticle>> longitudinalParticleList = new ArrayList<ArrayList<CGCParticle>>(totalTransversalCells);
 		for (int i = 0; i < totalTransversalCells; i++) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/util/GridFunctions.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/util/GridFunctions.java
@@ -175,5 +175,22 @@ public class GridFunctions {
 		return newGridPos;
 	}
 
+	/**
+	 * Shifts a cell index in the given direction with given orientation.
+	 * @param index cell index
+	 * @param d direction of the shift
+	 * @param o orienatation of the shift
+	 * @param numCells gridsize of the array
+	 * @return
+	 */
+	public static int shift(int index, int d, int o, int[] numCells) {
+
+		int[] gpos = getCellPos(index, numCells);
+		gpos[d] += o;
+		gpos[d] = (gpos[d] % numCells[d] + numCells[d])  % numCells[d];
+
+		return GridFunctions.getCellIndex(gpos, numCells);
+	}
+
 
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
@@ -55,8 +55,7 @@ public class MainBatch {
 		// If so creates a parser and uses the parameter as the
 		// path to the settings file.
 		if (args.length != 0) {
-			File path = new File("input");
-			File file = new File(path, args[0]);
+			File file = new File(args[0]);
 
 			if(file.exists()) {
 				if(file.isFile()) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
@@ -83,7 +83,7 @@ public class MainBatch {
 				}
 			}
 		}
-		return;
+		System.exit(0);
 	}
 
 	public static void runSimulationFromString(String configurationString) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
@@ -26,6 +26,7 @@ import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.ui.util.*;
 import org.openpixi.pixi.ui.util.yaml.YamlParser;
 
+import java.io.FilenameFilter;
 import java.io.IOException;
 
 public class MainBatch {
@@ -49,21 +50,40 @@ public class MainBatch {
 	 * </pre>
 	 */
 	public static void main(String[] args) throws FileNotFoundException, IOException, InterruptedException {
-		Debug.checkAssertsEnabled();
+		//Debug.checkAssertsEnabled();
 		// Checks if the user has specified at least one parameter.
 		// If so creates a parser and uses the parameter as the
 		// path to the settings file.
 		if (args.length != 0) {
 			File path = new File("input");
 			File file = new File(path, args[0]);
-			try {
-				String string = FileIO.readFile(file);
-				runSimulationFromString(string);
 
-			} catch (IOException e) {
-				System.out.println("Error opening " + args[0]);
+			if(file.exists()) {
+				if(file.isFile()) {
+					try {
+						String string = FileIO.readFile(file);
+						runSimulationFromString(string);
+
+					} catch (IOException e) {
+						System.out.println("Error opening " + args[0]);
+					}
+				} else if(file.isDirectory()){
+					System.out.println("Loading configuration files from " + file.getPath());
+					File[] listOfFiles = file.listFiles();
+					for(File f : listOfFiles) {
+						try {
+							System.out.println("Running " + f.getPath());
+							String string = FileIO.readFile(f);
+							runSimulationFromString(string);
+						} catch (IOException e) {
+							System.out.println("Error opening " + f.getPath());
+						}
+					}
+					System.out.println("Done!");
+				}
 			}
 		}
+		return;
 	}
 
 	public static void runSimulationFromString(String configurationString) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
@@ -69,7 +69,11 @@ public class MainBatch {
 					}
 				} else if(file.isDirectory()){
 					System.out.println("Loading configuration files from " + file.getPath());
-					File[] listOfFiles = file.listFiles();
+					FilenameFilter filter = new FilenameFilter() {
+						public boolean accept(File dir, String name) {
+							return name.toLowerCase().endsWith(".yaml");
+						}};
+					File[] listOfFiles = file.listFiles(filter);
 					for(File f : listOfFiles) {
 						try {
 							System.out.println("Running " + f.getPath());

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
@@ -61,6 +61,7 @@ public class MainBatch {
 			if(file.exists()) {
 				if(file.isFile()) {
 					try {
+						System.out.println("Running " + file.getPath());
 						String string = FileIO.readFile(file);
 						runSimulationFromString(string);
 
@@ -83,10 +84,10 @@ public class MainBatch {
 							System.out.println("Error opening " + f.getPath());
 						}
 					}
-					System.out.println("Done!");
 				}
 			}
 		}
+		System.out.println("Done!");
 		System.exit(0);
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlCurrents.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlCurrents.java
@@ -1,6 +1,7 @@
 package org.openpixi.pixi.ui.util.yaml;
 
 import org.openpixi.pixi.physics.Settings;
+import org.openpixi.pixi.physics.fields.currentgenerators.ICurrentGenerator;
 import org.openpixi.pixi.ui.util.yaml.currentgenerators.*;
 
 import java.util.ArrayList;
@@ -41,6 +42,8 @@ public class YamlCurrents {
     public ArrayList<YamlRandomTemporalParticleColorCurrentNucleus> randomTemporalParticleColorCurrentsNucleus = new ArrayList<YamlRandomTemporalParticleColorCurrentNucleus>();
 
 	public ArrayList<YamlMVModel> MVModels = new ArrayList<YamlMVModel>();
+
+	public ArrayList<YamlDualMVModel> dualMVModels = new ArrayList<YamlDualMVModel>();
 
 
 
@@ -126,6 +129,10 @@ public class YamlCurrents {
         }
 
 		for(YamlMVModel current : MVModels) {
+			s.addCurrentGenerator(current.getCurrentGenerator());
+		}
+
+		for(YamlDualMVModel current : dualMVModels) {
 			s.addCurrentGenerator(current.getCurrentGenerator());
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlOutput.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlOutput.java
@@ -29,6 +29,8 @@ public class YamlOutput {
 
 	public ArrayList<YamlProjectedEnergyDensity> projectedEnergyDensity = new ArrayList<YamlProjectedEnergyDensity>();
 
+	public ArrayList<YamlPlanarFields> planarFields = new ArrayList<YamlPlanarFields>();
+
 
 	/**
 	 * Creates FileGenerator instances and applies them to the Settings instance.
@@ -72,6 +74,10 @@ public class YamlOutput {
 		}
 
 		for(YamlProjectedEnergyDensity output : projectedEnergyDensity) {
+			s.addDiagnostics(output.getFileGenerator());
+		}
+
+		for(YamlPlanarFields output : planarFields) {
 			s.addDiagnostics(output.getFileGenerator());
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlDualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlDualMVModel.java
@@ -44,12 +44,20 @@ public class YamlDualMVModel {
 	 */
 	public String outputFile = null;
 
+	/**
+	 * Option whether to use the \mu^2 (true) or the g^2 \mu^2 (false, default) normalization for the Gaussian
+	 * probability distribution of the color charge densities.
+	 */
+	public Boolean useAlternativeNormalization = false;
+
 
 	public DualMVModel getCurrentGenerator() {
 		if(randomSeed1 != null && randomSeed2 != null) {
-			return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient, true, randomSeed1, randomSeed2, createInitialConditionsOutput, outputFile);
+			return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient, true,
+					randomSeed1, randomSeed2, createInitialConditionsOutput, outputFile, useAlternativeNormalization);
 		}
-		return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient, false, 0, 0, createInitialConditionsOutput, outputFile);
+		return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient, false, 0, 0,
+				createInitialConditionsOutput, outputFile, useAlternativeNormalization);
 	}
 
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlDualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlDualMVModel.java
@@ -1,0 +1,51 @@
+package org.openpixi.pixi.ui.util.yaml.currentgenerators;
+
+import org.openpixi.pixi.physics.fields.currentgenerators.DualMVModel;
+import org.openpixi.pixi.physics.fields.currentgenerators.MVModel;
+
+public class YamlDualMVModel {
+	/**
+	 * Direction of the current pulse (0 to d)
+	 */
+	public Integer direction;
+
+	/**
+	 * Starting location of the pulse on the longitudinal line
+	 */
+	public Double longitudinalLocation;
+
+	/**
+	 * Longitudinal width of the pulse (Gauss shape)
+	 */
+	public Double longitudinalWidth;
+
+	/**
+	 * \mu parameter of the MV model. This controls the average charge density squared.
+	 */
+	public Double mu;
+
+	/**
+	 * Seeds to use for the random number generator
+	 */
+	public Integer randomSeed1 = null;
+	public Integer randomSeed2 = null;
+
+	/**
+	 * Option for writing boost-invariant collision initial conditins to file.
+	 */
+	public Boolean createInitialConditionsOutput =  false;
+
+	/**
+	 * Path to the output file.
+	 */
+	public String outputFile = null;
+
+
+	public DualMVModel getCurrentGenerator() {
+		if(randomSeed1 != null && randomSeed2 != null) {
+			return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, true, randomSeed1, randomSeed2, createInitialConditionsOutput, outputFile);
+		}
+		return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, false, 0, 0, createInitialConditionsOutput, outputFile);
+	}
+
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlDualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlDualMVModel.java
@@ -1,7 +1,6 @@
 package org.openpixi.pixi.ui.util.yaml.currentgenerators;
 
 import org.openpixi.pixi.physics.fields.currentgenerators.DualMVModel;
-import org.openpixi.pixi.physics.fields.currentgenerators.MVModel;
 
 public class YamlDualMVModel {
 	/**
@@ -25,13 +24,18 @@ public class YamlDualMVModel {
 	public Double mu;
 
 	/**
+	 * Coefficient for the low pass filter in the Poisson solver
+	 */
+	public Double lowPassCoefficient = 1.0;
+
+	/**
 	 * Seeds to use for the random number generator
 	 */
 	public Integer randomSeed1 = null;
 	public Integer randomSeed2 = null;
 
 	/**
-	 * Option for writing boost-invariant collision initial conditins to file.
+	 * Option for writing boost-invariant collision initial conditions to file.
 	 */
 	public Boolean createInitialConditionsOutput =  false;
 
@@ -43,9 +47,9 @@ public class YamlDualMVModel {
 
 	public DualMVModel getCurrentGenerator() {
 		if(randomSeed1 != null && randomSeed2 != null) {
-			return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, true, randomSeed1, randomSeed2, createInitialConditionsOutput, outputFile);
+			return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient, true, randomSeed1, randomSeed2, createInitialConditionsOutput, outputFile);
 		}
-		return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, false, 0, 0, createInitialConditionsOutput, outputFile);
+		return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient, false, 0, 0, createInitialConditionsOutput, outputFile);
 	}
 
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlMVModel.java
@@ -29,6 +29,11 @@ public class YamlMVModel {
 	public Double mu;
 
 	/**
+	 * Coefficient for the low pass filter in the Poisson solver
+	 */
+	public Double lowPassCoefficient = 1.0;
+
+	/**
 	 * Seed to use for the random number generator
 	 */
 	public Integer randomSeed;
@@ -36,9 +41,9 @@ public class YamlMVModel {
 
 	public MVModel getCurrentGenerator() {
 		if(randomSeed != null) {
-			return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu, randomSeed);
+			return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu, randomSeed, lowPassCoefficient);
 		}
-		return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu);
+		return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient);
 	}
 
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlMVModel.java
@@ -38,12 +38,20 @@ public class YamlMVModel {
 	 */
 	public Integer randomSeed;
 
+	/**
+	 * Option whether to use the \mu^2 (true) or the g^2 \mu^2 (false, default) normalization for the Gaussian
+	 * probability distribution of the color charge densities.
+	 */
+	public Boolean useAlternativeNormalization = false;
+
 
 	public MVModel getCurrentGenerator() {
 		if(randomSeed != null) {
-			return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu, randomSeed, lowPassCoefficient);
+			return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu, randomSeed,
+					lowPassCoefficient, useAlternativeNormalization);
 		}
-		return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient);
+		return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient,
+				useAlternativeNormalization);
 	}
 
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlPlanarFields.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlPlanarFields.java
@@ -1,0 +1,35 @@
+package org.openpixi.pixi.ui.util.yaml.filegenerators;
+
+import org.openpixi.pixi.diagnostics.methods.PlanarFields;
+
+public class YamlPlanarFields {
+	/**
+	 * Measurement interval.
+	 */
+	public Double interval;
+
+	/**
+	 * Measurement starting time.
+	 */
+	public Double startingTime;
+
+	/**
+	 * Output file path.
+	 */
+	public String path;
+
+	/**
+	 * Direction orthogonal the plane.
+	 */
+	public Integer direction;
+
+	/**
+	 * Index of the plane in the chosen direction;
+	 */
+	public Integer planarIndex;
+
+
+	public PlanarFields getFileGenerator() {
+		return new PlanarFields(interval, path, startingTime, direction, planarIndex);
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlPlanarFields.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlPlanarFields.java
@@ -14,6 +14,11 @@ public class YamlPlanarFields {
 	public Double startingTime;
 
 	/**
+	 * Measurement stopping time.
+	 */
+	public Double finalTime;
+
+	/**
 	 * Output file path.
 	 */
 	public String path;
@@ -30,6 +35,14 @@ public class YamlPlanarFields {
 
 
 	public PlanarFields getFileGenerator() {
-		return new PlanarFields(interval, path, startingTime, direction, planarIndex);
+		if(startingTime == null) {
+			startingTime = 0.0;
+		}
+
+		if(finalTime == null) {
+			finalTime = Double.MAX_VALUE;
+		}
+
+		return new PlanarFields(interval, path, startingTime, finalTime, direction, planarIndex);
 	}
 }

--- a/pixi/src/test/java/org/openpixi/pixi/math/SU2MatrixTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/math/SU2MatrixTest.java
@@ -391,6 +391,25 @@ public class SU2MatrixTest {
 		}
 	}
 
+	@Test
+	public void testInv() {
+		// Create random matrix which is not SU2 in general.
+		SU2GroupElement m = new SU2GroupElement();
+		for (int i = 0; i < 3; i++) {
+			double r = Math.random() - 0.5;
+			m.set(i, r);
+		}
+
+		SU2GroupElement m2 = m.inv();
+
+		SU2GroupElement m3 = (SU2GroupElement) m.mult(m2);
+
+		Assert.assertEquals(1.0, m3.get(0), accuracy);
+		for (int i = 1; i < 3; i++) {
+			Assert.assertEquals(0.0, m3.get(i), accuracy);
+		}
+	}
+
 	private Array2DRowFieldMatrix<Complex>  adj(Array2DRowFieldMatrix<Complex> arg) {
 		Array2DRowFieldMatrix<Complex> m = (Array2DRowFieldMatrix<Complex>) arg.transpose();
 		for (int i = 0; i < 2; i++) {
@@ -569,6 +588,7 @@ public class SU2MatrixTest {
 
 		return output;
 	}
+
 
 
 }


### PR DESCRIPTION
New current generator: _DualMVModel_
This current generator initializes two MV models and computes/outputs the boost-invariant initial conditions which would result from such a collision if the pancakes were infinitely thin. It is a bit weird that a current generator writes files, but this is the best/simplest solution I could come up with. 
The initial conditions can also only be computed for SU(2).

New diagnostic: _PlanarFields_
This diagnostic is used to record fields in a given plane. It outputs the transversal gauge fields (fields within the plane) and the longitudinal electric field (perpendicular to the plane).

New script: _openpixi_batch.py_
This is a python script to create and submit batch jobs for the VSC2. It reads a template input file and generates YAML and SGE job files according to the given template. It can be used to vary parameters such as pancake width, coupling constant, time step.. basically any (floating point) parameter that can be set in a YAML file.
You can find the script and two examples in the /pixi/scripts/ folder.

Some other minor changes:
- _SU2GroupElement_ now includes a method to compute the inverse matrix. This is used in _DualMVModel_.
- _MVModel_ and _DualMVModel_ now include an option to use a low-pass filter for the Poisson solver and an option whether to use the \mu^2 or the g^2 \mu^2 (default) normalization for the color charge densities.
- If MainBatch is called from the terminal with an input directory instead of a YAML file, all of the YAML files in that directory are called in sequence. Input files do not need to be in the a folder called 'input' anymore. Any path is fine.
-  I collected the most common methods used in file output and put them in the new _FileFunctions_ class.
- Tweaked the cut-off charge in _ParticleLCCurrentNGP_ (it's lower now).
