### PR TITLE
Optimizations for SU2 multiplication, lattice equations of motion and ProjectedEnergyDensity.

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
@@ -48,11 +48,11 @@ public class ProjectedEnergyDensity implements Diagnostics {
 	private double timeInterval;
 	private int stepInterval;
 
-	/*
+
 	private EnergyDensityComputation energyDensityComputation;
 	private PoyntingComputation poyntingComputation;
-	*/
 
+	/*
 	private int totalNumberOfCells;
 	private int numberOfDimensions;
 	private int longitudinalNumberOfCells;
@@ -64,6 +64,7 @@ public class ProjectedEnergyDensity implements Diagnostics {
 
 	private double[] poyntingAveraged;
 	private double[] poyntingTimeAveraged;
+	*/
 
 	private double as;
 	private ElementFactory factory;
@@ -77,6 +78,7 @@ public class ProjectedEnergyDensity implements Diagnostics {
 
 	public void initialize(Simulation s) {
 		this.stepInterval = (int) (timeInterval / s.getTimeStep());
+		/*
 		this.totalNumberOfCells = s.grid.getTotalNumberOfCells();
 		this.numberOfDimensions = s.grid.getNumberOfDimensions();
 		this.longitudinalNumberOfCells = s.grid.getNumCells(direction);
@@ -89,23 +91,23 @@ public class ProjectedEnergyDensity implements Diagnostics {
 
 		this.poyntingAveraged = new double[longitudinalNumberOfCells];
 		this.poyntingTimeAveraged = new double[longitudinalNumberOfCells];
-
+		*/
 		this.as = s.grid.getLatticeSpacing();
 		this.factory = s.grid.getElementFactory();
 
-		/*
+
 		this.energyDensityComputation = new EnergyDensityComputation();
 		energyDensityComputation.initialize(s.grid, direction);
 		this.poyntingComputation = new PoyntingComputation();
 		poyntingComputation.initialize(s.grid, direction);
-		*/
+
 
 		FileFunctions.clearFile("output/" + path);
 	}
 
 	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps) throws IOException {
 		if(steps % stepInterval == 0) {
-			/*
+
 			energyDensityComputation.reset();
 			grid.getCellIterator().execute(grid, energyDensityComputation);
 			energyDensityComputation.convertToEnergyUnits(grid);
@@ -113,8 +115,9 @@ public class ProjectedEnergyDensity implements Diagnostics {
 			poyntingComputation.reset();
 			grid.getCellIterator().execute(grid, poyntingComputation);
 			poyntingComputation.convertToEnergyUnits(grid);
-			*/
 
+
+			/*
 			// Reset arrays
 			for (int i = 0; i < longitudinalNumberOfCells; i++) {
 				this.energyDensity_T_el[i] = 0.0;
@@ -232,7 +235,7 @@ public class ProjectedEnergyDensity implements Diagnostics {
 				poyntingTimeAveraged[i] *= invga;
 			}
 
-
+			*/
 
 			// Write to file
 			File file = FileFunctions.getFile("output/" + path);
@@ -240,12 +243,20 @@ public class ProjectedEnergyDensity implements Diagnostics {
 				FileWriter pw = new FileWriter(file, true);
 				Double time = steps * grid.getTemporalSpacing();
 				pw.write(time.toString() + "\n");
+				pw.write(FileFunctions.generateTSVString(energyDensityComputation.energyDensity_T_el) + "\n");
+				pw.write(FileFunctions.generateTSVString(energyDensityComputation.energyDensity_T_mag) + "\n");
+				pw.write(FileFunctions.generateTSVString(energyDensityComputation.energyDensity_L_el) + "\n");
+				pw.write(FileFunctions.generateTSVString(energyDensityComputation.energyDensity_L_mag) + "\n");
+				pw.write(FileFunctions.generateTSVString(poyntingComputation.poyntingAveraged) + "\n");
+				pw.write(FileFunctions.generateTSVString(poyntingComputation.poyntingTimeAveraged) + "\n");
+				/*
 				pw.write(FileFunctions.generateTSVString(energyDensity_T_el) + "\n");
 				pw.write(FileFunctions.generateTSVString(energyDensity_T_mag) + "\n");
 				pw.write(FileFunctions.generateTSVString(energyDensity_L_el) + "\n");
 				pw.write(FileFunctions.generateTSVString(energyDensity_L_mag) + "\n");
 				pw.write(FileFunctions.generateTSVString(poyntingAveraged) + "\n");
 				pw.write(FileFunctions.generateTSVString(poyntingTimeAveraged) + "\n");
+				*/
 				pw.close();
 			} catch (IOException ex) {
 				System.out.println("ProjectedEnergyDensity: Error writing to file.");
@@ -255,7 +266,7 @@ public class ProjectedEnergyDensity implements Diagnostics {
 
 	// Multithreaded code which leaks memory. I don't know why.
 
-	/*
+
 	private class EnergyDensityComputation implements CellAction {
 
 		private int direction;
@@ -372,7 +383,7 @@ public class ProjectedEnergyDensity implements Diagnostics {
 
 			int d = direction;
 			for (int i = 0; i < numberOfDimensions; i++) {
-				if(i != direction) {
+				if (i != direction) {
 					// AVERAGED COMPUTATION
 
 					// Average spatial components of field strength tensor in space and time (B-Field).
@@ -429,6 +440,5 @@ public class ProjectedEnergyDensity implements Diagnostics {
 			}
 		}
 	}
-	*/
 
 }

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
@@ -48,26 +48,13 @@ public class ProjectedEnergyDensity implements Diagnostics {
 	private double timeInterval;
 	private int stepInterval;
 
-
 	private EnergyDensityComputation energyDensityComputation;
 	private PoyntingComputation poyntingComputation;
 
-	/*
-	private int totalNumberOfCells;
-	private int numberOfDimensions;
-	private int longitudinalNumberOfCells;
-
-	private double[] energyDensity_T_el;
-	private double[] energyDensity_T_mag;
-	private double[] energyDensity_L_el;
-	private double[] energyDensity_L_mag;
-
-	private double[] poyntingAveraged;
-	private double[] poyntingTimeAveraged;
-	*/
-
 	private double as;
 	private ElementFactory factory;
+
+	protected double areaFactor;
 
 
 	public ProjectedEnergyDensity(String path, double timeInterval, int direction) {
@@ -78,20 +65,7 @@ public class ProjectedEnergyDensity implements Diagnostics {
 
 	public void initialize(Simulation s) {
 		this.stepInterval = (int) (timeInterval / s.getTimeStep());
-		/*
-		this.totalNumberOfCells = s.grid.getTotalNumberOfCells();
-		this.numberOfDimensions = s.grid.getNumberOfDimensions();
-		this.longitudinalNumberOfCells = s.grid.getNumCells(direction);
 
-
-		this.energyDensity_T_el = new double[longitudinalNumberOfCells];
-		this.energyDensity_T_mag = new double[longitudinalNumberOfCells];
-		this.energyDensity_L_el = new double[longitudinalNumberOfCells];
-		this.energyDensity_L_mag = new double[longitudinalNumberOfCells];
-
-		this.poyntingAveraged = new double[longitudinalNumberOfCells];
-		this.poyntingTimeAveraged = new double[longitudinalNumberOfCells];
-		*/
 		this.as = s.grid.getLatticeSpacing();
 		this.factory = s.grid.getElementFactory();
 
@@ -101,8 +75,15 @@ public class ProjectedEnergyDensity implements Diagnostics {
 		this.poyntingComputation = new PoyntingComputation();
 		poyntingComputation.initialize(s.grid, direction);
 
-
 		FileFunctions.clearFile("output/" + path);
+
+		// Compute area factor
+		areaFactor = 1.0;
+		for (int i = 0; i < s.getNumberOfDimensions(); i++) {
+			if(i != direction) {
+				areaFactor *= s.grid.getNumCells(i);
+			}
+		}
 	}
 
 	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps) throws IOException {
@@ -117,126 +98,6 @@ public class ProjectedEnergyDensity implements Diagnostics {
 			poyntingComputation.convertToEnergyUnits(grid);
 
 
-			/*
-			// Reset arrays
-			for (int i = 0; i < longitudinalNumberOfCells; i++) {
-				this.energyDensity_T_el[i] = 0.0;
-				this.energyDensity_T_mag[i] = 0.0;
-				this.energyDensity_L_el[i] = 0.0;
-				this.energyDensity_L_mag[i] = 0.0;
-
-				this.poyntingAveraged[i] = 0.0;
-				this.poyntingTimeAveraged[i] = 0.0;
-			}
-
-			for (int index = 0; index < totalNumberOfCells; index++) {
-
-				if(grid.isEvaluatable(index)) {
-					int projIndex = grid.getCellPos(index)[direction];
-					// Compute energy densities
-					// transversal & longitudinal electric energy density
-					double e_T_el = 0.0;
-					double e_L_el = 0.0;
-					// transversal & longitudinal magnetic energy density
-					double e_T_mag = 0.0;
-					double e_L_mag = 0.0;
-
-					for (int j = 0; j < grid.getNumberOfDimensions(); j++) {
-						double electric = 0.5 * grid.getE(index, j).square();
-						double magnetic = 0.25 * (grid.getBsquaredFromLinks(index, j, 0) + grid.getBsquaredFromLinks(index, j, 1));
-						if(j == direction) {
-							e_L_el += electric;
-							e_L_mag += magnetic;
-						} else {
-							e_T_el += electric;
-							e_T_mag += magnetic;
-						}
-					}
-
-					// Compute poynting vector component
-					double localPoyntingAveraged = 0.0;
-					double localPoyntingTimeAveraged = 0.0;
-
-					int d = direction;
-					for (int i = 0; i < numberOfDimensions; i++) {
-						if(i != direction) {
-							// AVERAGED COMPUTATION
-
-							// Average spatial components of field strength tensor in space and time (B-Field).
-							GroupElement FG = factory.groupZero();
-
-							// Spatial average at t-at/2
-							FG.addAssign(grid.getPlaquette(index, d, i, 1, 1, 0));
-
-							FG.addAssign(grid.getPlaquette(index, i, d, -1, 1, 0));
-							FG.addAssign(grid.getPlaquette(index, i, d, 1, -1, 0));
-							FG.addAssign(grid.getPlaquette(index, d, i, -1, -1, 0));
-
-							// Spatial average at t+at/2
-							FG.addAssign(grid.getPlaquette(index, d, i, 1, 1, 1));
-							FG.addAssign(grid.getPlaquette(index, i, d, -1, 1, 1));
-							FG.addAssign(grid.getPlaquette(index, i, d, 1, -1, 1));
-							FG.addAssign(grid.getPlaquette(index, d, i, -1, -1, 1));
-
-							// Divide by factors and convert to AlgebraElement.
-							AlgebraElement F = FG.proj().mult(1.0 / (8.0 * as));
-
-							// Average E field in space.
-							int shiftedIndex = grid.shift(index, i, -1);
-							AlgebraElement E1 = grid.getE(index, i);
-							AlgebraElement E2 = grid.getE(shiftedIndex, i).act(grid.getLink(index, i, -1, 0));
-							AlgebraElement E = E1.add(E2).mult(0.5);
-
-							// Multiply E and F;
-							localPoyntingAveraged += E.mult(F);
-						}
-					}
-
-					// TIME-AVERAGED COMPUTATION:
-
-					// Indices for cross product:
-					int dir1 = (direction + 1) % 3;
-					int dir2 = (direction + 2) % 3;
-
-					// fields at same time:
-					AlgebraElement E1 = grid.getE(index, dir1);
-					AlgebraElement E2 = grid.getE(index, dir2);
-					// time averaged B-field:
-					AlgebraElement B1 = grid.getB(index, dir1, 0).add(grid.getB(index, dir1, 1)).mult(0.5);
-					AlgebraElement B2 = grid.getB(index, dir2, 0).add(grid.getB(index, dir2, 1)).mult(0.5);
-
-					localPoyntingTimeAveraged = E1.mult(B2) - E2.mult(B1);
-
-					synchronized (this) {
-						energyDensity_T_el[projIndex] += e_T_el;
-						energyDensity_T_mag[projIndex] += e_T_mag;
-						energyDensity_L_el[projIndex] += e_L_el;
-						energyDensity_L_mag[projIndex] += e_L_mag;
-
-
-						poyntingAveraged[projIndex] += localPoyntingAveraged;
-						poyntingTimeAveraged[projIndex] += localPoyntingTimeAveraged;
-
-					}
-
-				}
-			}
-
-			// Divide by g*a factor
-			double invga = 1.0 / Math.pow(grid.getLatticeSpacing() * grid.getGaugeCoupling(), 2);
-
-			for (int i = 0; i < longitudinalNumberOfCells; i++) {
-				energyDensity_T_el[i] *= invga;
-				energyDensity_T_mag[i] *= invga;
-				energyDensity_L_el[i] *= invga;
-				energyDensity_L_mag[i] *= invga;
-
-				poyntingAveraged[i] *= invga;
-				poyntingTimeAveraged[i] *= invga;
-			}
-
-			*/
-
 			// Write to file
 			File file = FileFunctions.getFile("output/" + path);
 			try {
@@ -249,14 +110,6 @@ public class ProjectedEnergyDensity implements Diagnostics {
 				pw.write(FileFunctions.generateTSVString(energyDensityComputation.energyDensity_L_mag) + "\n");
 				pw.write(FileFunctions.generateTSVString(poyntingComputation.poyntingAveraged) + "\n");
 				pw.write(FileFunctions.generateTSVString(poyntingComputation.poyntingTimeAveraged) + "\n");
-				/*
-				pw.write(FileFunctions.generateTSVString(energyDensity_T_el) + "\n");
-				pw.write(FileFunctions.generateTSVString(energyDensity_T_mag) + "\n");
-				pw.write(FileFunctions.generateTSVString(energyDensity_L_el) + "\n");
-				pw.write(FileFunctions.generateTSVString(energyDensity_L_mag) + "\n");
-				pw.write(FileFunctions.generateTSVString(poyntingAveraged) + "\n");
-				pw.write(FileFunctions.generateTSVString(poyntingTimeAveraged) + "\n");
-				*/
 				pw.close();
 			} catch (IOException ex) {
 				System.out.println("ProjectedEnergyDensity: Error writing to file.");
@@ -265,8 +118,6 @@ public class ProjectedEnergyDensity implements Diagnostics {
 	}
 
 	// Multithreaded code which leaks memory. I don't know why.
-
-
 	private class EnergyDensityComputation implements CellAction {
 
 		private int direction;
@@ -296,14 +147,14 @@ public class ProjectedEnergyDensity implements Diagnostics {
 		}
 
 		public void convertToEnergyUnits(Grid grid) {
-			// Divide by g*a factor
-			double invga = 1.0 / Math.pow(grid.getLatticeSpacing() * grid.getGaugeCoupling(), 2);
+			// Divide by (g*a*NT)^2 factor
+			double unitFactor = 1.0 / (areaFactor * Math.pow(grid.getLatticeSpacing() * grid.getGaugeCoupling(), 2));
 
 			for (int i = 0; i < numberOfCells; i++) {
-				energyDensity_T_el[i] *= invga;
-				energyDensity_T_mag[i] *= invga;
-				energyDensity_L_el[i] *= invga;
-				energyDensity_L_mag[i] *= invga;
+				energyDensity_T_el[i] *= unitFactor;
+				energyDensity_T_mag[i] *= unitFactor;
+				energyDensity_L_el[i] *= unitFactor;
+				energyDensity_L_mag[i] *= unitFactor;
 			}
 		}
 
@@ -368,12 +219,12 @@ public class ProjectedEnergyDensity implements Diagnostics {
 		}
 
 		public void convertToEnergyUnits(Grid grid) {
-			// Divide by g*a factor
-			double invga = 1.0 / Math.pow(grid.getLatticeSpacing() * grid.getGaugeCoupling(), 2);
+			// Divide by (g*a*NT)^2 factor
+			double unitFactor = 1.0 / (areaFactor * Math.pow(grid.getLatticeSpacing() * grid.getGaugeCoupling(), 2));
 
 			for (int i = 0; i < numberOfCells; i++) {
-				poyntingAveraged[i] *= invga;
-				poyntingTimeAveraged[i] *= invga;
+				poyntingAveraged[i] *= unitFactor;
+				poyntingTimeAveraged[i] *= unitFactor;
 			}
 		}
 

--- a/pixi/src/main/java/org/openpixi/pixi/math/GroupElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/GroupElement.java
@@ -63,6 +63,8 @@ public interface GroupElement {
 	 */
 	GroupElement mult(GroupElement a);
 
+	void multAssign(GroupElement a);
+
 	/**
 	 * Returns the exact algebra element of the group element. The algebra element generates the group element
 	 * via the exponential map.

--- a/pixi/src/main/java/org/openpixi/pixi/math/SU2GroupElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/SU2GroupElement.java
@@ -190,6 +190,18 @@ public class SU2GroupElement implements GroupElement {
 
 	}
 
+	public void multAssign(GroupElement arg) {
+		double e0, e1, e2;
+		double[] ae = ((SU2GroupElement) arg).e;
+		e0 = e[0];
+		e1 = e[1];
+		e2 = e[2];
+		e[0] = e[0] * ae[0] - e[1] * ae[1] - e[2] * ae[2] - e[3] * ae[3];
+		e[1] = e0 * ae[1] + e[1] * ae[0] - e[2] * ae[3] + e[3] * ae[2];
+		e[2] = e0 * ae[2] + e[2] * ae[0] - e[3] * ae[1] + e1 * ae[3];
+		e[3] = e0 * ae[3] + e[3] * ae[0] - e1 * ae[2] + e2 * ae[1];
+	}
+
 	public AlgebraElement getAlgebraElement()
 	{
 		double norm = 0.0;

--- a/pixi/src/main/java/org/openpixi/pixi/math/SU3GroupElement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/math/SU3GroupElement.java
@@ -201,6 +201,11 @@ public class SU3GroupElement implements GroupElement {
 		return b;
 	}
 
+	public void multAssign(GroupElement arg) {
+		GroupElement U = this.mult(arg);
+		this.set(U);
+	}
+
 	public double[] det() {
 		// computed in Mathematica
 		double[] out = new double[2];

--- a/pixi/src/main/java/org/openpixi/pixi/parallel/particleaccess/ParallelParticleIterator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/parallel/particleaccess/ParallelParticleIterator.java
@@ -54,7 +54,8 @@ public class ParallelParticleIterator implements ParticleIterator {
 		}
 
 		public Object call() throws Exception {
-			for (int particleIdx = threadIdx; particleIdx < particles.size(); particleIdx += numOfThreads) {
+			int size = particles.size();
+			for (int particleIdx = threadIdx; particleIdx < size; particleIdx += numOfThreads) {
 				action.execute(particles.get(particleIdx));
 			}
 			return null;

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
@@ -497,20 +497,20 @@ public class Settings {
 		switch(simulationType) {
 			case TemporalYangMills:
 				setBoundary(GeneralBoundaryType.Periodic);
-				setFieldSolver(new TemporalYangMillsSolver());
+				setFieldSolver(new FastTYMSolver());
 				setParticleSolver(new EmptyParticleSolver());
 				setInterpolator(new EmptyInterpolator());
 				break;
 			case TemporalCGC:
 				setBoundary(GeneralBoundaryType.Absorbing);
-				setFieldSolver(new TemporalYangMillsSolver());
+				setFieldSolver(new FastTYMSolver());
 				setParticleSolver(new CGCParticleSolver());
 				setInterpolator(new CGCParticleInterpolation());
 				break;
 			case TemporalCGCNGP:
 
 				setBoundary(GeneralBoundaryType.Absorbing);
-				setFieldSolver(new TemporalYangMillsSolver());
+				setFieldSolver(new FastTYMSolver());
 				setParticleSolver(new CGCParticleSolver());
 				setInterpolator(new CGCParticleInterpolationNGP());
 				break;

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/FastTYMSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/FastTYMSolver.java
@@ -1,0 +1,83 @@
+package org.openpixi.pixi.physics.fields;
+
+import org.openpixi.pixi.math.GroupElement;
+import org.openpixi.pixi.parallel.cellaccess.CellAction;
+import org.openpixi.pixi.physics.grid.Grid;
+
+public class FastTYMSolver extends FieldSolver
+{
+
+	private double timeStep;
+	private UpdateLinks linkUpdater = new UpdateLinks();
+	private CombinedUpdate combinedUpdate = new CombinedUpdate();
+
+	@Override
+	public FieldSolver clone() {
+		FastTYMSolver clone = new FastTYMSolver();
+		clone.copyBaseClassFields(this);
+		clone.timeStep = timeStep;
+		clone.linkUpdater = linkUpdater;
+		clone.combinedUpdate = combinedUpdate;
+		return clone;
+	}
+
+	@Override
+	public void step(Grid grid, double timeStep) {
+		combinedUpdate.at = timeStep;
+		combinedUpdate.factor = timeStep / (grid.getLatticeSpacing() * grid.getLatticeSpacing());
+
+		cellIterator.execute(grid, combinedUpdate);
+	}
+
+	@Override
+	public void stepLinks(Grid grid, double timeStep) {
+		linkUpdater.at = timeStep;
+		cellIterator.execute(grid, linkUpdater);
+	}
+
+	private class CombinedUpdate implements CellAction {
+
+		private double at;
+		private double factor;
+
+		/**
+		 * Combined update of fields and links using the sum of staples.
+		 * @param grid
+		 * @param index
+		 */
+		public void execute(Grid grid, int index) {
+			if(grid.isActive(index)) {
+				GroupElement V;
+				for (int i = 0; i < grid.getNumberOfDimensions(); i++) {
+					GroupElement temp = grid.getU(index, i).mult(grid.getStapleSum(index, i));
+					grid.addE(index, i, temp.proj().mult(factor));
+					grid.addE(index, i, grid.getJ(index, i).mult(-at));
+					V = grid.getE(index, i).mult(-at).getLink();
+					V.multAssign(grid.getU(index, i));
+					grid.setUnext(index, i, V);
+				}
+			}
+		}
+	}
+
+	private class UpdateLinks implements CellAction {
+		private double at;
+
+		/**
+		 * Updates the links matrices in a given cell.
+		 * @param grid	Reference to the grid
+		 * @param index	Cell index
+		 */
+		public void execute(Grid grid, int index) {
+			if(grid.isActive(index)) {
+				GroupElement V;
+				for (int k = 0; k < grid.getNumberOfDimensions(); k++) {
+					V = grid.getE(index, k).mult(-at).getLink();
+					V.multAssign(grid.getU(index, k));
+					grid.setUnext(index, k, V);
+
+				}
+			}
+		}
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/TemporalYangMillsSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/TemporalYangMillsSolver.java
@@ -66,10 +66,8 @@ public class TemporalYangMillsSolver extends FieldSolver
 							temp.addAssign(grid.getPlaquette(index, i, j, 1, -1, 0));
 						}
 					}
-
-					AlgebraElement currentE = grid.getE(index, i).add(temp.proj().mult(factor));
-					currentE.addAssign(grid.getJ(index, i).mult(-at));
-					grid.setE(index, i, currentE);
+					grid.addE(index, i, temp.proj().mult(factor));
+					grid.addE(index, i, grid.getJ(index, i).mult(-at));
 				}
 			}
 		}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/TemporalYangMillsSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/TemporalYangMillsSolver.java
@@ -28,6 +28,7 @@ public class TemporalYangMillsSolver extends FieldSolver
 		fieldUpdater.at = timeStep;
 		fieldUpdater.as = grid.getLatticeSpacing();
 		fieldUpdater.g = grid.getGaugeCoupling();
+		fieldUpdater.factor = timeStep / (grid.getLatticeSpacing() * grid.getLatticeSpacing());
 		linkUpdater.at = timeStep;
 		linkUpdater.as = grid.getLatticeSpacing();
 		cellIterator.execute(grid, fieldUpdater);
@@ -48,6 +49,7 @@ public class TemporalYangMillsSolver extends FieldSolver
 		private double as;
 		private double at;
 		private double g;
+		private double factor;
 
 		/**
 		 * Updates the electric fields at a given coordinate
@@ -65,7 +67,7 @@ public class TemporalYangMillsSolver extends FieldSolver
 						}
 					}
 
-					AlgebraElement currentE = grid.getE(index, i).add(temp.proj().mult(at / (as * as)));
+					AlgebraElement currentE = grid.getE(index, i).add(temp.proj().mult(factor));
 					currentE.addAssign(grid.getJ(index, i).mult(-at));
 					grid.setE(index, i, currentE);
 				}
@@ -87,8 +89,9 @@ public class TemporalYangMillsSolver extends FieldSolver
 			if(grid.isActive(index)) {
 				GroupElement V;
 				for (int k = 0; k < grid.getNumberOfDimensions(); k++) {
-					V = grid.getE(index, k).mult(-at).getLink();    //minus sign takes take of conjugation
-					grid.setUnext(index, k, V.mult(grid.getU(index, k)));
+					V = grid.getE(index, k).mult(-at).getLink();
+					V.multAssign(grid.getU(index, k));
+					grid.setUnext(index, k, V);
 
 				}
 			}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -562,7 +562,16 @@ public class Grid {
 			Plaquette calculation
 		 */
 
-		return U1.mult(U2.mult(U3.mult(U4)));
+
+		GroupElement U = factory.groupIdentity();
+		U.multAssign(U1);
+		U.multAssign(U2);
+		U.multAssign(U3);
+		U.multAssign(U4);
+
+		return U;
+
+		//return U1.mult(U2.mult(U3.mult(U4)));
 	}
 
 	/**
@@ -581,7 +590,16 @@ public class Grid {
 		GroupElement U3 = getTemporalLink(shift(index, d, o), 0).adj();
 		GroupElement U4 = getLink(index, d, o, 0).adj();
 
-		return U1.mult(U2.mult(U3.mult(U4)));
+
+		GroupElement U = factory.groupIdentity();
+		U.multAssign(U1);
+		U.multAssign(U2);
+		U.multAssign(U3);
+		U.multAssign(U4);
+
+		return U;
+
+		//return U1.mult(U2.mult(U3.mult(U4)));
 	}
 
 	/**

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -614,6 +614,35 @@ public class Grid {
 		//return U1.mult(U2.mult(U3.mult(U4)));
 	}
 
+
+	/**
+	 * Computes the sum of staples surrounding a particular gauge link given by a lattice index and a direction.
+	 * This is used for the field equations of motion.
+	 * @param index Lattice index
+	 * @param d     Direction
+	 * @return      Sum of all surrounding staples
+	 */
+	public GroupElement getStapleSum(int index, int d) {
+		GroupElement S = factory.groupZero();
+		int ci1 = shift2(index, d, 1);
+		int ci2, ci3, ci4;
+		for (int i = 0; i < numDim; i++) {
+			if(i != d) {
+				ci2 = shift2(index, i, 1);
+				ci3 = shift2(ci1, i, -1);
+				ci4 = shift2(index, i, -1);
+				GroupElement U1 = getU(ci1, i).mult(getU(ci2, d).adj());
+				U1.multAssign(getU(index, i).adj());
+				GroupElement U2 = getU(ci4, d).mult(getU(ci3, i));
+				U2.adjAssign();
+				U2.multAssign(getU(ci4, i));
+				S.addAssign(U1);
+				S.addAssign(U2);
+			}
+		}
+		return S;
+	}
+
 	/**
 	 * Getter for gauge links. Returns a link starting from a certain lattice index with the right direction and
 	 * orientation.

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -73,6 +73,8 @@ public class Grid {
 	 */
 	protected int cummulatedCellCount[];
 
+
+	protected int[][][] shiftTable;
 	/**
 	 * Factory for SU(n) group and algebra elements.
 	 */
@@ -474,6 +476,16 @@ public class Grid {
 		for(int i = 0; i < length; i++) {
 			cells[i] = new Cell(numDim, numCol, factory);
 		}
+
+		shiftTable = new int[length][numDim][2];
+		for (int i = 0; i < length; i++) {
+			for (int j = 0; j < numDim; j++) {
+				for (int k = 0; k < 2; k++) {
+					int orientation = 2*k - 1;
+					shiftTable[i][j][k] = shift(i, j, orientation);
+				}
+			}
+		}
 	
 	}
 
@@ -545,9 +557,9 @@ public class Grid {
 			The four lattice indices associated with the plaquette.
 		 */
 		int x1 = index;
-		int x2 = shift(x1, d1, o1);
-		int x3 = shift(x2, d2, o2);
-		int x4 = shift(x3, d1, -o1);
+		int x2 = shift2(x1, d1, o1);
+		int x3 = shift2(x2, d2, o2);
+		int x4 = shift2(x3, d1, -o1);
 
 		/*
 			The four gauge links associated with the plaquette.
@@ -587,7 +599,7 @@ public class Grid {
 	public GroupElement getTemporalPlaquette(int index, int d, int o) {
 		GroupElement U1 = getTemporalLink(index, 0);
 		GroupElement U2 = getLink(index, d, o, 1);
-		GroupElement U3 = getTemporalLink(shift(index, d, o), 0).adj();
+		GroupElement U3 = getTemporalLink(shift2(index, d, o), 0).adj();
 		GroupElement U4 = getLink(index, d, o, 0).adj();
 
 
@@ -622,12 +634,12 @@ public class Grid {
 		{
 			if(orientation < 0)
 			{
-				return getCell(shift(index, direction, orientation)).getU(direction).adj();
+				return getCell(shift2(index, direction, orientation)).getU(direction).adj();
 			}
 			return getCell(index).getU(direction);
 		} else {
 			if(orientation < 0) {
-				return getCell(shift(index, direction, orientation)).getUnext(direction).adj();
+				return getCell(shift2(index, direction, orientation)).getUnext(direction).adj();
 			}
 			return getCell(index).getUnext(direction);
 		}
@@ -741,6 +753,11 @@ public class Grid {
 			// do nothing if orientation == 0
 		}
 		return result;
+	}
+
+	protected int shift2(int index, int direction, int orientation)
+	{
+		return shiftTable[index][direction][(orientation+1)/2];
 	}
 
 	/*
@@ -865,7 +882,7 @@ public class Grid {
 	public AlgebraElement getGaussConstraint(int index) {
 		AlgebraElement gauss = factory.algebraZero();
 		for (int i = 0; i < numDim; i++) {
-			int shiftedIndex = shift(index, i, -1);
+			int shiftedIndex = shift2(index, i, -1);
 			AlgebraElement E = getE(shiftedIndex, i).copy();
 			E.actAssign(getLink(index, i, -1, 0));
 			gauss.addAssign(getE(index, i));
@@ -931,8 +948,8 @@ public class Grid {
 		int dirY = (direction + 1) % 3;
 		int dirZ = (direction + 2) % 3;
 
-		int indexShiftedY = shift(index, dirY, -1);
-		int indexShiftedZ = shift(index, dirZ, -1);
+		int indexShiftedY = shift2(index, dirY, -1);
+		int indexShiftedZ = shift2(index, dirZ, -1);
 
 		AlgebraElement By = getB(index, dirY, timeIndex); // By(y, z)
 		AlgebraElement Byz1 = getB(indexShiftedZ, dirY, timeIndex); // By(y, z+1)
@@ -965,8 +982,8 @@ public class Grid {
 		int dirY = (direction + 1) % 3;
 		int dirZ = (direction + 2) % 3;
 
-		int indexShiftedY = shift(index, dirY, 1);
-		int indexShiftedZ = shift(index, dirZ, 1);
+		int indexShiftedY = shift2(index, dirY, 1);
+		int indexShiftedZ = shift2(index, dirZ, 1);
 
 		AlgebraElement Ey = getE(index, dirY); // Ey(y, z)
 		AlgebraElement Eyz1 = getE(indexShiftedZ, dirY); // Ey(y, z+1)
@@ -994,7 +1011,7 @@ public class Grid {
 	 * @return      Averaged electric field
 	 */
 	public AlgebraElement getAveragedE(int index, int d) {
-		int shiftedIndex = shift(index, d, -1);
+		int shiftedIndex = shift2(index, d, -1);
 		AlgebraElement E1 = getE(index, d);
 		AlgebraElement E2 = getE(shiftedIndex, d).act(getLink(index, d, -1, 0));
 		return E1.add(E2).mult(0.5);

--- a/pixi/src/main/java/org/openpixi/pixi/physics/util/PerformanceTimer.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/util/PerformanceTimer.java
@@ -1,0 +1,23 @@
+package org.openpixi.pixi.physics.util;
+
+/**
+ * Created by David on 20.03.2016.
+ */
+public class PerformanceTimer {
+
+	private long time = 0;
+	public boolean active = false;
+
+	public void reset() {
+		time = System.nanoTime();
+	}
+
+	public void lap(String s) {
+		if(active) {
+			long delta = (System.nanoTime() - time) / (1000 * 1000);
+			System.out.println(s + " " + delta + "ms");
+			reset();
+		}
+	}
+
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
@@ -37,6 +37,9 @@ public class MainBatch {
 	public static int iterations;
 	private static Simulation simulation;
 
+	private static final long GIGABYTE = 1024L * 1024L * 1024L;
+
+
 	/**
 	 * This class takes an input parameter which specifies the YAML file.
 	 *
@@ -95,7 +98,22 @@ public class MainBatch {
 
 		// Simulation run and time measurement
 		long t0 = System.nanoTime();
+		Runtime runtime = Runtime.getRuntime();
 		try {
+			while(simulation.continues()) {
+				long stept0 = System.nanoTime();
+				simulation.step();
+
+				// Some diagnostic stuff
+				int stepdt = (int) ((System.nanoTime() - stept0) / 1000 / 1000);
+				double currentTime = simulation.totalSimulationTime;
+				double totalTime = simulation.getIterations() * simulation.getTimeStep();
+				double memory = ((int) (100 * runtime.totalMemory() / GIGABYTE)) / 100.0;
+				int mempercent = (int) (100 * runtime.totalMemory() / runtime.maxMemory());
+
+				System.out.println("MainBatch: step " + currentTime + "/" + totalTime + " (" + stepdt + "ms)");
+				System.out.println("MainBatch: memory: " + memory + "gb (" + mempercent + "%)");
+			}
 			simulation.run();
 		} catch (IOException e) {
 			System.out.println("MainBatch: something went wrong.");
@@ -104,7 +122,8 @@ public class MainBatch {
 		// dt in seconds
 		long t1 = System.nanoTime();
 		int dt = (int) ((t1 - t0) / 1000 / 1000 / 1000);
-		System.out.println("MainBatch: Simulation time: " + dt + " s.");
+		int avg = (int) ((t1 - t0) / 1000 / 1000) / simulation.getIterations();
+		System.out.println("MainBatch: Simulation time: " + dt + " s (average " + avg + "ms)");
 	}
 
 	public static void initializeSimulationFromString(String configurationString) {

--- a/pixi/src/test/java/org/openpixi/pixi/PerfTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/PerfTest.java
@@ -1,0 +1,139 @@
+package org.openpixi.pixi;
+
+/**
+ * Created by David on 17.03.2016.
+ */
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openpixi.pixi.math.SU2GroupElement;
+import org.openpixi.pixi.physics.Settings;
+import org.openpixi.pixi.physics.Simulation;
+import org.openpixi.pixi.ui.util.yaml.YamlParser;
+
+import java.io.IOException;
+
+public class PerfTest {
+
+	@Test
+	@Ignore
+	public void testFullSimulation() {
+		String configurationString = "simulationType: temporal cgc ngp\n" +
+				"gridStep: 1\n" +
+				"couplingConstant: 1\n" +
+				"numberOfDimensions: 3\n" +
+				"numberOfColors: 2\n" +
+				"numberOfThreads: 4\n" +
+				"gridCells: [512, 32, 32]\n" +
+				"timeStep: 0.5\n" +
+				"duration: 600\n" +
+				"evaluationRegion:\n" +
+				"  enabled: true\n" +
+				"  point1: [2, 0, 0]\n" +
+				"  point2: [-3, -1, -1]\n" +
+				"activeRegion:\n" +
+				"  enabled: true\n" +
+				"  point1: [1, 0, 0]\n" +
+				"  point2: [-2, -1, -1]\n" +
+				"\n" +
+				"currents:\n" +
+				"  dualMVModels:\n" +
+				"    - direction: 0\n" +
+				"      longitudinalLocation: 8\n" +
+				"      longitudinalWidth: 2.0\n" +
+				"      mu: 0.1\n" +
+				"      lowPassCoefficient: 1\n" +
+				"      randomSeed1: 1\n" +
+				"      randomSeed2: 2\n" +
+				"      createInitialConditionsOutput: false\n" +
+				"      outputFile: \"planarInitial.dat\"\n" +
+				"\n" +
+				"output:\n" +
+				"  projectedEnergyDensity:\n" +
+				"    - direction: 0\n" +
+				"      path: \"test.dat\"\n" +
+				"      interval: 1.0";
+
+		Settings settings = new Settings();
+		YamlParser yamlParser = new YamlParser(settings);
+		yamlParser.parseString(configurationString);
+
+		Simulation s = new Simulation(settings);
+		try {
+			long t0 = System.nanoTime();
+			while(s.continues()) {
+				s.step();
+				System.out.println("Simulation step: " + s.totalSimulationTime);
+			}
+
+			long t1 = System.nanoTime();
+			int dt = (int) ((t1 - t0) / 1000 / 1000 / 1000);
+			System.out.println("MainBatch: Simulation time: " + dt + " s.");
+		} catch (IOException ex) {
+
+		}
+	}
+/*
+	@Test
+	public void multVsMultAssign() {
+		int tests = 100000000;
+		SU2GroupElement A = createRandomSU2Matrix();
+		SU2GroupElement B = createRandomSU2Matrix();
+		long t0, t1, dt;
+
+		t0 = System.nanoTime();
+		for (int i = 0; i < tests; i++) {
+			A.mult(B).mult(A).mult(B).mult(A).mult(B).mult(A).mult(B);
+		}
+		t1 = System.nanoTime();
+		dt = (int) ((t1 - t0) / 1000 / 1000);
+		System.out.println("mult: " + dt + " ms.");
+
+
+		t0 = System.nanoTime();
+		for (int i = 0; i < tests; i++) {
+			SU2GroupElement C = new SU2GroupElement(1, 0, 0, 0);
+			C.multAssign(A);
+			C.multAssign(B);
+			C.multAssign(A);
+			C.multAssign(B);
+			C.multAssign(A);
+			C.multAssign(B);
+			C.multAssign(A);
+			C.multAssign(B);
+		}
+
+		t1 = System.nanoTime();
+		dt = (int) ((t1 - t0) / 1000 / 1000);
+		System.out.println("multAssign: " + dt + " ms.");
+
+		try {
+			Thread.sleep(10000);                 //1000 milliseconds is one second.
+		} catch(InterruptedException ex) {
+			Thread.currentThread().interrupt();
+		}
+	}
+*/
+
+	private SU2GroupElement createRandomSU2Matrix() {
+		/*
+			Create random SU2 matrix.
+		 */
+		double[] vec = new double[4];
+		double modulus = 0.0;
+		for (int i = 0; i < 4; i++) {
+			vec[i] = (Math.random() - 0.5);
+			modulus += vec[i] * vec[i];
+		}
+		modulus = Math.sqrt(modulus);
+
+		for (int i = 0; i < 4; i++) {
+			vec[i] /= modulus;
+		}
+
+		SU2GroupElement m = new SU2GroupElement(vec[0], vec[1], vec[2], vec[3]);
+
+		return m;
+	}
+}

--- a/pixi/src/test/java/org/openpixi/pixi/PerfTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/PerfTest.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 public class PerfTest {
 
 	@Test
-	@Ignore
 	public void testFullSimulation() {
 		String configurationString = "simulationType: temporal cgc ngp\n" +
 				"gridStep: 1\n" +
@@ -25,9 +24,9 @@ public class PerfTest {
 				"numberOfDimensions: 3\n" +
 				"numberOfColors: 2\n" +
 				"numberOfThreads: 4\n" +
-				"gridCells: [512, 32, 32]\n" +
+				"gridCells: [512, 16, 16]\n" +
 				"timeStep: 0.5\n" +
-				"duration: 600\n" +
+				"duration: 64\n" +
 				"evaluationRegion:\n" +
 				"  enabled: true\n" +
 				"  point1: [2, 0, 0]\n" +

--- a/pixi/src/test/java/org/openpixi/pixi/PerfTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/PerfTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 public class PerfTest {
 
 	@Test
+	@Ignore
 	public void testFullSimulation() {
 		String configurationString = "simulationType: temporal cgc ngp\n" +
 				"gridStep: 1\n" +

--- a/pixi/src/test/java/org/openpixi/pixi/math/SU2MatrixTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/math/SU2MatrixTest.java
@@ -262,6 +262,43 @@ public class SU2MatrixTest {
 
 	}
 
+
+	@Test
+	public void testMultiplicationAssign() {
+		SU2GroupElement a = createRandomSU2Matrix();
+		SU2GroupElement b = createRandomSU2Matrix();
+
+		Array2DRowFieldMatrix<Complex> aMatrix = convertToMatrix(a);
+		Array2DRowFieldMatrix<Complex> bMatrix = convertToMatrix(b);
+
+		/*
+			Do the multiplication.
+		 */
+		a.multAssign(b);
+		GroupElement c = a;
+		Array2DRowFieldMatrix<Complex> cMatrix = (Array2DRowFieldMatrix<Complex>) aMatrix.multiply(bMatrix).copy();
+
+		/*
+			Compare results.
+		 */
+		Array2DRowFieldMatrix<Complex> cMatrix2 = convertToMatrix(c);
+
+		for (int i = 0; i < 2; i++) {
+			for (int j = 0; j < 2; j++) {
+				Assert.assertEquals(cMatrix.getEntry(i, j).getReal(),
+						cMatrix2.getEntry(i, j).getReal(),
+						accuracy);
+
+				Assert.assertEquals(cMatrix.getEntry(i, j).getImaginary(),
+						cMatrix2.getEntry(i, j).getImaginary(),
+						accuracy);
+			}
+
+		}
+
+
+	}
+
 	@Test
 	public void testScalarMultiplication() {
 		int numberOfTests = 10;

--- a/pixi/src/test/java/org/openpixi/pixi/physics/grid/GridTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/physics/grid/GridTest.java
@@ -168,7 +168,7 @@ public class GridTest {
 	@Test
 	public void testShiftSpeed()
 	{
-		int numberOfTests = 10;
+		int numberOfTests = 50000000;
 
 		Settings settings = getStandardSettings();
 		settings.addFieldGenerator(new SU2RandomFields());
@@ -179,12 +179,14 @@ public class GridTest {
 		// Create random lattice position
 		int[] pos = getRandomLatticePosition(s);
 		int index = g.getCellIndex(pos);
+		int index3 = g.getCellIndex(pos);
 
 		// Start random generators with exactly the same seed (for comparability)
 		long seed = System.currentTimeMillis();
 		Random generator1 = new Random(seed);
 		Random generator2 = new Random(seed);
 		Random generator3 = new Random(seed);
+		Random generator4 = new Random(seed);
 
 		// Test shift() using position vectors
 		long time1 = -System.currentTimeMillis();
@@ -210,27 +212,40 @@ public class GridTest {
 		}
 		time2 += System.currentTimeMillis();
 
-		// Test duration of random seed creation:
+		// Test shift2() using indices
 		long time3 = -System.currentTimeMillis();
 		for (int t = 0; t < numberOfTests; t++) {
 
-			// Choose random direction and orientation
+			// Choose random direction
 			int d = generator3.nextInt(s.getNumberOfDimensions());
 			int o = generator3.nextInt(2) * 2 - 1;
+
+			index3 = g.shift2(index3, d, o);
 		}
 		time3 += System.currentTimeMillis();
+
+		// Test duration of random seed creation:
+		long time4 = -System.currentTimeMillis();
+		for (int t = 0; t < numberOfTests; t++) {
+
+			// Choose random direction and orientation
+			int d = generator4.nextInt(s.getNumberOfDimensions());
+			int o = generator4.nextInt(2) * 2 - 1;
+		}
+		time4 += System.currentTimeMillis();
 
 		// Test the same using indices:
 		int index2 = g.getCellIndex(pos);
 
 		// Tests
 		Assert.assertEquals(index, index2);
+		Assert.assertEquals(index3, index2);
 
 		if (numberOfTests > 1000) {
 			// Compare times
-			System.out.println("Shift test: Time1: " + time1 + " vs. Time2: " + time2);
-			System.out.println("Generation of random numbers: " + time3);
-			System.out.println("Shift test without random number generation: Time1: " + (time1 - time3) + " vs. Time2: " + (time2 - time3));
+			System.out.println("Shift test: Time1: " + time1 + " vs. Time2: " + time2 + " vs. Time3: " + time3);
+			System.out.println("Generation of random numbers: " + time4);
+			System.out.println("Shift test without random number generation: Time1: " + (time1 - time4) + " vs. Time2: " + (time2 - time4) + " vs. Time3: " + (time3 - time4));
 		}
 	}
 

--- a/pixi/src/test/java/org/openpixi/pixi/physics/grid/GridTest.java
+++ b/pixi/src/test/java/org/openpixi/pixi/physics/grid/GridTest.java
@@ -168,7 +168,7 @@ public class GridTest {
 	@Test
 	public void testShiftSpeed()
 	{
-		int numberOfTests = 50000000;
+		int numberOfTests = 20;
 
 		Settings settings = getStandardSettings();
 		settings.addFieldGenerator(new SU2RandomFields());


### PR DESCRIPTION
A few big optimization and small fixes.
- Optimized SU(2) _multAssign_ method, which is a little bit faster and does not create new _SU2GroupElement_ instances.
- Plaquette methods which use _multAssign_ instead of _mult_ (this basically solves the memory problem and is faster because the garbage collector has less to collect).
- Added grid method _shift2_ which uses a lookup table of precomputed values.
- Multithreading for _ProjectedEnergyDensity_ (its back!).
- _FastTYMSolver_, a temporal YM solver which uses staples instead of plaquettes and saves matrix multiplications. Replaces _TemporalYangMillsSolver_.

Fixes/Tweaks:
- Missing factor added in _ProjectedEnergyDensity_.
- Extra output for _MainBatch_ (memory, wall clock time per simulation step)
