### PR TITLE
NGP optimizations

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
@@ -50,6 +50,12 @@ public class DualMVModel implements ICurrentGenerator {
 	private double lowPassCoefficient;
 
 	/**
+	 * Infrared regulator for the Poisson solver.
+	 */
+	private double infraredCoefficient;
+
+
+	/**
 	 * Initial condition output
 	 */
 	private String outputFile;
@@ -65,7 +71,8 @@ public class DualMVModel implements ICurrentGenerator {
 	private MVModel mv2;
 
 
-	public DualMVModel(int direction, double location, double longitudinalWidth, double mu, double lowPassCoefficient,
+	public DualMVModel(int direction, double location, double longitudinalWidth, double mu,
+					   double lowPassCoefficient, double infraredCoefficient,
 					   boolean useSeed, int seed1, int seed2, boolean createInitialConditionsOutput, String outputFile,
 					   boolean useAlternativeNormalization){
 		this.direction = direction;
@@ -73,6 +80,7 @@ public class DualMVModel implements ICurrentGenerator {
 		this.longitudinalWidth = longitudinalWidth;
 		this.mu = mu;
 		this.lowPassCoefficient = lowPassCoefficient;
+		this.infraredCoefficient = infraredCoefficient;
 
 		this.useSeed = useSeed;
 		this.seed1 = seed1;
@@ -85,13 +93,12 @@ public class DualMVModel implements ICurrentGenerator {
 	}
 
 	public void initializeCurrent(Simulation s, int totalInstances) {
-		if(useSeed){
-			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, seed1, lowPassCoefficient, useAlternativeNormalization);
-			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu, seed2, lowPassCoefficient, useAlternativeNormalization);
-		} else {
-			mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, lowPassCoefficient, useAlternativeNormalization);
-			mv2 = new MVModel(direction, -1, -(location+1), longitudinalWidth, mu, lowPassCoefficient, useAlternativeNormalization);
-		}
+
+		mv1 = new MVModel(direction, 1, location, longitudinalWidth, mu, useSeed, seed1,
+				lowPassCoefficient, infraredCoefficient, useAlternativeNormalization);
+
+		mv2 = new MVModel(direction, -1,  -(location+1), longitudinalWidth, mu, useSeed, seed2,
+				lowPassCoefficient, infraredCoefficient, useAlternativeNormalization);
 
 		mv1.initializeCurrent(s, totalInstances);
 		mv2.initializeCurrent(s, totalInstances);

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/MVModel.java
@@ -41,9 +41,18 @@ public class MVModel implements ICurrentGenerator {
 	private int seed;
 
 	/**
-	 *
+	 * Coefficient used for the UV regulator, which is implemented as a hard cutoff. This parameter is given in units of
+	 * the maximum lattice momentum. A value of 1.0 corresponds to no UV cutoff. A value of 0.0 cuts off all modes in
+	 * momentum space.
 	 */
-	private double lowPassCoefficient = 1.0;
+	private double lowPassCoefficient ;
+
+	/**
+	 * Coefficient used for the IR regulator, which is implemented as a mass-term in the Poisson solver. As with the
+	 * UV regulator this coefficient is given in units of the lattice momentum. A value of 0.0 removes the IR regulator,
+	 * any other value leads to a finite mass term in the Poisson equation.
+	 */
+	private double infraredCoefficient;
 
 	/**
 	 * Option whether to use the \mu^2 (true) or the g^2 \mu^2 (false) normalization for the Gaussian
@@ -53,21 +62,18 @@ public class MVModel implements ICurrentGenerator {
 
 	protected ParticleLCCurrent particleLCCurrent;
 
-
-	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu, double lowPassCoefficient, boolean useAlternativeNormalization) {
-		this(direction, orientation, location, longitudinalWidth, mu, 0, lowPassCoefficient, useAlternativeNormalization);
-		this.useSeed = false;
-	}
-
-	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu, int seed, double lowPassCoefficient, boolean useAlternativeNormalization){
+	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu,
+				   boolean useSeed, int seed,
+				   double lowPassCoefficient, double infraredCoefficient, boolean useAlternativeNormalization){
 		this.direction = direction;
 		this.orientation = orientation;
 		this.location = location;
 		this.longitudinalWidth = longitudinalWidth;
 		this.mu = mu;
+		this.useSeed = useSeed;
 		this.seed = seed;
-		this.useSeed = true;
 		this.lowPassCoefficient = lowPassCoefficient;
+		this.infraredCoefficient = infraredCoefficient;
 		this.useAlternativeNormalization = useAlternativeNormalization;
 	}
 
@@ -124,6 +130,7 @@ public class MVModel implements ICurrentGenerator {
 			this.particleLCCurrent = new ParticleLCCurrentNGP(direction, orientation, location, longitudinalWidth);
 		}
 		particleLCCurrent.lowPassCoefficient = lowPassCoefficient;
+		particleLCCurrent.infraredCoefficient = infraredCoefficient;
 		particleLCCurrent.setTransversalChargeDensity(transversalChargeDensity);
 		particleLCCurrent.initializeCurrent(s, totalInstances);
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/ParticleLCCurrent.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/ParticleLCCurrent.java
@@ -80,6 +80,12 @@ public class ParticleLCCurrent implements ICurrentGenerator {
 	 */
 	public double lowPassCoefficient = 1.0;
 
+
+	/**
+	 * Infrared regulator for the Poisson solver
+	 */
+	public double infraredCoefficient = 0.0;
+
 	/**
 	 * Standard constructor for the ParticleLCCurrent class.
 	 *
@@ -132,6 +138,7 @@ public class ParticleLCCurrent implements ICurrentGenerator {
 		poissonSolver = new NewLCPoissonSolver(direction, orientation, location, longitudinalWidth,
 				transversalChargeDensity, transversalNumCells);
 		poissonSolver.lowPassCoefficient = lowPassCoefficient;
+		poissonSolver.infraredCoefficient = infraredCoefficient;
 		poissonSolver.initialize(s);
 		poissonSolver.solve(s);
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/ParticleLCCurrentNGP.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/ParticleLCCurrentNGP.java
@@ -3,6 +3,7 @@ package org.openpixi.pixi.physics.fields.currentgenerators;
 import org.openpixi.pixi.math.AlgebraElement;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.particles.CGCParticle;
+import org.openpixi.pixi.physics.particles.IParticle;
 import org.openpixi.pixi.physics.util.GridFunctions;
 
 import java.util.ArrayList;
@@ -25,11 +26,6 @@ public class ParticleLCCurrentNGP extends ParticleLCCurrent {
 
 	@Override
 	public void initializeParticles(Simulation s, int particlesPerLink) {
-
-		int longitudinalCells = s.grid.getNumCells(direction);
-		CGCParticle[][] longitudinalParticleArray = new CGCParticle[totalTransversalCells][longitudinalCells * particlesPerLink];
-
-
 		double cutoffCharge = 10E-22 * Math.pow( g * as, 2) / (Math.pow(as, 3) * particlesPerLink);
 
 		ArrayList<ArrayList<CGCParticle>> longitudinalParticleList = new ArrayList<ArrayList<CGCParticle>>(totalTransversalCells);
@@ -88,7 +84,7 @@ public class ParticleLCCurrentNGP extends ParticleLCCurrent {
 		}
 
 		// Charge refinement
-		int numberOfIterations = 50;
+		int numberOfIterations = 100;
 		for (int i = 0; i < totalTransversalCells; i++) {
 			ArrayList<CGCParticle> particleList = longitudinalParticleList.get(i);
 			// 2nd order refinement
@@ -105,6 +101,13 @@ public class ParticleLCCurrentNGP extends ParticleLCCurrent {
 				}
 			}
 		}
+
+		// Make sure particle charges Q0 and Q1 are the same.
+		for(IParticle p : s.particles) {
+			CGCParticle P = (CGCParticle) p;
+			P.Q1 = P.Q0.copy();
+		}
+
 	}
 
 	private void refine2(int i, ArrayList<CGCParticle> list, int particlesPerLink) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCParticleInterpolationNGP.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCParticleInterpolationNGP.java
@@ -64,9 +64,6 @@ public class CGCParticleInterpolationNGP implements  InterpolatorAlgorithm {
 	public void interpolateToParticle(IParticle p, Grid g) {
 		// Compute parallel transport for the particle.
 		CGCParticle P = (CGCParticle) p;
-		GroupElement identity = g.getElementFactory().groupIdentity();
-
-		double at = g.getTemporalSpacing();
 		double as = g.getLatticeSpacing();
 		int direction = P.direction;
 
@@ -79,8 +76,8 @@ public class CGCParticleInterpolationNGP implements  InterpolatorAlgorithm {
 		int[] ngpNew = GridFunctions.nearestGridPoint(newPosition, as);
 
 		if(ngpOld[direction] == ngpNew[direction]) {
-			// one cell move
-			 P.U = identity;
+			// one cell move: do nothing!
+			//P.U = identity;
 		} else {
 			// two cell move
 			int cellIndexOld = g.getCellIndex(ngpOld);
@@ -91,6 +88,7 @@ public class CGCParticleInterpolationNGP implements  InterpolatorAlgorithm {
 			} else {
 				P.U = g.getUnext(cellIndexNew, direction).adj();
 			}
+			P.updateCharge = true;
 		}
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/movement/solver/CGCParticleSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/movement/solver/CGCParticleSolver.java
@@ -1,5 +1,6 @@
 package org.openpixi.pixi.physics.movement.solver;
 
+import org.openpixi.pixi.math.AlgebraElement;
 import org.openpixi.pixi.physics.force.Force;
 import org.openpixi.pixi.physics.particles.CGCParticle;
 import org.openpixi.pixi.physics.particles.IParticle;
@@ -22,8 +23,16 @@ public class CGCParticleSolver implements ParticleSolver {
 
 	public void updateCharge(IParticle p, Force f, double dt) {
 		CGCParticle P = (CGCParticle) p;
-
-		P.Q1 = P.Q0.act(P.U.adj());
+		if(P.updateCharge) {
+			// Charge has to be parallel transported.
+			P.Q1 = P.Q0.act(P.U.adj());
+			P.updateCharge = false;
+		} else {
+			// No update needed, just switch Q1 and Q0.
+			AlgebraElement Q = P.Q1;
+			P.Q1 = P.Q0;
+			P.Q0 = Q;
+		}
 	}
 
 	public void prepare(IParticle p, Force f, double step) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCParticle.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCParticle.java
@@ -11,11 +11,13 @@ public class CGCParticle extends YangMillsParticle {
 
 	public int direction;
 	public GroupElement U;
+	public boolean updateCharge;
 
 	public CGCParticle(int numberOfDimensions, int numberOfColors, int direction) {
 		super(numberOfDimensions, numberOfColors);
 		this.direction = direction;
 		this.U = (new ElementFactory(numberOfColors)).groupIdentity();
+		this.updateCharge = true;
 	}
 
 	public IParticle copy() {
@@ -31,6 +33,7 @@ public class CGCParticle extends YangMillsParticle {
 
 		p.setRadius(this.r);
 		p.setDisplayColor(this.col);
+		p.updateCharge = this.updateCharge;
 
 		return p;
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
@@ -60,15 +60,15 @@ public class MainBatch {
 			if(file.exists()) {
 				if(file.isFile()) {
 					try {
-						System.out.println("Running " + file.getPath());
+						System.out.println("MainBatch: Running " + file.getPath());
 						String string = FileIO.readFile(file);
 						runSimulationFromString(string);
 
 					} catch (IOException e) {
-						System.out.println("Error opening " + args[0]);
+						System.out.println("MainBatch: Error opening " + args[0]);
 					}
 				} else if(file.isDirectory()){
-					System.out.println("Loading configuration files from " + file.getPath());
+					System.out.println("MainBatch: Loading configuration files from " + file.getPath());
 					FilenameFilter filter = new FilenameFilter() {
 						public boolean accept(File dir, String name) {
 							return name.toLowerCase().endsWith(".yaml");
@@ -76,27 +76,35 @@ public class MainBatch {
 					File[] listOfFiles = file.listFiles(filter);
 					for(File f : listOfFiles) {
 						try {
-							System.out.println("Running " + f.getPath());
+							System.out.println("MainBatch: Running " + f.getPath());
 							String string = FileIO.readFile(f);
 							runSimulationFromString(string);
 						} catch (IOException e) {
-							System.out.println("Error opening " + f.getPath());
+							System.out.println("MainBatch: Error opening " + f.getPath());
 						}
 					}
 				}
 			}
 		}
-		System.out.println("Done!");
+		System.out.println("MainBatch: Done!");
 		System.exit(0);
 	}
 
 	public static void runSimulationFromString(String configurationString) {
 		initializeSimulationFromString(configurationString);
+
+		// Simulation run and time measurement
+		long t0 = System.nanoTime();
 		try {
 			simulation.run();
 		} catch (IOException e) {
 			System.out.println("MainBatch: something went wrong.");
 		}
+
+		// dt in seconds
+		long t1 = System.nanoTime();
+		int dt = (int) ((t1 - t0) / 1000 / 1000 / 1000);
+		System.out.println("MainBatch: Simulation time: " + dt + " s.");
 	}
 
 	public static void initializeSimulationFromString(String configurationString) {
@@ -105,8 +113,16 @@ public class MainBatch {
 		YamlParser yamlParser = new YamlParser(settings);
 		yamlParser.parseString(configurationString);
 
+		// Initialization time measurement
+		long t0 = System.nanoTime();
+
 		// Initialize the simulation
 		simulation = new Simulation(settings);
+
+		// dt in milliseconds
+		long t1 = System.nanoTime();
+		int dt = (int) ((t1 - t0) / 1000 / 1000);
+		System.out.println("MainBatch: Initialization time: " + dt + " ms.");
 	}
 
 	public static void step() {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlDualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlDualMVModel.java
@@ -29,6 +29,11 @@ public class YamlDualMVModel {
 	public Double lowPassCoefficient = 1.0;
 
 	/**
+	 * Coefficient infrared regulator in the Poisson solver
+	 */
+	public Double infraredCoefficient = 0.0;
+
+	/**
 	 * Seeds to use for the random number generator
 	 */
 	public Integer randomSeed1 = null;
@@ -52,12 +57,17 @@ public class YamlDualMVModel {
 
 
 	public DualMVModel getCurrentGenerator() {
-		if(randomSeed1 != null && randomSeed2 != null) {
-			return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient, true,
-					randomSeed1, randomSeed2, createInitialConditionsOutput, outputFile, useAlternativeNormalization);
+		boolean useSeed = (randomSeed1 != null && randomSeed2 != null);
+		if(!useSeed) {
+			randomSeed1 = 0;
+			randomSeed2 = 0;
 		}
-		return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient, false, 0, 0,
-				createInitialConditionsOutput, outputFile, useAlternativeNormalization);
+
+		return new DualMVModel(direction, longitudinalLocation, longitudinalWidth, mu,
+				lowPassCoefficient,  infraredCoefficient,
+				useSeed, randomSeed1, randomSeed2,
+				createInitialConditionsOutput, outputFile,
+				useAlternativeNormalization);
 	}
 
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/currentgenerators/YamlMVModel.java
@@ -34,6 +34,11 @@ public class YamlMVModel {
 	public Double lowPassCoefficient = 1.0;
 
 	/**
+	 * Coefficient infrared regulator in the Poisson solver
+	 */
+	public Double infraredCoefficient = 0.0;
+
+	/**
 	 * Seed to use for the random number generator
 	 */
 	public Integer randomSeed;
@@ -46,12 +51,12 @@ public class YamlMVModel {
 
 
 	public MVModel getCurrentGenerator() {
-		if(randomSeed != null) {
-			return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu, randomSeed,
-					lowPassCoefficient, useAlternativeNormalization);
+		boolean useSeed = (randomSeed != null);
+		if(!useSeed) {
+			randomSeed = 0;
 		}
-		return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu, lowPassCoefficient,
-				useAlternativeNormalization);
+		return new MVModel(direction, orientation, longitudinalLocation, longitudinalWidth, mu, useSeed, randomSeed,
+				lowPassCoefficient, infraredCoefficient, useAlternativeNormalization);
 	}
 
 }


### PR DESCRIPTION
In the NGP interpolation method parallel transport of the particle charges is only necessary when crossing a cell boundary. I use this fact to update the particle charge only if it is really needed and avoid trivial matrix multiplications. This should improve performance for smaller time-steps and larger transversal grids.

Also MainBatch now measures initialization (i.e. initial conditions, charge refinement, etc) and simulation  time (field solving, interpolation, diagnostics...).
