### PR TITLE
Lattice units fix, Poynting vector for ProjectedEnergyDiagnostic and UV and IR fixes for the Poisson solver.

### DIFF
--- a/pixi/input/current/MV model/MVModel_glueburst.yaml
+++ b/pixi/input/current/MV model/MVModel_glueburst.yaml
@@ -1,0 +1,63 @@
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: 2
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 8
+gridCells: [512, 4, 4]
+timeStep: 0.5
+duration: 480
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+currents:
+  MVModels:
+    - direction: 0
+      orientation: 1
+      longitudinalLocation: 32
+      longitudinalWidth: 4
+      mu: 0.4
+      randomSeed: 1
+      lowPassCoefficient: 0.729927
+      infraredCoefficient: 0.0324412
+
+
+
+
+# Generated panel code:
+panels:
+  dividerLocation: 574
+  leftPanel:
+    electricFieldPanel:
+      automaticScaling: false
+      colorIndex: 2
+      directionIndex: 0
+      scaleFactor: 1.0
+      showCoordinates: x, i, 2
+      showFields:
+      - E
+      - j
+      - rho
+      - Gauss
+  orientation: 1
+  rightPanel:
+    dividerLocation: 254
+    leftPanel:
+      chartPanel:
+        logarithmicScale: true
+        showCharts:
+        - Gauss law violation
+        - E squared
+        - B squared
+        - Energy density
+    orientation: 0
+    rightPanel:
+      infoPanel: {}
+  windowHeight: 596
+  windowWidth: 1346

--- a/pixi/input/current/MV model/MVModel_glueburst.yaml
+++ b/pixi/input/current/MV model/MVModel_glueburst.yaml
@@ -22,10 +22,10 @@ currents:
       orientation: 1
       longitudinalLocation: 32
       longitudinalWidth: 4
-      mu: 0.4
+      mu: 1
       randomSeed: 1
-      lowPassCoefficient: 0.729927
-      infraredCoefficient: 0.0324412
+      lowPassCoefficient: 2
+      infraredCoefficient: 0.0
 
 
 

--- a/pixi/input/current/MV model/MVModel_glueburst_cic.yaml
+++ b/pixi/input/current/MV model/MVModel_glueburst_cic.yaml
@@ -1,0 +1,63 @@
+simulationType: temporal cgc
+gridStep: 1
+couplingConstant: 2
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 8
+gridCells: [512, 4, 4]
+timeStep: 0.5
+duration: 480
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+currents:
+  MVModels:
+    - direction: 0
+      orientation: 1
+      longitudinalLocation: 32
+      longitudinalWidth: 4
+      mu: 0.4
+      randomSeed: 1
+      lowPassCoefficient: 0.729927
+      infraredCoefficient: 0.0324412
+
+
+
+
+# Generated panel code:
+panels:
+  dividerLocation: 574
+  leftPanel:
+    electricFieldPanel:
+      automaticScaling: false
+      colorIndex: 2
+      directionIndex: 0
+      scaleFactor: 1.0
+      showCoordinates: x, i, 2
+      showFields:
+      - E
+      - j
+      - rho
+      - Gauss
+  orientation: 1
+  rightPanel:
+    dividerLocation: 254
+    leftPanel:
+      chartPanel:
+        logarithmicScale: true
+        showCharts:
+        - Gauss law violation
+        - E squared
+        - B squared
+        - Energy density
+    orientation: 0
+    rightPanel:
+      infoPanel: {}
+  windowHeight: 596
+  windowWidth: 1346

--- a/pixi/input/current/MV model/MVModel_glueburst_cic.yaml
+++ b/pixi/input/current/MV model/MVModel_glueburst_cic.yaml
@@ -22,10 +22,11 @@ currents:
       orientation: 1
       longitudinalLocation: 32
       longitudinalWidth: 4
-      mu: 0.4
+      mu: 1
       randomSeed: 1
-      lowPassCoefficient: 0.729927
-      infraredCoefficient: 0.0324412
+      lowPassCoefficient: 2
+      infraredCoefficient: 0.0
+
 
 
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/FileFunctions.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/FileFunctions.java
@@ -1,6 +1,7 @@
 package org.openpixi.pixi.diagnostics;
 
 import java.io.File;
+import java.text.DecimalFormat;
 
 public class FileFunctions {
 
@@ -37,4 +38,21 @@ public class FileFunctions {
 		}
 	}
 
