### PR TITLE
Infrared regulator for the Poisson solver

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
@@ -50,6 +50,12 @@ public class DualMVModel implements ICurrentGenerator {
 	private double lowPassCoefficient;
 
 	/**
+	 * Infrared regulator for the Poisson solver.
+	 */
+	private double infraredCoefficient;
+
+
+	/**
 	 * Initial condition output
 	 */
 	private String outputFile;
@@ -65,7 +71,8 @@ public class DualMVModel implements ICurrentGenerator {
 	private MVModel mv2;
 
 
-	public DualMVModel(int direction, double location, double longitudinalWidth, double mu, double lowPassCoefficient,
+	public DualMVModel(int direction, double location, double longitudinalWidth, double mu,
+					   double lowPassCoefficient, double infraredCoefficient,
 					   boolean useSeed, int seed1, int seed2, boolean createInitialConditionsOutput, String outputFile,
 					   boolean useAlternativeNormalization){
 		this.direction = direction;
@@ -73,6 +80,7 @@ public class DualMVModel implements ICurrentGenerator {
 		this.longitudinalWidth = longitudinalWidth;
 		this.mu = mu;
 		this.lowPassCoefficient = lowPassCoefficient;
+		this.infraredCoefficient = infraredCoefficient;
 
 		this.useSeed = useSeed;
 		this.seed1 = seed1;
@@ -85,13 +93,12 @@ public class DualMVModel implements ICurrentGenerator {
 	}
 
 	public void initializeCurrent(Simulation s, int totalInstances) {
-		if(useSeed){
-			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, seed1, lowPassCoefficient, useAlternativeNormalization);
-			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu, seed2, lowPassCoefficient, useAlternativeNormalization);
-		} else {
-			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, lowPassCoefficient, useAlternativeNormalization);
-			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu, lowPassCoefficient, useAlternativeNormalization);
-		}
+
+		mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, useSeed, seed1,
+				lowPassCoefficient, infraredCoefficient, useAlternativeNormalization);
+
+		mv2 = new MVModel(direction, -1,  -(location+1), longitudinalWidth, mu, useSeed, seed2,
+				lowPassCoefficient, infraredCoefficient, useAlternativeNormalization);
 
 		mv1.initializeCurrent(s, totalInstances);
 		mv2.initializeCurrent(s, totalInstances);

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
@@ -41,9 +41,18 @@ public class MVModel implements ICurrentGenerator {
 	private int seed;
 
 	/**
-	 *
+	 * Coefficient used for the UV regulator, which is implemented as a hard cutoff. This parameter is given in units of
+	 * the maximum lattice momentum. A value of 1.0 corresponds to no UV cutoff. A value of 0.0 cuts off all modes in
+	 * momentum space.
 	 */
-	private double lowPassCoefficient = 1.0;
+	private double lowPassCoefficient ;
+
+	/**
+	 * Coefficient used for the IR regulator, which is implemented as a mass-term in the Poisson solver. As with the
+	 * UV regulator this coefficient is given in units of the lattice momentum. A value of 0.0 removes the IR regulator,
+	 * any other value leads to a finite mass term in the Poisson equation.
+	 */
+	private double infraredCoefficient;
 
 	/**
 	 * Option whether to use the \mu^2 (true) or the g^2 \mu^2 (false) normalization for the Gaussian
@@ -53,21 +62,18 @@ public class MVModel implements ICurrentGenerator {
 
 	protected ParticleLCCurrent particleLCCurrent;
 
-
-	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu, double lowPassCoefficient, boolean useAlternativeNormalization) {
-		this(direction, orientation, location, longitudinalWidth, mu, 0, lowPassCoefficient, useAlternativeNormalization);
-		this.useSeed = false;
-	}
-
-	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu, int seed, double lowPassCoefficient, boolean useAlternativeNormalization){
+	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu,
+				   boolean useSeed, int seed,
+				   double lowPassCoefficient, double infraredCoefficient, boolean useAlternativeNormalization){
 		this.direction = direction;
 		this.orientation = orientation;
 		this.location = location;
 		this.longitudinalWidth = longitudinalWidth;
 		this.mu = mu;
+		this.useSeed = useSeed;
 		this.seed = seed;
-		this.useSeed = true;
 		this.lowPassCoefficient = lowPassCoefficient;
+		this.infraredCoefficient = infraredCoefficient;
 		this.useAlternativeNormalization = useAlternativeNormalization;
 	}
 
@@ -124,6 +130,7 @@ public class MVModel implements ICurrentGenerator {
 			this.particleLCCurrent = new ParticleLCCurrentNGP(direction, orientation, location, longitudinalWidth);
 		}
 		particleLCCurrent.lowPassCoefficient = lowPassCoefficient;
+		particleLCCurrent.infraredCoefficient = infraredCoefficient;
 		particleLCCurrent.setTransversalChargeDensity(transversalChargeDensity);
 		particleLCCurrent.initializeCurrent(s, totalInstances);
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/ParticleLCCurrent.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/ParticleLCCurrent.java
@@ -80,6 +80,12 @@ public class ParticleLCCurrent implements ICurrentGenerator {
 	 */
 	public double lowPassCoefficient = 1.0;
 
+
+	/**
+	 * Infrared regulator for the Poisson solver
+	 */
+	public double infraredCoefficient = 0.0;
+
 	/**
 	 * Standard constructor for the ParticleLCCurrent class.
 	 *
@@ -132,6 +138,7 @@ public class ParticleLCCurrent implements ICurrentGenerator {
 		poissonSolver = new NewLCPoissonSolver(direction, orientation, location, longitudinalWidth,
 				transversalChargeDensity, transversalNumCells);
 		poissonSolver.lowPassCoefficient = lowPassCoefficient;
+		poissonSolver.infraredCoefficient = infraredCoefficient;
 		poissonSolver.initialize(s);
 		poissonSolver.solve(s);
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlDualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlDualMVModel.java
@@ -29,6 +29,11 @@ public class YamlDualMVModel {
 	public Double lowPassCoefficient = 1.0;
 
 	/**
+	 * Coefficient infrared regulator in the Poisson solver
+	 */
+	public Double infraredCoefficient = 0.0;
+
+	/**
 	 * Seeds to use for the random number generator
 	 */
 	public Integer randomSeed1 = null;
@@ -52,12 +57,17 @@ public class YamlDualMVModel {
 
 
 	public DualMVModel getCurrentGenerator() {
-		if(randomSeed1 != null && randomSeed2 != null) {
-			return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient, true,
-					randomSeed1, randomSeed2, createInitialConditionsOutput, outputFile, useAlternativeNormalization);
+		boolean useSeed = (randomSeed1 != null && randomSeed2 != null);
+		if(!useSeed) {
+			randomSeed1 = 0;
+			randomSeed2 = 0;
 		}
-		return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient, false, 0, 0,
-				createInitialConditionsOutput, outputFile, useAlternativeNormalization);
+
+		return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu,
+				lowPassCoefficient,  infraredCoefficient,
+				useSeed, randomSeed1, randomSeed2,
+				createInitialConditionsOutput, outputFile,
+				useAlternativeNormalization);
 	}
 
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlMVModel.java
@@ -34,6 +34,11 @@ public class YamlMVModel {
 	public Double lowPassCoefficient = 1.0;
 
 	/**
+	 * Coefficient infrared regulator in the Poisson solver
+	 */
+	public Double infraredCoefficient = 0.0;
+
+	/**
 	 * Seed to use for the random number generator
 	 */
 	public Integer randomSeed;
@@ -46,12 +51,12 @@ public class YamlMVModel {
 
 
 	public MVModel getCurrentGenerator() {
-		if(randomSeed != null) {
-			return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu, randomSeed,
-					lowPassCoefficient, useAlternativeNormalization);
+		boolean useSeed = (randomSeed != null);
+		if(!useSeed) {
+			randomSeed = 0;
 		}
-		return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient,
-				useAlternativeNormalization);
+		return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu, useSeed, randomSeed,
+				lowPassCoefficient, infraredCoefficient, useAlternativeNormalization);
 	}
 
 }


### PR DESCRIPTION
Added an optional mass term to the Poisson solver. 
_infraredCoefficient_ can be set for _MVModel_ and _DualMVModel_, just like _lowPassCoefficient_. It is also measured in units of the maximum lattice momentum. 

YAML example:

```
currents:
  dualMVModels:
    - direction: 0
      longitudinalLocation: 32
      longitudinalWidth: 8.0
      mu: 0.1
      lowPassCoefficient: 0.1
      infraredCoefficient: 0.001
      createInitialConditionsOutput: true
      outputFile: "planarInitial.dat"
```
