### PR TITLE
Bugfix for the Poynting theorem calculation

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
@@ -46,7 +46,7 @@ public class PoyntingTheoremInTime implements Diagnostics {
 		this.s = s;
 		this.stepInterval = (int) (timeInterval / this.s.getTimeStep());
 		poyntingTheorem = PoyntingTheoremBuffer.getOrAppendInstance(s);
-		poyntingTheorem.initialize(s);
+		//poyntingTheorem.initialize(s);
 
 		if(!supressOutput) {
 			// Create/delete file.

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
@@ -46,6 +46,7 @@ public class PoyntingTheoremInTime implements Diagnostics {
 		this.s = s;
 		this.stepInterval = (int) (timeInterval / this.s.getTimeStep());
 		poyntingTheorem = PoyntingTheoremBuffer.getOrAppendInstance(s);
+		poyntingTheorem.initialize(s);
 
 		if(!supressOutput) {
 			// Create/delete file.

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
@@ -356,7 +356,7 @@ public class Simulation {
 
 		// 1) Initialize and run diagnostics before first simulation step.
 		if(totalSimulationSteps == 0) {
-			for (int i = 0; i< diagnostics.size(); i++) {
+			for (int i = 0; i< diagnostics.size(); i++) {	//Attention! Size of the diagnostics may change during the initialization!!
 				diagnostics.get(i).initialize(this);
 			}
 			runDiagnostics();

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
@@ -356,8 +356,8 @@ public class Simulation {
 
 		// 1) Initialize and run diagnostics before first simulation step.
 		if(totalSimulationSteps == 0) {
-			for (Diagnostics d: diagnostics) {
-				d.initialize(this);
+			for (int i = 0; i< diagnostics.size(); i++) {
+				diagnostics.get(i).initialize(this);
 			}
 			runDiagnostics();
 		}


### PR DESCRIPTION
There was a bug during the initialization of the diagnostics ArrayList, caused by PoyntingTheoremBuffer adding a new element while being inside of a for-loop over the same ArrayList. Fixed by making the end of the for-loop dynamic.