+
+	/**
+	 * Converts a 1D double array to a tab-separated values (TSV) string.
+	 * @param array	1D double array
+	 * @return	String with the values of the array as TSV.
+	 */
+	public static String generateTSVString(double[] array) {
+		StringBuilder outputStringBuilder = new StringBuilder();
+		DecimalFormat formatter = new DecimalFormat("0.################E0");
+		for (int i = 0; i < array.length; i++) {
+			outputStringBuilder.append(formatter.format(array[i]));
+			if(i < array.length - 1) {
+				outputStringBuilder.append("\t");
+			}
+		}
+		return outputStringBuilder.toString();
+	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
@@ -2,6 +2,9 @@ package org.openpixi.pixi.diagnostics.methods;
 
 import org.openpixi.pixi.diagnostics.Diagnostics;
 import org.openpixi.pixi.diagnostics.FileFunctions;
+import org.openpixi.pixi.math.AlgebraElement;
+import org.openpixi.pixi.math.ElementFactory;
+import org.openpixi.pixi.math.GroupElement;
 import org.openpixi.pixi.parallel.cellaccess.CellAction;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.grid.Grid;
@@ -10,7 +13,6 @@ import org.openpixi.pixi.physics.particles.IParticle;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.text.DecimalFormat;
 import java.util.ArrayList;
 
 /**
@@ -18,6 +20,7 @@ import java.util.ArrayList;
  * and writes 4 energy density components to a file:
  * Electric longitudinal (energyDensity_L_el), magnetic longitudinal (energyDensity_L_mag),
  * electric transversal  (energyDensity_T_el) and magnetic transversal (energyDensity_T_mag) energy density.
+ *
  * Using these four components one can compute various quantities:
  * total energy density = (sum of all components)
  * longitudinal energy density = (sum of longitudinal components)
@@ -25,12 +28,16 @@ import java.util.ArrayList;
  * longitudinal pressure = transversal energy density - longitudinal energy density
  * transvesal pressure = longitudinal energy density
  *
+ * It also outputs the longitudinal Poynting vector component (Averaged & Only time-averaged).
+ *
  * The output format:
  * 1) time
  * 2) electric transversal
  * 3) magnetic transversal
  * 4) electric longitudinal
  * 5) magnetic longitudinal
+ * 6) longitudinal poynting vector (averaged)
+ * 7) longitudinal poynting vector (only time-averaged)
  *
  */
 public class ProjectedEnergyDensity implements Diagnostics {
@@ -42,6 +49,7 @@ public class ProjectedEnergyDensity implements Diagnostics {
 	private int stepInterval;
 
 	private EnergyDensityComputation energyDensityComputation;
+	private PoyntingComputation poyntingComputation;
 
 	public ProjectedEnergyDensity(String path, double timeInterval, int direction) {
 		this.direction = direction;
@@ -53,6 +61,8 @@ public class ProjectedEnergyDensity implements Diagnostics {
 		this.stepInterval = (int) (timeInterval / s.getTimeStep());
 		this.energyDensityComputation = new EnergyDensityComputation();
 		energyDensityComputation.initialize(s.grid, direction);
+		this.poyntingComputation = new PoyntingComputation();
+		poyntingComputation.initialize(s.grid, direction);
 
 		FileFunctions.clearFile("output/" + path);
 	}
@@ -62,6 +72,11 @@ public class ProjectedEnergyDensity implements Diagnostics {
 			energyDensityComputation.reset();
 			grid.getCellIterator().execute(grid, energyDensityComputation);
 			energyDensityComputation.convertToEnergyUnits(grid);
+
+			poyntingComputation.reset();
+			grid.getCellIterator().execute(grid, poyntingComputation);
+			poyntingComputation.convertToEnergyUnits(grid);
+
 
 			// Write to file
 			File file = FileFunctions.getFile("output/" + path);
@@ -73,6 +88,8 @@ public class ProjectedEnergyDensity implements Diagnostics {
 				pw.write(FileFunctions.generateTSVString(energyDensityComputation.energyDensity_T_mag) + "\n");
 				pw.write(FileFunctions.generateTSVString(energyDensityComputation.energyDensity_L_el) + "\n");
 				pw.write(FileFunctions.generateTSVString(energyDensityComputation.energyDensity_L_mag) + "\n");
+				pw.write(FileFunctions.generateTSVString(poyntingComputation.poyntingAveraged) + "\n");
+				pw.write(FileFunctions.generateTSVString(poyntingComputation.poyntingTimeAveraged) + "\n");
 				pw.close();
 			} catch (IOException ex) {
 				System.out.println("ProjectedEnergyDensity: Error writing to file.");
@@ -148,6 +165,113 @@ public class ProjectedEnergyDensity implements Diagnostics {
 					energyDensity_L_el[projIndex] += e_L_el;
 					energyDensity_L_mag[projIndex] += e_L_mag;
 				}
+			}
+		}
+	}
+
+
+	private class PoyntingComputation implements CellAction {
+
+		private int direction;
+		private int numberOfDimensions;
+		private int numberOfCells;
+		private double[] poyntingAveraged;
+		private double[] poyntingTimeAveraged;
+		private double as;
+		private ElementFactory factory;
+
+		public void initialize(Grid grid, int direction) {
+			this.direction = direction;
+			this.numberOfCells = grid.getNumCells(direction);
+			this.poyntingAveraged = new double[numberOfCells];
+			this.poyntingTimeAveraged = new double[numberOfCells];
+			this.numberOfDimensions = grid.getNumberOfDimensions();
+			this.as = grid.getLatticeSpacing();
+			this.factory = grid.getElementFactory();
+		}
+
+		public void reset() {
+			for (int i = 0; i < numberOfCells; i++) {
+				this.poyntingAveraged[i] = 0.0;
+				this.poyntingTimeAveraged[i] = 0.0;
+			}
+		}
+
+		public void convertToEnergyUnits(Grid grid) {
+			// Divide by g*a factor
+			double invga = 1.0 / Math.pow(grid.getLatticeSpacing() * grid.getGaugeCoupling(), 2);
+
+			for (int i = 0; i < numberOfCells; i++) {
+				poyntingAveraged[i] *= invga;
+				poyntingTimeAveraged[i] *= invga;
+			}
+		}
+
+		/**
+		 * Computes the longitudinal Poynting vector component in 3D.
+		 * @param grid   Reference to the grid.
+		 * @param index	 Cell index.
+		 */
+		public void execute(Grid grid, int index) {
+			double localPoyntingAveraged = 0.0;
+			double localPoyntingTimeAveraged = 0.0;
+
+			int d = direction;
+			for (int i = 0; i < numberOfDimensions; i++) {
+				if(i != direction) {
+					// AVERAGED COMPUTATION
+
+					// Average spatial components of field strength tensor in space and time (B-Field).
+					GroupElement FG = factory.groupZero();
+
+					// Spatial average at t-at/2
+					FG.addAssign(grid.getPlaquette(index, d, i, 1, 1, 0));
+
+					FG.addAssign(grid.getPlaquette(index, i, d, -1, 1, 0));
+					FG.addAssign(grid.getPlaquette(index, i, d, 1, -1, 0));
+					FG.addAssign(grid.getPlaquette(index, d, i, -1, -1, 0));
+
+					// Spatial average at t+at/2
+					FG.addAssign(grid.getPlaquette(index, d, i, 1, 1, 1));
+					FG.addAssign(grid.getPlaquette(index, i, d, -1, 1, 1));
+					FG.addAssign(grid.getPlaquette(index, i, d, 1, -1, 1));
+					FG.addAssign(grid.getPlaquette(index, d, i, -1, -1, 1));
+
+					// Divide by factors and convert to AlgebraElement.
+					AlgebraElement F = FG.proj().mult(1.0 / (8.0 * as));
+
+					// Average E field in space.
+					int shiftedIndex = grid.shift(index, i, -1);
+					AlgebraElement E1 = grid.getE(index, i);
+					AlgebraElement E2 = grid.getE(shiftedIndex, i).act(grid.getLink(index, i, -1, 0));
+					AlgebraElement E = E1.add(E2).mult(0.5);
+
+					// Multiply E and F;
+					localPoyntingAveraged += E.mult(F);
+				}
+			}
+
+			// TIME-AVERAGED COMPUTATION:
+
+			// Indices for cross product:
+			int dir1 = (direction + 1) % 3;
+			int dir2 = (direction + 2) % 3;
+
+			// fields at same time:
+			AlgebraElement E1 = grid.getE(index, dir1);
+			AlgebraElement E2 = grid.getE(index, dir2);
+			// time averaged B-field:
+			AlgebraElement B1 = grid.getB(index, dir1, 0).add(grid.getB(index, dir1, 1)).mult(0.5);
+			AlgebraElement B2 = grid.getB(index, dir2, 0).add(grid.getB(index, dir2, 1)).mult(0.5);
+
+			localPoyntingTimeAveraged = E1.mult(B2) - E2.mult(B1);
+
+			// Add to array.
+			int projIndex = grid.getCellPos(index)[direction];
+			synchronized (this) {
+				this.poyntingAveraged[projIndex] += localPoyntingAveraged;
+				this.poyntingTimeAveraged[projIndex] += localPoyntingTimeAveraged;
+
 			}
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
@@ -103,6 +103,17 @@ public class ProjectedEnergyDensity implements Diagnostics {
 				}
 			}
 
+			// Divide by g*a factor
+			double invga = 1.0 / Math.pow(grid.getLatticeSpacing() * grid.getGaugeCoupling(), 2);
+			int longitudinalNumCells = grid.getNumCells(direction);
+
+			for (int i = 0; i < longitudinalNumCells; i++) {
+				energyDensity_T_el[i] *= invga;
+				energyDensity_T_mag[i] *= invga;
+				energyDensity_L_el[i] *= invga;
+				energyDensity_L_mag[i] *= invga;
+			}
+
 			// Write to file
 			File file = FileFunctions.getFile("output/" + path);
 			try {

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
@@ -48,8 +48,26 @@ public class ProjectedEnergyDensity implements Diagnostics {
 	private double timeInterval;
 	private int stepInterval;
 
+	/*
 	private EnergyDensityComputation energyDensityComputation;
 	private PoyntingComputation poyntingComputation;
+	*/
+
+	private int totalNumberOfCells;
+	private int numberOfDimensions;
+	private int longitudinalNumberOfCells;
+
+	private double[] energyDensity_T_el;
+	private double[] energyDensity_T_mag;
+	private double[] energyDensity_L_el;
+	private double[] energyDensity_L_mag;
+
+	private double[] poyntingAveraged;
+	private double[] poyntingTimeAveraged;
+
+	private double as;
+	private ElementFactory factory;
+
 
 	public ProjectedEnergyDensity(String path, double timeInterval, int direction) {
 		this.direction = direction;
@@ -59,16 +77,35 @@ public class ProjectedEnergyDensity implements Diagnostics {
 
 	public void initialize(Simulation s) {
 		this.stepInterval = (int) (timeInterval / s.getTimeStep());
+		this.totalNumberOfCells = s.grid.getTotalNumberOfCells();
+		this.numberOfDimensions = s.grid.getNumberOfDimensions();
+		this.longitudinalNumberOfCells = s.grid.getNumCells(direction);
+
+
+		this.energyDensity_T_el = new double[longitudinalNumberOfCells];
+		this.energyDensity_T_mag = new double[longitudinalNumberOfCells];
+		this.energyDensity_L_el = new double[longitudinalNumberOfCells];
+		this.energyDensity_L_mag = new double[longitudinalNumberOfCells];
+
+		this.poyntingAveraged = new double[longitudinalNumberOfCells];
+		this.poyntingTimeAveraged = new double[longitudinalNumberOfCells];
+
+		this.as = s.grid.getLatticeSpacing();
+		this.factory = s.grid.getElementFactory();
+
+		/*
 		this.energyDensityComputation = new EnergyDensityComputation();
 		energyDensityComputation.initialize(s.grid, direction);
 		this.poyntingComputation = new PoyntingComputation();
 		poyntingComputation.initialize(s.grid, direction);
+		*/
 
 		FileFunctions.clearFile("output/" + path);
 	}
 
 	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps) throws IOException {
 		if(steps % stepInterval == 0) {
+			/*
 			energyDensityComputation.reset();
 			grid.getCellIterator().execute(grid, energyDensityComputation);
 			energyDensityComputation.convertToEnergyUnits(grid);
@@ -76,6 +113,125 @@ public class ProjectedEnergyDensity implements Diagnostics {
 			poyntingComputation.reset();
 			grid.getCellIterator().execute(grid, poyntingComputation);
 			poyntingComputation.convertToEnergyUnits(grid);
+			*/
+
+			// Reset arrays
+			for (int i = 0; i < longitudinalNumberOfCells; i++) {
+				this.energyDensity_T_el[i] = 0.0;
+				this.energyDensity_T_mag[i] = 0.0;
+				this.energyDensity_L_el[i] = 0.0;
+				this.energyDensity_L_mag[i] = 0.0;
+
+				this.poyntingAveraged[i] = 0.0;
+				this.poyntingTimeAveraged[i] = 0.0;
+			}
+
+			for (int index = 0; index < totalNumberOfCells; index++) {
+
+				if(grid.isEvaluatable(index)) {
+					int projIndex = grid.getCellPos(index)[direction];
+					// Compute energy densities
+					// transversal & longitudinal electric energy density
+					double e_T_el = 0.0;
+					double e_L_el = 0.0;
+					// transversal & longitudinal magnetic energy density
+					double e_T_mag = 0.0;
+					double e_L_mag = 0.0;
+
+					for (int j = 0; j < grid.getNumberOfDimensions(); j++) {
+						double electric = 0.5 * grid.getE(index, j).square();
+						double magnetic = 0.25 * (grid.getBsquaredFromLinks(index, j, 0) + grid.getBsquaredFromLinks(index, j, 1));
+						if(j == direction) {
+							e_L_el += electric;
+							e_L_mag += magnetic;
+						} else {
+							e_T_el += electric;
+							e_T_mag += magnetic;
+						}
+					}
+
+					// Compute poynting vector component
+					double localPoyntingAveraged = 0.0;
+					double localPoyntingTimeAveraged = 0.0;
+
+					int d = direction;
+					for (int i = 0; i < numberOfDimensions; i++) {
+						if(i != direction) {
+							// AVERAGED COMPUTATION
+
+							// Average spatial components of field strength tensor in space and time (B-Field).
+							GroupElement FG = factory.groupZero();
+
+							// Spatial average at t-at/2
+							FG.addAssign(grid.getPlaquette(index, d, i, 1, 1, 0));
+
+							FG.addAssign(grid.getPlaquette(index, i, d, -1, 1, 0));
+							FG.addAssign(grid.getPlaquette(index, i, d, 1, -1, 0));
+							FG.addAssign(grid.getPlaquette(index, d, i, -1, -1, 0));
+
+							// Spatial average at t+at/2
+							FG.addAssign(grid.getPlaquette(index, d, i, 1, 1, 1));
+							FG.addAssign(grid.getPlaquette(index, i, d, -1, 1, 1));
+							FG.addAssign(grid.getPlaquette(index, i, d, 1, -1, 1));
+							FG.addAssign(grid.getPlaquette(index, d, i, -1, -1, 1));
+
+							// Divide by factors and convert to AlgebraElement.
+							AlgebraElement F = FG.proj().mult(1.0 / (8.0 * as));
+
+							// Average E field in space.
+							int shiftedIndex = grid.shift(index, i, -1);
+							AlgebraElement E1 = grid.getE(index, i);
+							AlgebraElement E2 = grid.getE(shiftedIndex, i).act(grid.getLink(index, i, -1, 0));
+							AlgebraElement E = E1.add(E2).mult(0.5);
+
+							// Multiply E and F;
+							localPoyntingAveraged += E.mult(F);
+						}
+					}
+
+					// TIME-AVERAGED COMPUTATION:
+
+					// Indices for cross product:
+					int dir1 = (direction + 1) % 3;
+					int dir2 = (direction + 2) % 3;
+
+					// fields at same time:
+					AlgebraElement E1 = grid.getE(index, dir1);
+					AlgebraElement E2 = grid.getE(index, dir2);
+					// time averaged B-field:
+					AlgebraElement B1 = grid.getB(index, dir1, 0).add(grid.getB(index, dir1, 1)).mult(0.5);
+					AlgebraElement B2 = grid.getB(index, dir2, 0).add(grid.getB(index, dir2, 1)).mult(0.5);
+
+					localPoyntingTimeAveraged = E1.mult(B2) - E2.mult(B1);
+
+					synchronized (this) {
+						energyDensity_T_el[projIndex] += e_T_el;
+						energyDensity_T_mag[projIndex] += e_T_mag;
+						energyDensity_L_el[projIndex] += e_L_el;
+						energyDensity_L_mag[projIndex] += e_L_mag;
+
+
+						poyntingAveraged[projIndex] += localPoyntingAveraged;
+						poyntingTimeAveraged[projIndex] += localPoyntingTimeAveraged;
+
+					}
+
+				}
+			}
+
+			// Divide by g*a factor
+			double invga = 1.0 / Math.pow(grid.getLatticeSpacing() * grid.getGaugeCoupling(), 2);
+
+			for (int i = 0; i < longitudinalNumberOfCells; i++) {
+				energyDensity_T_el[i] *= invga;
+				energyDensity_T_mag[i] *= invga;
+				energyDensity_L_el[i] *= invga;
+				energyDensity_L_mag[i] *= invga;
+
+				poyntingAveraged[i] *= invga;
+				poyntingTimeAveraged[i] *= invga;
+			}
+
 
 
 			// Write to file
@@ -84,12 +240,12 @@ public class ProjectedEnergyDensity implements Diagnostics {
 				FileWriter pw = new FileWriter(file, true);
 				Double time = steps * grid.getTemporalSpacing();
 				pw.write(time.toString() + "\n");
-				pw.write(FileFunctions.generateTSVString(energyDensityComputation.energyDensity_T_el) + "\n");
-				pw.write(FileFunctions.generateTSVString(energyDensityComputation.energyDensity_T_mag) + "\n");
-				pw.write(FileFunctions.generateTSVString(energyDensityComputation.energyDensity_L_el) + "\n");
-				pw.write(FileFunctions.generateTSVString(energyDensityComputation.energyDensity_L_mag) + "\n");
-				pw.write(FileFunctions.generateTSVString(poyntingComputation.poyntingAveraged) + "\n");
-				pw.write(FileFunctions.generateTSVString(poyntingComputation.poyntingTimeAveraged) + "\n");
+				pw.write(FileFunctions.generateTSVString(energyDensity_T_el) + "\n");
+				pw.write(FileFunctions.generateTSVString(energyDensity_T_mag) + "\n");
+				pw.write(FileFunctions.generateTSVString(energyDensity_L_el) + "\n");
+				pw.write(FileFunctions.generateTSVString(energyDensity_L_mag) + "\n");
+				pw.write(FileFunctions.generateTSVString(poyntingAveraged) + "\n");
+				pw.write(FileFunctions.generateTSVString(poyntingTimeAveraged) + "\n");
 				pw.close();
 			} catch (IOException ex) {
 				System.out.println("ProjectedEnergyDensity: Error writing to file.");
@@ -97,6 +253,9 @@ public class ProjectedEnergyDensity implements Diagnostics {
 		}
 	}
 
+	// Multithreaded code which leaks memory. I don't know why.
+
+	/*
 	private class EnergyDensityComputation implements CellAction {
 
 		private int direction;
@@ -207,11 +366,6 @@ public class ProjectedEnergyDensity implements Diagnostics {
 			}
 		}
 
-		/**
-		 * Computes the longitudinal Poynting vector component in 3D.
-		 * @param grid   Reference to the grid.
-		 * @param index	 Cell index.
-		 */
 		public void execute(Grid grid, int index) {
 			double localPoyntingAveraged = 0.0;
 			double localPoyntingTimeAveraged = 0.0;
@@ -275,4 +429,6 @@ public class ProjectedEnergyDensity implements Diagnostics {
 			}
 		}
 	}
+	*/
+
 }

--- a/pixi/src/main/java/org/openpixi/pixi/math/SU2GroupElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/SU2GroupElement.java
@@ -67,7 +67,7 @@ public class SU2GroupElement implements GroupElement {
 	public void addAssign(GroupElement arg) {
 		SU2GroupElement a = (SU2GroupElement) arg;
 		for (int i = 0; i < 4; i++) {
-			e[i] += a.get(i);
+			e[i] += a.e[i];
 		}
 	}
 
@@ -80,7 +80,7 @@ public class SU2GroupElement implements GroupElement {
 	public void subAssign(GroupElement arg) {
 		SU2GroupElement a = (SU2GroupElement) arg;
 		for (int i = 0; i < 4; i++) {
-			e[i] -= a.get(i);
+			e[i] -= a.e[i];
 		}
 	}
 
@@ -94,7 +94,7 @@ public class SU2GroupElement implements GroupElement {
 		SU2GroupElement a = (SU2GroupElement) arg;
 
 		for (int i = 0; i < 4; i++) {
-			e[i] = a.get(i);
+			e[i] = a.e[i];
 		}
 	}
 
@@ -128,7 +128,7 @@ public class SU2GroupElement implements GroupElement {
 		SU2GroupElement b = new SU2GroupElement(this);
 		for (int i = 1; i < 4; i++)
 		{
-			b.set(i, -b.get(i));
+			b.e[i] = - this.e[i];
 		}
 		return b;
 	}
@@ -136,7 +136,7 @@ public class SU2GroupElement implements GroupElement {
 	public void adjAssign() {
 		for (int i = 1; i < 4; i++)
 		{
-			this.set(i, -this.get(i));
+			this.e[i] = -this.e[i];
 		}
 	}
 
@@ -171,7 +171,7 @@ public class SU2GroupElement implements GroupElement {
 
 		SU2GroupElement b = new SU2GroupElement();
 		for (int i = 0; i < 4; i++) {
-			b.set(i, e[i] * number);
+			b.e[i] = e[i] * number;
 		}
 		return b;
 
@@ -182,10 +182,10 @@ public class SU2GroupElement implements GroupElement {
 		SU2GroupElement a = (SU2GroupElement) arg;
 
 		SU2GroupElement b = new SU2GroupElement();
-		b.e[0] = e[0] * a.get(0) - e[1] * a.get(1) - e[2] * a.get(2) - e[3] * a.get(3);
-		b.e[1] = e[0] * a.get(1) + e[1] * a.get(0) - e[2] * a.get(3) + e[3] * a.get(2);
-		b.e[2] = e[0] * a.get(2) + e[2] * a.get(0) - e[3] * a.get(1) + e[1] * a.get(3);
-		b.e[3] = e[0] * a.get(3) + e[3] * a.get(0) - e[1] * a.get(2) + e[2] * a.get(1);
+		b.e[0] = e[0] * a.e[0] - e[1] * a.e[1] - e[2] * a.e[2] - e[3] * a.e[3];
+		b.e[1] = e[0] * a.e[1] + e[1] * a.e[0] - e[2] * a.e[3] + e[3] * a.e[2];
+		b.e[2] = e[0] * a.e[2] + e[2] * a.e[0] - e[3] * a.e[1] + e[1] * a.e[3];
+		b.e[3] = e[0] * a.e[3] + e[3] * a.e[0] - e[1] * a.e[2] + e[2] * a.e[1];
 		return b;
 
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
@@ -129,6 +129,10 @@ public class NewLCPoissonSolver {
 		gvCalculation.reset(gridCopy);
 		gridCopy.getCellIterator().execute(gridCopy, gvCalculation);
 		gaussViolation = gvCalculation.getResult();
+
+		// Remove reference to gridCopy (?)
+		this.gridCopy = null;
+
 	}
 
 	public AlgebraElement getGaussConstraint(int i) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
@@ -76,10 +76,10 @@ public class NewLCPoissonSolver {
 
 		// UV Regulator
 		double psqrMax = 4.0 * effTransversalDimensions / (as * as);
-		double lambda = lowPassCoefficient * psqrMax;
+		double lambda = lowPassCoefficient * lowPassCoefficient * psqrMax;
 
 		// IR Regulator
-		double msqr = infraredCoefficient * psqrMax;
+		double msqr = infraredCoefficient * infraredCoefficient * psqrMax;
 
 		// First step: compute transversal potential phi
 		for (int i = 0; i < factory.numberOfComponents; i++) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
@@ -3,6 +3,7 @@ package org.openpixi.pixi.physics.fields;
 import org.openpixi.pixi.math.AlgebraElement;
 import org.openpixi.pixi.math.ElementFactory;
 import org.openpixi.pixi.math.GroupElement;
+import org.openpixi.pixi.parallel.cellaccess.CellAction;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.gauge.DoubleFFTWrapper;
 import org.apache.commons.math3.special.Erf;
@@ -115,6 +116,11 @@ public class NewLCPoissonSolver {
 		}
 
 		// Second step: compute links from transversal potential
+		GaugeLinkSetter gaugeLinkSetter = new GaugeLinkSetter();
+		gaugeLinkSetter.initialize(s.grid, gridCopy, phi);
+		s.grid.getCellIterator().execute(s.grid, gaugeLinkSetter);
+
+		/*
 		double gaugeNorm = g * as;
 		int totalCells = s.grid.getTotalNumberOfCells();
 		for (int i = 0; i < totalCells; i++) {
@@ -156,17 +162,30 @@ public class NewLCPoissonSolver {
 				}
 			}
 		}
+		*/
 
 
 		// Third step: Compute electric field from temporal plaquette
+		ElectricFieldSetter electricFieldSetter = new ElectricFieldSetter();
+		s.grid.getCellIterator().execute(s.grid, electricFieldSetter);
+		gridCopy.getCellIterator().execute(gridCopy, electricFieldSetter);
+
+		/*
 		for (int i = 0; i < totalCells; i++) {
 			for (int j = 0; j < numberOfDimensions; j++) {
 				s.grid.setE(i, j, s.grid.getEFromLinks(i, j));
 				gridCopy.setE(i, j, gridCopy.getEFromLinks(i, j));
 			}
 		}
+		*/
 
 		// Compute gauss violation from grid copy
+		GaussViolationCalculation gvCalculation = new GaussViolationCalculation();
+		gvCalculation.reset(gridCopy);
+		gridCopy.getCellIterator().execute(gridCopy, gvCalculation);
+		gaussViolation = gvCalculation.getResult();
+
+		/*
 		gaussViolation = new AlgebraElement[s.grid.getTotalNumberOfCells()];
 		for (int i = 0; i < gridCopy.getTotalNumberOfCells(); i++) {
 			if(s.grid.isActive(i)) {
@@ -175,6 +194,7 @@ public class NewLCPoissonSolver {
 				gaussViolation[i] = factory.algebraZero();
 			}
 		}
+		*/
 	}
 
 	public AlgebraElement getGaussConstraint(int i) {
@@ -225,5 +245,99 @@ public class NewLCPoissonSolver {
 		}
 
 		return momentumSquared / (as * as);
+	}
+
+	// Classes for multithreaded operations
+
+	/**
+	 * This class sets all the gauge links according to the solution of the Poisson equation.
+	 */
+	private class GaugeLinkSetter implements CellAction {
+		private Grid grid;
+		private Grid gridCopy;
+		private AlgebraElement[] phi;
+
+		public void initialize(Grid grid, Grid gridCopy, AlgebraElement[] phi) {
+			this.grid = grid;
+			this.gridCopy = gridCopy;
+			this.phi = phi;
+		}
+
+		public void execute(Grid gr, int index) {
+			int[] gridPos = this.grid.getCellPos(index);
+			int[] transversalGridPos = GridFunctions.reduceGridPos(gridPos, direction);
+			int longitudinalGridPos = gridPos[direction];
+			double z = longitudinalGridPos * as - location;
+			int transversalCellIndex = GridFunctions.getCellIndex(transversalGridPos, transversalNumCells);
+
+			// Shape function (i.e. F(z,t)) at t = -dt/2 and t = dt /2.
+			double s0 = g * integratedShapeFunction(z, - at / 2.0, orientation, longitudinalWidth);
+			double s1 = g * integratedShapeFunction(z, + at / 2.0, orientation, longitudinalWidth);
+
+			// Setup the gauge links at t = -dt/2 and t = dt/2
+			GroupElement V0 = this.phi[transversalCellIndex].mult(- s0).getLink();
+			GroupElement V0next = this.phi[transversalCellIndex].mult(- s1).getLink();
+
+			// New method: Apply gauge transformation directly to gauge links without the use of a discretized derivative.
+			for (int j = 0; j < numberOfDimensions; j++) {
+				if (j != direction) {
+					int transversalCellIndexShifted = GridFunctions.getCellIndex(
+							GridFunctions.reduceGridPos(
+									this.grid.getCellPos(s.grid.shift(index, j, 1))
+									, direction),
+							transversalNumCells);
+
+					GroupElement V1 = this.phi[transversalCellIndexShifted].mult(- s0).getLink();
+					GroupElement V1next = this.phi[transversalCellIndexShifted].mult(- s1).getLink();
+
+					GroupElement U = this.grid.getU(index, j);
+					GroupElement Unext = this.grid.getUnext(index, j);
+					// U_x,i = V_x V_{x+i}^t
+					this.grid.setU(index, j, V0.mult(U).mult(V1.adj()));
+					this.grid.setUnext(index, j, V0next.mult(Unext).mult(V1next.adj()));
+
+					// Also write to copy of the grid.
+					this.gridCopy.setU(index, j, V0.mult(V1.adj()));
+					this.gridCopy.setUnext(index, j, V0next.mult(V1next.adj()));
+				}
+			}
+		}
+	}
+
+	/**
+	 * Computes and stores the Gauss law violation at every lattice site.
+	 */
+	private class GaussViolationCalculation implements CellAction {
+		public AlgebraElement[] gaussViolation;
+		private ElementFactory factory;
+
+
+		public void reset(Grid grid) {
+			this.gaussViolation = new AlgebraElement[grid.getTotalNumberOfCells()];
+			this.factory = grid.getElementFactory();
+		}
+
+		public void execute(Grid grid, int index) {
+			if(grid.isActive(index)) {
+				this.gaussViolation[index] = grid.getGaussConstraint(index);
+			} else {
+				this.gaussViolation[index] = this.factory.algebraZero();
+			}
+		}
+
+		public AlgebraElement[] getResult() {
+			return gaussViolation;
+		}
+	}
+
+	/**
+	 * This class computes the electric fields from the gauge links (U and Unext).
+	 */
+	private class ElectricFieldSetter implements CellAction {
+		public void execute(Grid grid, int index) {
+			for (int j = 0; j < numberOfDimensions; j++) {
+				grid.setE(index, j, grid.getEFromLinks(index, j));
+			}
+		}
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/NewLCPoissonSolver.java
@@ -90,12 +90,12 @@ public class NewLCPoissonSolver {
 			fft.complexForward(fftArray);
 			// Solve Poisson equation in momentum space.
 			for (int j = 1; j < totalTransversalCells; j++) {
-				double pEffSqaured = computeEffectiveLatticeMomentumSquared(j);
+				double pEffSquared = computeEffectiveLatticeMomentumSquared(j);
 				double pSquare = computeLatticeMomentumSquared(j);
 				double invLaplace;
 				// Implement as momentum cutoff
 				if(pSquare <= lambdaSquared) {
-					invLaplace = 1.0 / (pEffSqaured + mSquared);
+					invLaplace = 1.0 / (pEffSquared + mSquared);
 				} else {
 					invLaplace = 0.0;
 				}
@@ -189,7 +189,7 @@ public class NewLCPoissonSolver {
 		for (int i = 0; i < effTransversalDimensions; i++) {
 			double momentumComponent;
 			int n = transversalNumCells[i];
-			if(i < n / 2) {
+			if(transversalGridPos[i] < n / 2) {
 				momentumComponent = twopi * transversalGridPos[i] / (as * n);
 			} else {
 				momentumComponent = twopi * (n - transversalGridPos[i]) / (as * n);


### PR DESCRIPTION
Changes to _ProjectedEnergyDiagnostic_:
- Fixed missing conversion factor (ga)^2.
- ~~Basic multithreading.~~ This lead to a memory leak and has been reversed.
- Longitudinal component of the Poynting vector. There are two variations of this calculation. One where magnetic and electric fields are averaged and parallel-transported correctly (I think..) in space and time and one where the magnetic fields are only averaged in time. The first one seems to give slightly better results in the Poynting theorem.

Changes to _NewLCPoissonSolver_ (our standard Poisson solver for CGC stuff).
- UV and IR regulators were implemented wrong. In the case of UV it was cutting off at a certain effective lattice momentum instead of the square of the lattice momentum. This becomes apparent at higher values for the cutoff. Moreover the values used in the Poisson solver were off from the intended values. We will have to recompute quite a bit and rethink what values for the UV cutoff are acceptable (it must be much higher than 2.5 GeV).
- To make things simpler the UV and IR coefficients are now given in terms of the same energy units as for other energies (such as the mu coefficient in the MV model).
- Basic multithreading.

Also small optimizations in _SU2GroupElement_.

I also added YAML files which show that single pulses can become unstable for large amplitudes or short widths. This is probably the energy increase we saw before adding the infared regulation. It seems that our Gauss constraint violating CIC implementations fixes this instability. Maybe it is a problem with the NGP? 
