### PR TITLE
New PoyntingTheoremInTime diagnostics

### DIFF
--- a/pixi/input/current/MV model/MVModel_NGP_with_output.yaml
+++ b/pixi/input/current/MV model/MVModel_NGP_with_output.yaml
@@ -1,0 +1,93 @@
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: 2
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 8
+gridCells: [128, 8, 8]
+timeStep: 0.25
+duration: 96
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+currents:
+  MVModels:
+    - direction: 0
+      orientation: 1
+      longitudinalLocation: 32
+      longitudinalWidth: 3.0
+      mu: 0.05
+      randomSeed: 1
+    - direction: 0
+      orientation: -1
+      longitudinalLocation: -32
+      longitudinalWidth: 3.0
+      mu: 0.05
+      randomSeed: 2
+
+output:
+  bulkQuantitiesInTime:
+    - path: "bulk.txt"
+      interval: 1.0
+  poyntingTheoremInTime:
+    - path: "poyntingTheorem.txt"
+      interval: 1.0
+
+# Generated panel code:
+panels:
+  dividerLocation: 1015
+  leftPanel:
+    dividerLocation: 483
+    leftPanel:
+      chartPanel:
+        logarithmicScale: false
+        showCharts:
+        - Gauss law violation
+        - E squared
+        - B squared
+        - Energy density
+    orientation: 0
+    rightPanel:
+      dividerLocation: 501
+      leftPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 0
+          scaleFactor: 25.0
+          showCoordinates: x, i, 0
+          showFields:
+          - E
+          - Gauss
+      orientation: 1
+      rightPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 1
+          scaleFactor: 25.0
+          showCoordinates: x, i, 4
+          showFields:
+          - E
+  orientation: 1
+  rightPanel:
+    dividerLocation: 415
+    leftPanel:
+      energyDensity2DGLPanel:
+        automaticScaling: false
+        scaleFactor: 10000.0
+        showCoordinates: x, y, 16
+    orientation: 0
+    rightPanel:
+      gaussViolation2DGLPanel:
+        automaticScaling: true
+        scaleFactor: 1.0
+        showCoordinates: x, y, 0
+  windowHeight: 1054
+  windowWidth: 1922

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
@@ -1,0 +1,126 @@
+package org.openpixi.pixi.diagnostics.methods;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.io.IOException;
+import java.util.Locale;
+
+import org.openpixi.pixi.diagnostics.Diagnostics;
+import org.openpixi.pixi.diagnostics.FileFunctions;
+import org.openpixi.pixi.physics.Simulation;
+import org.openpixi.pixi.physics.grid.Grid;
+import org.openpixi.pixi.physics.particles.IParticle;
+import org.openpixi.pixi.physics.measurements.FieldMeasurements;
+
+public class PoyntingTheoremInTime implements Diagnostics {
+
+	private String path;
+	private double timeInterval;
+	private int stepInterval;
+	private boolean supressOutput;
+	private Simulation s;
+	private PoyntingTheoremBuffer poyntingTheorem;
+
+	public PoyntingTheoremInTime(String path, double timeInterval)
+	{
+		this(path, timeInterval, false);
+	}
+
+	public PoyntingTheoremInTime(String path, double timeInterval, boolean supressOutput)
+	{
+		this.path = path;
+		this.timeInterval = timeInterval;
+		this.supressOutput = supressOutput;
+	}
+
+	/**
+	 * Initializes the BulkQuantitiesInTime object.
+	 * It sets the step interval and creates/deletes the output file.
+	 *
+	 * @param s    Instance of the simulation object
+	 */
+	public void initialize(Simulation s)
+	{
+		this.s = s;
+		this.stepInterval = (int) (timeInterval / this.s.getTimeStep());
+		poyntingTheorem = PoyntingTheoremBuffer.getOrAppendInstance(s);
+
+		if(!supressOutput) {
+			// Create/delete file.
+			FileFunctions.clearFile("output/" + path);
+
+			// Write first line.
+			File file = FileFunctions.getFile("output/" + path);
+			try {
+				FileWriter pw = new FileWriter(file, true);
+				pw.write("#time");
+				pw.write(" \t Energy density");
+				pw.write(" \t dE/dt");
+				pw.write(" \t div S");
+				pw.write(" \t B rot E - E rot B");
+				pw.write(" \t J*E");
+				pw.write(" \t dE/dt + div S + J*E");
+				pw.write(" \t Time-integrated div S");
+				pw.write(" \t Time-integrated B rot E - E rot B");
+				pw.write(" \t Time-integrated J*E");
+				pw.write(" \t E + time-integrated(div S + J*E)");
+				pw.write(" \t E + time-integrated(B rot E - E rot B + J*E)");
+				pw.write("\n");
+				pw.close();
+			} catch (IOException ex) {
+				System.out.println("PoyntingTheoremInTime Error: Could not write to file '" + path + "'.");
+			}
+		}
+	}
+
+	/**
+	 * Computes the average of the diagonal components of the stress-energy tensor over the lattice and writes them to the output file.
+	 *
+	 * @param grid		Reference to the Grid instance.
+	 * @param particles	Reference to the list of particles.
+	 * @param steps		Total simulation steps so far.
+	 * @throws IOException
+	 */
+	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps) throws IOException {
+		if(steps % stepInterval == 0) {
+
+			double energyDensity = poyntingTheorem.getTotalEnergyDensity();
+			double energyDensityDerivative = poyntingTheorem.getTotalEnergyDensityDerivative();
+			double divS1 = poyntingTheorem.getTotalDivS1();
+			double divS2 = poyntingTheorem.getTotalDivS2();
+			double jS = poyntingTheorem.getTotalJE();
+			double poyntingTheoremSum = energyDensityDerivative + divS1 + jS;
+			double integratedDivS1 = poyntingTheorem.getIntegratedTotalDivS1();
+			double integratedDivS2 = poyntingTheorem.getIntegratedTotalDivS2();
+			double integratedJS = poyntingTheorem.getIntegratedTotalJE();
+			double integratedPoyntingTheorem1 = poyntingTheorem.getTotalEnergyDensity()
+					+ integratedDivS1 + integratedJS;
+			double integratedPoyntingTheorem2 = poyntingTheorem.getTotalEnergyDensity()
+					+ integratedDivS2 + integratedJS;
+
+			if(!supressOutput) {
+				File file = FileFunctions.getFile("output/" + path);
+				FileWriter pw = new FileWriter(file, true);
+				DecimalFormat formatter = new DecimalFormat("0.################E0");
+
+				pw.write(formatter.format(steps * s.getTimeStep()) + "\t");
+				pw.write(formatter.format(energyDensity)+ "\t");
+				pw.write(formatter.format(energyDensityDerivative) + "\t");
+				pw.write(formatter.format(divS1) + "\t");
+				pw.write(formatter.format(divS2) + "\t");
+				pw.write(formatter.format(jS) + "\t");
+				pw.write(formatter.format(poyntingTheoremSum));
+				pw.write(formatter.format(integratedDivS1));
+				pw.write(formatter.format(integratedDivS2));
+				pw.write(formatter.format(integratedJS));
+				pw.write(formatter.format(integratedPoyntingTheorem1));
+				pw.write(formatter.format(integratedPoyntingTheorem2));
+				pw.write("\n");
+
+				pw.close();
+			}
+		}
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
@@ -105,18 +105,18 @@ public class PoyntingTheoremInTime implements Diagnostics {
 				FileWriter pw = new FileWriter(file, true);
 				DecimalFormat formatter = new DecimalFormat("0.################E0");
 
-				pw.write(formatter.format(steps * s.getTimeStep()) + "\t");
-				pw.write(formatter.format(energyDensity)+ "\t");
-				pw.write(formatter.format(energyDensityDerivative) + "\t");
-				pw.write(formatter.format(divS1) + "\t");
-				pw.write(formatter.format(divS2) + "\t");
-				pw.write(formatter.format(jS) + "\t");
-				pw.write(formatter.format(poyntingTheoremSum));
-				pw.write(formatter.format(integratedDivS1));
-				pw.write(formatter.format(integratedDivS2));
-				pw.write(formatter.format(integratedJS));
-				pw.write(formatter.format(integratedPoyntingTheorem1));
-				pw.write(formatter.format(integratedPoyntingTheorem2));
+				pw.write(formatter.format(steps * s.getTimeStep()));
+				pw.write("\t" + formatter.format(energyDensity));
+				pw.write("\t" + formatter.format(energyDensityDerivative));
+				pw.write("\t" + formatter.format(divS1));
+				pw.write("\t" + formatter.format(divS2));
+				pw.write("\t" + formatter.format(jS));
+				pw.write("\t" + formatter.format(poyntingTheoremSum));
+				pw.write("\t" + formatter.format(integratedDivS1));
+				pw.write("\t" + formatter.format(integratedDivS2));
+				pw.write("\t" + formatter.format(integratedJS));
+				pw.write("\t" + formatter.format(integratedPoyntingTheorem1));
+				pw.write("\t" + formatter.format(integratedPoyntingTheorem2));
 				pw.write("\n");
 
 				pw.close();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
@@ -187,7 +187,6 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 		double poyntingTheoremSum = energyDensityDerivative + divS1 + jS;
 		double integratedDivS1 = poyntingTheorem.getIntegratedTotalDivS1();
 		double integratedDivS2 = poyntingTheorem.getIntegratedTotalDivS2();
-		double integratedBrotEminusErotB = poyntingTheorem.getIntegratedTotalDivS2();
 		double integratedJS = poyntingTheorem.getIntegratedTotalJE();
 		double integratedPoyntingTheorem1 = poyntingTheorem.getTotalEnergyDensity()
 				+ integratedDivS1 + integratedJS;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
@@ -157,7 +157,6 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 
 		Simulation s = getSimulationAnimation().getSimulation();
 		double time = s.totalSimulationTime;
-		poyntingTheorem = PoyntingTheoremBuffer.getOrAppendInstance(s);
 
 		//TODO Make this method d-dimensional!!
 		// The values computed from fieldMeasurements already come in "physical units", i.e. the factor g*a is accounted for.
@@ -180,19 +179,6 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 		double totalCharge = fieldMeasurements.calculateTotalCharge(s.grid);
 		double totalChargeSquared = fieldMeasurements.calculateTotalChargeSquared(s.grid);
 
-		double energyDensityDerivative = poyntingTheorem.getTotalEnergyDensityDerivative();
-		double divS1 = poyntingTheorem.getTotalDivS1();
-		double divS2 = poyntingTheorem.getTotalDivS2();
-		double jS = poyntingTheorem.getTotalJE();
-		double poyntingTheoremSum = energyDensityDerivative + divS1 + jS;
-		double integratedDivS1 = poyntingTheorem.getIntegratedTotalDivS1();
-		double integratedDivS2 = poyntingTheorem.getIntegratedTotalDivS2();
-		double integratedJS = poyntingTheorem.getIntegratedTotalJE();
-		double integratedPoyntingTheorem1 = poyntingTheorem.getTotalEnergyDensity()
-				+ integratedDivS1 + integratedJS;
-		double integratedPoyntingTheorem2 = poyntingTheorem.getTotalEnergyDensity()
-				+ integratedDivS2 + integratedJS;
-
 		traces[INDEX_E_SQUARED].addPoint(time, eSquared);
 		traces[INDEX_B_SQUARED].addPoint(time, bSquared);
 		traces[INDEX_GAUSS_VIOLATION].addPoint(time, gaussViolation);
@@ -202,21 +188,49 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 		traces[INDEX_PZ].addPoint(time, pz);
 		traces[INDEX_TOTAL_CHARGE].addPoint(time, totalCharge);
 		traces[INDEX_TOTAL_CHARGE_SQUARED].addPoint(time, totalChargeSquared);
-		traces[INDEX_ENERGY_DENSITY_DERIVATIVE].addPoint(time, energyDensityDerivative);
-		traces[INDEX_DIV_S].addPoint(time, divS1);
-		traces[INDEX_B_ROT_E_MINUS_E_ROT_B].addPoint(time, divS2);
-		traces[INDEX_JE].addPoint(time, jS);
-		traces[INDEX_POYNTING_THEOREM].addPoint(time, poyntingTheoremSum);
-		traces[INDEX_INTEGRATED_DIV_S].addPoint(time, integratedDivS1);
-		traces[INDEX_INTEGRATED_B_ROT_E_MINUS_E_ROT_B].addPoint(time, integratedDivS2);
-		traces[INDEX_INTEGRATED_JE].addPoint(time, integratedJS);
-		traces[INDEX_INTEGRATED_POYNTING_THEOREM_1].addPoint(time, integratedPoyntingTheorem1);
-		traces[INDEX_INTEGRATED_POYNTING_THEOREM_2].addPoint(time, integratedPoyntingTheorem2);
 
 		if (showChartsProperty.getValue(INDEX_ENERGY_DENSITY_2)) {
 			occupationNumbers.initialize(s);
 			occupationNumbers.calculate(s.grid, s.particles, 0);
 			traces[INDEX_ENERGY_DENSITY_2].addPoint(time, occupationNumbers.energyDensity);
+		}
+
+		// Poynting theorem calculations
+		if (showChartsProperty.getValue(INDEX_ENERGY_DENSITY_DERIVATIVE)
+				|| showChartsProperty.getValue(INDEX_DIV_S)
+				|| showChartsProperty.getValue(INDEX_B_ROT_E_MINUS_E_ROT_B)
+				|| showChartsProperty.getValue(INDEX_JE)
+				|| showChartsProperty.getValue(INDEX_POYNTING_THEOREM)
+				|| showChartsProperty.getValue(INDEX_INTEGRATED_DIV_S)
+				|| showChartsProperty.getValue(INDEX_INTEGRATED_B_ROT_E_MINUS_E_ROT_B)
+				|| showChartsProperty.getValue(INDEX_INTEGRATED_JE)
+				|| showChartsProperty.getValue(INDEX_INTEGRATED_POYNTING_THEOREM_1)
+				|| showChartsProperty.getValue(INDEX_INTEGRATED_POYNTING_THEOREM_2)) {
+			poyntingTheorem = PoyntingTheoremBuffer.getOrAppendInstance(s);
+
+			double energyDensityDerivative = poyntingTheorem.getTotalEnergyDensityDerivative();
+			double divS1 = poyntingTheorem.getTotalDivS1();
+			double divS2 = poyntingTheorem.getTotalDivS2();
+			double jS = poyntingTheorem.getTotalJE();
+			double poyntingTheoremSum = energyDensityDerivative + divS1 + jS;
+			double integratedDivS1 = poyntingTheorem.getIntegratedTotalDivS1();
+			double integratedDivS2 = poyntingTheorem.getIntegratedTotalDivS2();
+			double integratedJS = poyntingTheorem.getIntegratedTotalJE();
+			double integratedPoyntingTheorem1 = poyntingTheorem.getTotalEnergyDensity()
+					+ integratedDivS1 + integratedJS;
+			double integratedPoyntingTheorem2 = poyntingTheorem.getTotalEnergyDensity()
+					+ integratedDivS2 + integratedJS;
+
+			traces[INDEX_ENERGY_DENSITY_DERIVATIVE].addPoint(time, energyDensityDerivative);
+			traces[INDEX_DIV_S].addPoint(time, divS1);
+			traces[INDEX_B_ROT_E_MINUS_E_ROT_B].addPoint(time, divS2);
+			traces[INDEX_JE].addPoint(time, jS);
+			traces[INDEX_POYNTING_THEOREM].addPoint(time, poyntingTheoremSum);
+			traces[INDEX_INTEGRATED_DIV_S].addPoint(time, integratedDivS1);
+			traces[INDEX_INTEGRATED_B_ROT_E_MINUS_E_ROT_B].addPoint(time, integratedDivS2);
+			traces[INDEX_INTEGRATED_JE].addPoint(time, integratedJS);
+			traces[INDEX_INTEGRATED_POYNTING_THEOREM_1].addPoint(time, integratedPoyntingTheorem1);
+			traces[INDEX_INTEGRATED_POYNTING_THEOREM_2].addPoint(time, integratedPoyntingTheorem2);
 		}
 
 		for (int i = 0; i < showChartsProperty.getSize(); i++) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/chart/Chart2DPanel.java
@@ -42,11 +42,14 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 	public final int INDEX_TOTAL_CHARGE_SQUARED = 9;
 	public final int INDEX_ENERGY_DENSITY_DERIVATIVE = 10;
 	public final int INDEX_DIV_S = 11;
-	public final int INDEX_JE = 12;
-	public final int INDEX_POYNTING_THEOREM = 13;
-	public final int INDEX_INTEGRATED_DIV_S = 14;
-	public final int INDEX_INTEGRATED_JE = 15;
-	public final int INDEX_INTEGRATED_POYNTING_THEOREM = 16;
+	public final int INDEX_B_ROT_E_MINUS_E_ROT_B = 12;
+	public final int INDEX_JE = 13;
+	public final int INDEX_POYNTING_THEOREM = 14;
+	public final int INDEX_INTEGRATED_DIV_S = 15;
+	public final int INDEX_INTEGRATED_B_ROT_E_MINUS_E_ROT_B = 16;
+	public final int INDEX_INTEGRATED_JE = 17;
+	public final int INDEX_INTEGRATED_POYNTING_THEOREM_1 = 18;
+	public final int INDEX_INTEGRATED_POYNTING_THEOREM_2 = 19;
 
 	String[] chartLabel = new String[] {
 			"Gauss law violation",
@@ -61,31 +64,37 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 			"Total charge squared",
 			"dE/dt",
 			"div S",
+			"B rot E - E rot B",
 			"J*E",
 			"dE/dt + div S + J*E",
-			"Integrated div S",
-			"Integrated J*E",
-			"E + Integrated(div S + J*E)"
+			"Time-integrated div S",
+			"Time-integrated B rot E - E rot B",
+			"Time-integrated J*E",
+			"E + time-integrated(div S + J*E)",
+			"E + time-integrated(B rot E - E rot B + J*E)"
 	};
 
 	Color[] traceColors = new Color[] {
-			Color.red,
+			Color.red,//Gauss law violation
 			Color.green,
 			Color.blue,
 			Color.black,
-			Color.red,
+			Color.red,//px
 			Color.green,
 			Color.blue,
 			Color.magenta,
-			Color.darkGray,
+			Color.darkGray,//Total charge
 			Color.darkGray,
 			Color.orange,
-			Color.cyan,
+			Color.cyan,//div S
+			Color.green,
 			Color.blue,
 			Color.black,
-			Color.red,
+			Color.red,//Time-integrated div S
+			Color.blue,//Time-integrated B rot E - E rot B
 			Color.green,
-			Color.pink
+			Color.pink,
+			Color.black
 	};
 
 	public BooleanProperties logarithmicProperty;
@@ -172,13 +181,18 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 		double totalChargeSquared = fieldMeasurements.calculateTotalChargeSquared(s.grid);
 
 		double energyDensityDerivative = poyntingTheorem.getTotalEnergyDensityDerivative();
-		double divS = poyntingTheorem.getTotalDivS();
+		double divS1 = poyntingTheorem.getTotalDivS1();
+		double divS2 = poyntingTheorem.getTotalDivS2();
 		double jS = poyntingTheorem.getTotalJE();
-		double poyntingTheoremSum = energyDensityDerivative + divS + jS;
-		double integratedDivS = poyntingTheorem.getIntegratedTotalDivS();
+		double poyntingTheoremSum = energyDensityDerivative + divS1 + jS;
+		double integratedDivS1 = poyntingTheorem.getIntegratedTotalDivS1();
+		double integratedDivS2 = poyntingTheorem.getIntegratedTotalDivS2();
+		double integratedBrotEminusErotB = poyntingTheorem.getIntegratedTotalDivS2();
 		double integratedJS = poyntingTheorem.getIntegratedTotalJE();
-		double integratedPoyntingTheorem = poyntingTheorem.getTotalEnergyDensity()
-				+ integratedDivS + integratedJS;
+		double integratedPoyntingTheorem1 = poyntingTheorem.getTotalEnergyDensity()
+				+ integratedDivS1 + integratedJS;
+		double integratedPoyntingTheorem2 = poyntingTheorem.getTotalEnergyDensity()
+				+ integratedDivS2 + integratedJS;
 
 		traces[INDEX_E_SQUARED].addPoint(time, eSquared);
 		traces[INDEX_B_SQUARED].addPoint(time, bSquared);
@@ -190,12 +204,15 @@ public class Chart2DPanel extends AnimationChart2DPanel {
 		traces[INDEX_TOTAL_CHARGE].addPoint(time, totalCharge);
 		traces[INDEX_TOTAL_CHARGE_SQUARED].addPoint(time, totalChargeSquared);
 		traces[INDEX_ENERGY_DENSITY_DERIVATIVE].addPoint(time, energyDensityDerivative);
-		traces[INDEX_DIV_S].addPoint(time, divS);
+		traces[INDEX_DIV_S].addPoint(time, divS1);
+		traces[INDEX_B_ROT_E_MINUS_E_ROT_B].addPoint(time, divS2);
 		traces[INDEX_JE].addPoint(time, jS);
 		traces[INDEX_POYNTING_THEOREM].addPoint(time, poyntingTheoremSum);
-		traces[INDEX_INTEGRATED_DIV_S].addPoint(time, integratedDivS);
+		traces[INDEX_INTEGRATED_DIV_S].addPoint(time, integratedDivS1);
+		traces[INDEX_INTEGRATED_B_ROT_E_MINUS_E_ROT_B].addPoint(time, integratedDivS2);
 		traces[INDEX_INTEGRATED_JE].addPoint(time, integratedJS);
-		traces[INDEX_INTEGRATED_POYNTING_THEOREM].addPoint(time, integratedPoyntingTheorem);
+		traces[INDEX_INTEGRATED_POYNTING_THEOREM_1].addPoint(time, integratedPoyntingTheorem1);
+		traces[INDEX_INTEGRATED_POYNTING_THEOREM_2].addPoint(time, integratedPoyntingTheorem2);
 
 		if (showChartsProperty.getValue(INDEX_ENERGY_DENSITY_2)) {
 			occupationNumbers.initialize(s);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensity2DGLPanel.java
@@ -39,17 +39,21 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 	public static final int INDEX_ENERGY_DENSITY = 0;
 	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE = 1;
 	public static final int INDEX_DIV_POYNTING = 2;
-	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_DIV_POYNTING = 3;
-	public static final int INDEX_CURRENT_ELECTRIC_FIELD = 4;
-	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_DIV_POYNTING_CURRENT = 5;
+	public static final int INDEX_B_ROT_E_MINUS_E_ROT_B = 3;
+	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_DIV_POYNTING = 4;
+	public static final int INDEX_CURRENT_ELECTRIC_FIELD = 5;
+	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_DIV_POYNTING_CURRENT = 6;
+	public static final int INDEX_ENERGY_DENSITY_DERIVATIVE_B_ROT_E_MINUS_E_ROT_B_CURRENT = 7;
 
 	String[] dataLabel = new String[] {
 			"Energy density",
 			"dE/dt",
 			"div S",
+			"B rot E - E rot B",
 			"dE/dt + div S",
 			"j*E",
-			"dE/dt + div S + j*E"
+			"dE/dt + div S + j*E",
+			"dE/dt + (B rot E - E rot B) + j*E"
 	};
 
 	public static final int RED = 0;
@@ -125,16 +129,24 @@ public class EnergyDensity2DGLPanel extends AnimationGLPanel {
 						value = poyntingTheorem.getEnergyDensityDerivative(index);
 						break;
 					case INDEX_DIV_POYNTING:
+						value = poyntingTheorem.getDivPoyntingVector4(index);
+						break;
+					case INDEX_B_ROT_E_MINUS_E_ROT_B:
 						value = poyntingTheorem.getDivPoyntingVector3(index);
 						break;
 					case INDEX_ENERGY_DENSITY_DERIVATIVE_DIV_POYNTING:
 						value = poyntingTheorem.getEnergyDensityDerivative(index)
-							+ poyntingTheorem.getDivPoyntingVector3(index);
+							+ poyntingTheorem.getDivPoyntingVector4(index);
 						break;
 					case INDEX_CURRENT_ELECTRIC_FIELD:
 						value = poyntingTheorem.getCurrentElectricField2(index);
 						break;
 					case INDEX_ENERGY_DENSITY_DERIVATIVE_DIV_POYNTING_CURRENT:
+						value = poyntingTheorem.getEnergyDensityDerivative(index)
+							+ poyntingTheorem.getDivPoyntingVector4(index)
+							+ poyntingTheorem.getCurrentElectricField2(index);
+						break;
+					case INDEX_ENERGY_DENSITY_DERIVATIVE_B_ROT_E_MINUS_E_ROT_B_CURRENT:
 						value = poyntingTheorem.getEnergyDensityDerivative(index)
 							+ poyntingTheorem.getDivPoyntingVector3(index)
 							+ poyntingTheorem.getCurrentElectricField2(index);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlOutput.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlOutput.java
@@ -31,6 +31,7 @@ public class YamlOutput {
 
 	public ArrayList<YamlPlanarFields> planarFields = new ArrayList<YamlPlanarFields>();
 
+	public ArrayList<YamlPoyntingTheoremInTime> poyntingTheoremInTime = new ArrayList<YamlPoyntingTheoremInTime>();
 
 	/**
 	 * Creates FileGenerator instances and applies them to the Settings instance.
@@ -78,6 +79,10 @@ public class YamlOutput {
 		}
 
 		for(YamlPlanarFields output : planarFields) {
+			s.addDiagnostics(output.getFileGenerator());
+		}
+
+		for(YamlPoyntingTheoremInTime output : poyntingTheoremInTime) {
 			s.addDiagnostics(output.getFileGenerator());
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlPoyntingTheoremInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlPoyntingTheoremInTime.java
@@ -1,0 +1,32 @@
+package org.openpixi.pixi.ui.util.yaml.filegenerators;
+
+import org.openpixi.pixi.diagnostics.methods.PoyntingTheoremInTime;
+
+import java.util.ArrayList;
+
+/**
+ * Yaml wrapper for the YamlParticlesInTime FileGenerator.
+ */
+public class YamlPoyntingTheoremInTime {
+
+	/**
+	 * File name.
+	 */
+	public String path;
+
+	/**
+	 * Measurement interval.
+	 */
+	public double interval;
+
+
+	/**
+	 * Returns an instance of BulkQuantitiesInTime according to the parameters in the YAML file.
+	 *
+	 * @return Instance of BulkQuantitiesInTime.
+	 */
+	public PoyntingTheoremInTime getFileGenerator() {
+		PoyntingTheoremInTime fileGen = new PoyntingTheoremInTime(path, interval);
+		return fileGen;
+	}
+}


### PR DESCRIPTION
- A new diagnostics class PoyntingTheoremInTime is added. The usage can be seen in the file `pixi/input/current/MV model/MVModel_NGP_with_output.yaml`
- "div S" and "B rot E - E rot B" are treated separately and can be separately selected in the Chart2DPanel or in the EnergyDensity2GLPanel .
- Chart2DPanel only calculates Poynting theorem quantities if at least one quantity is selected for displaying.
