### PR TITLE
Voxel panel

### DIFF
--- a/pixi/input/CGC/MV model/MVModel_NGP_movie.yaml
+++ b/pixi/input/CGC/MV model/MVModel_NGP_movie.yaml
@@ -1,0 +1,85 @@
+# MVmodel_NGP_movie
+#
+# This file demonstrates how to create a movie.
+#
+# You can create a movie from the sequence of images
+# by the following command:
+#
+# ffmpeg -r 25 -sameq -i img-%05d.png MVmodel_NGP_movie.mov
+
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: 2
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 8
+gridCells: [128, 8, 8]
+timeStep: 0.25
+duration: 96
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+currents:
+  MVModels:
+    - direction: 0
+      orientation: 1
+      longitudinalLocation: 32
+      longitudinalWidth: 3.0
+      mu: 0.05
+      randomSeed: 1
+    - direction: 0
+      orientation: -1
+      longitudinalLocation: -32
+      longitudinalWidth: 3.0
+      mu: 0.05
+      randomSeed: 2
+
+output:
+  screenshotInTime:
+    - path: "MVModel_NGP_movie/img-{counter}.png"
+      interval: 0.25
+      offset : 0
+      width: 1280
+      height: 720
+      panel:
+        energyDensityVoxelGLPanel:
+          automaticScaling: false
+          centerx: -6
+          centery: 4
+          centerz: 0
+          data: Energy density
+          direction: x
+          distanceFactor: 0.6
+          opacity: 1.0
+          phi: -2.1
+          scaleFactor: 100000.0
+          showSimulationBox: false
+          theta: 1.3
+          visibilityThreshold: 0.0
+          whiteBackground: false
+
+# Generated panel code:
+panels:
+  energyDensityVoxelGLPanel:
+    automaticScaling: false
+    centerx: -6
+    centery: 4
+    centerz: 0
+    data: Energy density
+    direction: x
+    distanceFactor: 0.6
+    opacity: 1.0
+    phi: -2.1
+    scaleFactor: 100000.0
+    showSimulationBox: false
+    theta: 1.3
+    visibilityThreshold: 0.0
+    whiteBackground: false
+  windowHeight: 700
+  windowWidth: 1200

--- a/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
@@ -24,6 +24,7 @@ import org.openpixi.pixi.ui.panel.PhaseSpacePanel;
 import org.openpixi.pixi.ui.panel.chart.Chart2DPanel;
 import org.openpixi.pixi.ui.panel.gl.EnergyDensity2DGLPanel;
 import org.openpixi.pixi.ui.panel.gl.EnergyDensity3DGLPanel;
+import org.openpixi.pixi.ui.panel.gl.EnergyDensityVoxelGLPanel;
 import org.openpixi.pixi.ui.panel.gl.GaussViolation2DGLPanel;
 import org.openpixi.pixi.ui.panel.gl.OccupationNumbers2DGLPanel;
 import org.openpixi.pixi.ui.tab.PropertiesTab;
@@ -54,6 +55,7 @@ public class PanelManager {
 	JMenuItem itemEnergyDensity2DPanel;
 	JMenuItem itemEnergyDensity2DGLPanel;
 	JMenuItem itemEnergyDensity3DGLPanel;
+	JMenuItem itemEnergyDensityVoxelGLPanel;
 	JMenuItem itemOccupationNumbers2DGLPanel;
 	JMenuItem itemChart2DPanel;
 	JMenuItem itemGaussViolation2DGLPanel;
@@ -210,6 +212,10 @@ public class PanelManager {
 			itemEnergyDensity3DGLPanel.addActionListener(new MenuSelected());
 			add(itemEnergyDensity3DGLPanel);
 
+			itemEnergyDensityVoxelGLPanel = new JMenuItem("Energy density Voxel (Open GL)");
+			itemEnergyDensityVoxelGLPanel.addActionListener(new MenuSelected());
+			add(itemEnergyDensityVoxelGLPanel);
+
 			itemOccupationNumbers2DGLPanel = new JMenuItem("Occupation numbers 2D (Open GL)");
 			itemOccupationNumbers2DGLPanel.addActionListener(new MenuSelected());
 			add(itemOccupationNumbers2DGLPanel);
@@ -289,6 +295,8 @@ public class PanelManager {
 				component = new EnergyDensity2DGLPanel(mainControlApplet.simulationAnimation);
 			} else if (event.getSource() == itemEnergyDensity3DGLPanel) {
 				component = new EnergyDensity3DGLPanel(mainControlApplet.simulationAnimation);
+			} else if (event.getSource() == itemEnergyDensityVoxelGLPanel) {
+				component = new EnergyDensityVoxelGLPanel(mainControlApplet.simulationAnimation);
 			} else if (event.getSource() == itemOccupationNumbers2DGLPanel) {
 				component = new OccupationNumbers2DGLPanel(mainControlApplet.simulationAnimation);
 			} else if (event.getSource() == itemChart2DPanel) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -250,7 +250,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 
 					gl2.glColor4f( red, green, blue, alpha);
 					if (value >= visibilityThreshold) {
-						drawCube(gl2, x, y, z, (float) as * .5f);
+						drawCube(gl2, x, y, z, (float) as * .5f, (float) viewx, (float) viewy, (float) viewz);
 					}
 				}
 			}
@@ -311,12 +311,10 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 
 	/**
 	 * See http://www.tutorialspoint.com/jogl/jogl_3d_cube.htm
-	 * @param gl2
-	 * @param x
-	 * @param y
-	 * @param z
+	 *
+	 * Only draw visible sides (approximately)
 	 */
-	private void drawCube(GL2 gl2, float x, float y, float z, float size) {
+	private void drawCube(GL2 gl2, float x, float y, float z, float size, float viewx, float viewy, float viewz) {
 
 		gl2.glPushMatrix();
 
@@ -324,35 +322,43 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		gl2.glScalef(size,  size, size);
 
 		gl2.glBegin(GL2.GL_QUADS); // Start Drawing The Cube
-		gl2.glVertex3f(1.0f, 1.0f, -1.0f); // Top Right Of The Quad (Top)
-		gl2.glVertex3f(-1.0f, 1.0f, -1.0f); // Top Left Of The Quad (Top)
-		gl2.glVertex3f(-1.0f, 1.0f, 1.0f); // Bottom Left Of The Quad (Top)
-		gl2.glVertex3f(1.0f, 1.0f, 1.0f); // Bottom Right Of The Quad (Top)
 
-		gl2.glVertex3f(1.0f, -1.0f, 1.0f); // Top Right Of The Quad
-		gl2.glVertex3f(-1.0f, -1.0f, 1.0f); // Top Left Of The Quad
-		gl2.glVertex3f(-1.0f, -1.0f, -1.0f); // Bottom Left Of The Quad
-		gl2.glVertex3f(1.0f, -1.0f, -1.0f); // Bottom Right Of The Quad
+		if (viewx > 0) {
+			gl2.glVertex3f(1.0f, 1.0f, -1.0f); // Top Right Of The Quad (Right)
+			gl2.glVertex3f(1.0f, 1.0f, 1.0f); // Top Left Of The Quad
+			gl2.glVertex3f(1.0f, -1.0f, 1.0f); // Bottom Left Of The Quad
+			gl2.glVertex3f(1.0f, -1.0f, -1.0f); // Bottom Right Of The Quad
+		} else {
+			gl2.glVertex3f(-1.0f, 1.0f, 1.0f); // Top Right Of The Quad (Left)
+			gl2.glVertex3f(-1.0f, 1.0f, -1.0f); // Top Left Of The Quad (Left)
+			gl2.glVertex3f(-1.0f, -1.0f, -1.0f); // Bottom Left Of The Quad
+			gl2.glVertex3f(-1.0f, -1.0f, 1.0f); // Bottom Right Of The Quad
+		}
 
-		gl2.glVertex3f(1.0f, 1.0f, 1.0f); // Top Right Of The Quad (Front)
-		gl2.glVertex3f(-1.0f, 1.0f, 1.0f); // Top Left Of The Quad (Front)
-		gl2.glVertex3f(-1.0f, -1.0f, 1.0f); // Bottom Left Of The Quad
-		gl2.glVertex3f(1.0f, -1.0f, 1.0f); // Bottom Right Of The Quad
+		if (viewy > 0) {
+			gl2.glVertex3f(1.0f, 1.0f, -1.0f); // Top Right Of The Quad (Top)
+			gl2.glVertex3f(-1.0f, 1.0f, -1.0f); // Top Left Of The Quad (Top)
+			gl2.glVertex3f(-1.0f, 1.0f, 1.0f); // Bottom Left Of The Quad (Top)
+			gl2.glVertex3f(1.0f, 1.0f, 1.0f); // Bottom Right Of The Quad (Top)
+		} else {
+			gl2.glVertex3f(1.0f, -1.0f, 1.0f); // Top Right Of The Quad
+			gl2.glVertex3f(-1.0f, -1.0f, 1.0f); // Top Left Of The Quad
+			gl2.glVertex3f(-1.0f, -1.0f, -1.0f); // Bottom Left Of The Quad
+			gl2.glVertex3f(1.0f, -1.0f, -1.0f); // Bottom Right Of The Quad
+		}
 
-		gl2.glVertex3f(1.0f, -1.0f, -1.0f); // Bottom Left Of The Quad
-		gl2.glVertex3f(-1.0f, -1.0f, -1.0f); // Bottom Right Of The Quad
-		gl2.glVertex3f(-1.0f, 1.0f, -1.0f); // Top Right Of The Quad (Back)
-		gl2.glVertex3f(1.0f, 1.0f, -1.0f); // Top Left Of The Quad (Back)
+		if (viewz > 0) {
+			gl2.glVertex3f(1.0f, 1.0f, 1.0f); // Top Right Of The Quad (Front)
+			gl2.glVertex3f(-1.0f, 1.0f, 1.0f); // Top Left Of The Quad (Front)
+			gl2.glVertex3f(-1.0f, -1.0f, 1.0f); // Bottom Left Of The Quad
+			gl2.glVertex3f(1.0f, -1.0f, 1.0f); // Bottom Right Of The Quad
+		} else {
+			gl2.glVertex3f(1.0f, -1.0f, -1.0f); // Bottom Left Of The Quad
+			gl2.glVertex3f(-1.0f, -1.0f, -1.0f); // Bottom Right Of The Quad
+			gl2.glVertex3f(-1.0f, 1.0f, -1.0f); // Top Right Of The Quad (Back)
+			gl2.glVertex3f(1.0f, 1.0f, -1.0f); // Top Left Of The Quad (Back)
+		}
 
-		gl2.glVertex3f(-1.0f, 1.0f, 1.0f); // Top Right Of The Quad (Left)
-		gl2.glVertex3f(-1.0f, 1.0f, -1.0f); // Top Left Of The Quad (Left)
-		gl2.glVertex3f(-1.0f, -1.0f, -1.0f); // Bottom Left Of The Quad
-		gl2.glVertex3f(-1.0f, -1.0f, 1.0f); // Bottom Right Of The Quad
-
-		gl2.glVertex3f(1.0f, 1.0f, -1.0f); // Top Right Of The Quad (Right)
-		gl2.glVertex3f(1.0f, 1.0f, 1.0f); // Top Left Of The Quad
-		gl2.glVertex3f(1.0f, -1.0f, 1.0f); // Bottom Left Of The Quad
-		gl2.glVertex3f(1.0f, -1.0f, -1.0f); // Bottom Right Of The Quad
 		gl2.glEnd(); // Done Drawing The Quad
 
 		gl2.glPopMatrix();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -40,6 +40,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 
 	public ScaleProperties scaleProperties;
 	public DoubleProperties visibilityThresholdProperties;
+	public DoubleProperties opacityProperties;
 
 	public double phi;
 	public double theta;
@@ -55,7 +56,8 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 	public EnergyDensityVoxelGLPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
 		scaleProperties = new ScaleProperties(simulationAnimation);
-		visibilityThresholdProperties = new DoubleProperties(simulationAnimation, "Visibility threshold", 0.5);
+		visibilityThresholdProperties = new DoubleProperties(simulationAnimation, "Visibility threshold", 0.0);
+		opacityProperties = new DoubleProperties(simulationAnimation, "Opacity", 1);
 
 		MouseListener l = new MouseListener();
 		addMouseListener(l);
@@ -91,6 +93,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		Simulation s = getSimulationAnimation().getSimulation();
 
 		double visibilityThreshold = visibilityThresholdProperties.getValue();
+		double opacity = opacityProperties.getValue();
 
 		// Perspective.
 		float sizex = (float) s.getSimulationBoxSize(0);
@@ -244,7 +247,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 					red = (float) Math.sqrt(red / norm);
 					green = (float) Math.sqrt(green / norm);
 					blue = (float) Math.sqrt(blue / norm);
-					alpha = value;
+					alpha = value * (float) opacity;
 
 					scaleProperties.putValue(EfieldSquared + BfieldSquared);
 
@@ -368,5 +371,6 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		addLabel(box, "Energy density 2D (OpenGL) panel");
 		scaleProperties.addComponents(box);
 		visibilityThresholdProperties.addComponents(box);
+		opacityProperties.addComponents(box);
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -29,6 +29,7 @@ import javax.swing.Box;
 
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.ui.SimulationAnimation;
+import org.openpixi.pixi.ui.panel.properties.DoubleProperties;
 import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
 
 
@@ -38,6 +39,7 @@ import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
 public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 
 	public ScaleProperties scaleProperties;
+	public DoubleProperties visibilityThresholdProperties;
 
 	public double phi;
 	public double theta;
@@ -52,6 +54,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 	public EnergyDensityVoxelGLPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
 		scaleProperties = new ScaleProperties(simulationAnimation);
+		visibilityThresholdProperties = new DoubleProperties(simulationAnimation, "Visibility threshold", 0.5);
 
 		MouseListener l = new MouseListener();
 		addMouseListener(l);
@@ -86,6 +89,8 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		double scale = scaleProperties.getScale();
 		scaleProperties.resetAutomaticScale();
 		Simulation s = getSimulationAnimation().getSimulation();
+
+		double visibilityThreshold = visibilityThresholdProperties.getValue();
 
 		// Perspective.
 		float sizex = (float) s.getSimulationBoxSize(0);
@@ -180,8 +185,8 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 					scaleProperties.putValue(EfieldSquared + BfieldSquared);
 
 					gl2.glColor3f( red, green, blue);
-					if (value > 0.4) {
-						drawCube(gl2, x, y, z, (float) as*.5f);
+					if (value >= visibilityThreshold) {
+						drawCube(gl2, x, y, z, (float) as * .5f);
 					}
 				}
 			}
@@ -270,5 +275,6 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 	public void addPropertyComponents(Box box) {
 		addLabel(box, "Energy density 2D (OpenGL) panel");
 		scaleProperties.addComponents(box);
+		visibilityThresholdProperties.addComponents(box);
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -51,9 +51,6 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 	/** Distance of viewer */
 	public double distanceFactor;
 
-	/** Maximum height of values */
-	public double heightFactor;
-
 	/** Constructor */
 	public EnergyDensityVoxelGLPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
@@ -67,7 +64,6 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		phi = - 0.5 * Math.PI;
 		theta = Math.PI * 0.25;
 		distanceFactor = 1;
-		heightFactor = .25;
 
 		scaleProperties.setAutomaticScaling(true);
 	}
@@ -103,9 +99,6 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		float size = Math.max(Math.max(sizex, sizey), sizez);
 		float distance = (float) distanceFactor * size;
 		float widthHeightRatio = (float) width / (float) height;
-
-		// Scaling for height:
-		float heightScale = (float) heightFactor * size;
 
 		gl2.glMatrixMode( GL2.GL_PROJECTION );
 		gl2.glLoadIdentity();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -375,7 +375,11 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 			if (e.isControlDown()) {
 				// Change distance (Ctrl key)
 				double factor = 0.01;
+				double prevDistanceFactor = distanceFactor;
 				distanceFactor -= factor * deltaY;
+				if (distanceFactor <= 0) {
+					distanceFactor = prevDistanceFactor;
+				}
 			} else if (e.isShiftDown()) {
 				// Translate scene (Shift key)
 				double factor = 0.1;
@@ -395,7 +399,11 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 				// Rotate scene
 				double factor = 0.01;
 				phi -= factor * deltaX;
+				double oldTheta = theta;
 				theta -= factor * deltaY;
+				if ((theta <= 0) || (theta > Math.PI)) {
+					theta = oldTheta;
+				}
 			}
 			mouseOldX = e.getX();
 			mouseOldY = e.getY();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -129,7 +129,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		float[] previousBlue = new float[s.grid.getNumCells(1)];
 
 		for(int i = 0; i < s.grid.getNumCells(0); i++) {
-			gl2.glBegin( GL2.GL_QUAD_STRIP );
+//			gl2.glBegin( GL2.GL_QUAD_STRIP );
 			for(int k = 0; k < s.grid.getNumCells(1); k++)
 			{
 				//float xstart = (float) (s.grid.getLatticeSpacing() * (i + 0.5) * sx);
@@ -185,17 +185,18 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 				scaleProperties.putValue(EfieldSquared + BfieldSquared);
 
 				if (k > 0) {
-					gl2.glColor3f( previousRed[k], previousGreen[k], previousBlue[k]);
-					gl2.glVertex3f( xstart2, ystart2, heightScale * previousValue[k]);
+//					gl2.glColor3f( previousRed[k], previousGreen[k], previousBlue[k]);
+//					gl2.glVertex3f( xstart2, ystart2, heightScale * previousValue[k]);
 					gl2.glColor3f( red, green, blue);
-					gl2.glVertex3f( xstart3, ystart2, heightScale * (float) value);
+//					gl2.glVertex3f( xstart3, ystart2, heightScale * (float) value);
+					drawCube(gl2, xstart3, ystart2, heightScale * (float) value);
 				}
 				previousValue[k] = (float) value;
 				previousRed[k] = (float) red;
 				previousGreen[k] = (float) green;
 				previousBlue[k] = (float) blue;
 			}
-			gl2.glEnd();
+//			gl2.glEnd();
 		}
 		scaleProperties.calculateAutomaticScale(1.0);
 	}
@@ -227,6 +228,66 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 			super.mouseReleased(e);
 			simulationAnimation.repaint();
 		}
+	}
+
+	/**
+	 * See http://www.tutorialspoint.com/jogl/jogl_3d_cube.htm
+	 * @param gl2
+	 * @param x
+	 * @param y
+	 * @param z
+	 */
+	private void drawCube(GL2 gl2, float x, float y, float z) {
+
+		gl2.glPushMatrix();
+
+		gl2.glTranslatef(x, y, z);
+
+		// Rotate The Cube On X, Y & Z
+		//gl2.glRotatef(rquad, 1.0f, 1.0f, 1.0f);
+
+		// giving different colors to different sides
+		gl2.glBegin(GL2.GL_QUADS); // Start Drawing The Cube
+		gl2.glColor3f(1f, 0f, 0f); // red color
+		gl2.glVertex3f(1.0f, 1.0f, -1.0f); // Top Right Of The Quad (Top)
+		gl2.glVertex3f(-1.0f, 1.0f, -1.0f); // Top Left Of The Quad (Top)
+		gl2.glVertex3f(-1.0f, 1.0f, 1.0f); // Bottom Left Of The Quad (Top)
+		gl2.glVertex3f(1.0f, 1.0f, 1.0f); // Bottom Right Of The Quad (Top)
+
+		gl2.glColor3f(0f, 1f, 0f); // green color
+		gl2.glVertex3f(1.0f, -1.0f, 1.0f); // Top Right Of The Quad
+		gl2.glVertex3f(-1.0f, -1.0f, 1.0f); // Top Left Of The Quad
+		gl2.glVertex3f(-1.0f, -1.0f, -1.0f); // Bottom Left Of The Quad
+		gl2.glVertex3f(1.0f, -1.0f, -1.0f); // Bottom Right Of The Quad
+
+		gl2.glColor3f(0f, 0f, 1f); // blue color
+		gl2.glVertex3f(1.0f, 1.0f, 1.0f); // Top Right Of The Quad (Front)
+		gl2.glVertex3f(-1.0f, 1.0f, 1.0f); // Top Left Of The Quad (Front)
+		gl2.glVertex3f(-1.0f, -1.0f, 1.0f); // Bottom Left Of The Quad
+		gl2.glVertex3f(1.0f, -1.0f, 1.0f); // Bottom Right Of The Quad
+
+		gl2.glColor3f(1f, 1f, 0f); // yellow (red + green)
+		gl2.glVertex3f(1.0f, -1.0f, -1.0f); // Bottom Left Of The Quad
+		gl2.glVertex3f(-1.0f, -1.0f, -1.0f); // Bottom Right Of The Quad
+		gl2.glVertex3f(-1.0f, 1.0f, -1.0f); // Top Right Of The Quad (Back)
+		gl2.glVertex3f(1.0f, 1.0f, -1.0f); // Top Left Of The Quad (Back)
+
+		gl2.glColor3f(1f, 0f, 1f); // purple (red + green)
+		gl2.glVertex3f(-1.0f, 1.0f, 1.0f); // Top Right Of The Quad (Left)
+		gl2.glVertex3f(-1.0f, 1.0f, -1.0f); // Top Left Of The Quad (Left)
+		gl2.glVertex3f(-1.0f, -1.0f, -1.0f); // Bottom Left Of The Quad
+		gl2.glVertex3f(-1.0f, -1.0f, 1.0f); // Bottom Right Of The Quad
+
+		gl2.glColor3f(0f, 1f, 1f); // sky blue (blue +green)
+		gl2.glVertex3f(1.0f, 1.0f, -1.0f); // Top Right Of The Quad (Right)
+		gl2.glVertex3f(1.0f, 1.0f, 1.0f); // Top Left Of The Quad
+		gl2.glVertex3f(1.0f, -1.0f, 1.0f); // Bottom Left Of The Quad
+		gl2.glVertex3f(1.0f, -1.0f, -1.0f); // Bottom Right Of The Quad
+		gl2.glEnd(); // Done Drawing The Quad
+
+		gl2.glPopMatrix();
+
+//		gl2.glFlush();
 	}
 
 	public void addPropertyComponents(Box box) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -1,0 +1,236 @@
+/*
+ * OpenPixi - Open Particle-In-Cell (PIC) Simulator
+ * Copyright (C) 2012  OpenPixi.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.openpixi.pixi.ui.panel.gl;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+import javax.media.opengl.GL;
+import javax.media.opengl.GL2;
+import javax.media.opengl.GLAutoDrawable;
+import javax.media.opengl.glu.GLU;
+import javax.swing.Box;
+
+import org.openpixi.pixi.physics.Simulation;
+import org.openpixi.pixi.ui.SimulationAnimation;
+import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
+
+
+/**
+ * Displays 2D energy density in 3D view.
+ */
+public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
+
+	public ScaleProperties scaleProperties;
+
+	public double phi;
+	public double theta;
+
+	/** Distance of viewer */
+	public double distanceFactor;
+
+	/** Maximum height of values */
+	public double heightFactor;
+
+	/** Constructor */
+	public EnergyDensityVoxelGLPanel(SimulationAnimation simulationAnimation) {
+		super(simulationAnimation);
+		scaleProperties = new ScaleProperties(simulationAnimation);
+
+		MouseListener l = new MouseListener();
+		addMouseListener(l);
+		addMouseMotionListener(l);
+
+		phi = - 0.5 * Math.PI;
+		theta = Math.PI * 0.25;
+		distanceFactor = 1;
+		heightFactor = .25;
+
+		scaleProperties.setAutomaticScaling(true);
+	}
+
+	@Override
+	public void reshape(GLAutoDrawable glautodrawable, int x, int y,
+			int width, int height) {
+		// Set up perspective below
+	}
+
+	@Override
+	public void display(GLAutoDrawable glautodrawable) {
+		GL2 gl2 = glautodrawable.getGL().getGL2();
+		int width = glautodrawable.getWidth();
+		int height = glautodrawable.getHeight();
+		gl2.glEnable(GL.GL_DEPTH_TEST);
+		gl2.glClear( GL.GL_COLOR_BUFFER_BIT | GL.GL_DEPTH_BUFFER_BIT );
+		gl2.glLoadIdentity();
+
+		// coordinate system origin at lower left with width and height same as the window
+		GLU glu = new GLU();
+
+		double scale = scaleProperties.getScale();
+		scaleProperties.resetAutomaticScale();
+		Simulation s = getSimulationAnimation().getSimulation();
+
+		// Perspective.
+		float size = (float) Math.max(s.getWidth(), s.getHeight());
+		float distance = (float) distanceFactor * size;
+		float widthHeightRatio = (float) width / (float) height;
+
+		// Scaling for height:
+		float heightScale = (float) heightFactor * size;
+
+		gl2.glMatrixMode( GL2.GL_PROJECTION );
+		gl2.glLoadIdentity();
+		glu.gluPerspective(
+				45, // field of view angle, in degrees
+				widthHeightRatio, // aspect ratio of field of view
+				1, // distance to near clipping plane
+				2.5 * size); // distance to far clipping plane
+		glu.gluLookAt(
+				s.getWidth() / 2 + distance * Math.cos(phi) * Math.sin(theta), s.getHeight() / 2 + distance * Math.sin(phi) * Math.sin(theta), distance * Math.cos(theta), // where we stand
+				s.getWidth() / 2, s.getHeight() / 2, 0, // where we are viewing at
+				0, 0, 1); // "up" direction
+
+		/** Scaling factor for the displayed panel in x-direction*/
+		double sx = 1; //getWidth() / s.getWidth();
+		/** Scaling factor for the displayed panel in y-direction*/
+		double sy = 1; //getHeight() / s.getHeight();
+
+		// Lattice spacing and coupling constant
+		double as = s.grid.getLatticeSpacing();
+		double g = s.getCouplingConstant();
+
+		int[] pos = new int[s.getNumberOfDimensions()];
+		for(int w = 2; w < s.getNumberOfDimensions(); w++) {
+			pos[w] = s.grid.getNumCells(w)/2;
+		}
+
+		double colors = s.grid.getNumberOfColors();
+
+		float[] previousValue = new float[s.grid.getNumCells(1)];
+		float[] previousRed = new float[s.grid.getNumCells(1)];
+		float[] previousGreen = new float[s.grid.getNumCells(1)];
+		float[] previousBlue = new float[s.grid.getNumCells(1)];
+
+		for(int i = 0; i < s.grid.getNumCells(0); i++) {
+			gl2.glBegin( GL2.GL_QUAD_STRIP );
+			for(int k = 0; k < s.grid.getNumCells(1); k++)
+			{
+				//float xstart = (float) (s.grid.getLatticeSpacing() * (i + 0.5) * sx);
+				float xstart2 = (float)(s.grid.getLatticeSpacing() * i * sx);
+				float xstart3 = (float)(s.grid.getLatticeSpacing() * (i + 1) * sx);
+				//float ystart = (float) (s.grid.getLatticeSpacing() * (k + 0.5) * sy);
+				float ystart2 = (float) (s.grid.getLatticeSpacing() * k * sy);
+
+				pos[0] = i;
+				pos[1] = k;
+				int index = s.grid.getCellIndex(pos);
+
+				double EfieldSquared = 0.0;
+				double BfieldSquared = 0.0;
+				float red = 0;
+				float green = 0;
+				float blue = 0;
+				if(s.grid.isEvaluatable(index)) {
+					for (int w = 0; w < s.getNumberOfDimensions(); w++) {
+						EfieldSquared += s.grid.getEsquaredFromLinks(index, w) / (as * g * as * g) / 2;
+						// Time averaging for B field.
+						BfieldSquared += s.grid.getBsquaredFromLinks(index, w, 0) / (as * g * as * g) / 4.0;
+						BfieldSquared += s.grid.getBsquaredFromLinks(index, w, 1) / (as * g * as * g) / 4.0;
+						// get color:
+						double color;
+						for (int n = 0; n < colors * colors - 1; n++) {
+							color = s.grid.getE(index, w).get(n);
+							// cycle through colors if there are more than three
+							switch (n % 3) {
+								case 0:
+									red += color * color;
+									break;
+								case 1:
+									green += color * color;
+									break;
+								case 2:
+									blue += color * color;
+									break;
+							}
+						}
+					}
+				}
+				// Normalize
+				double norm = Math.max(red + green + blue, 10E-20);
+				float value = (float) Math.min(1, scale * (EfieldSquared + BfieldSquared));
+
+				// Set color according to E-field, and brightness according
+				// to total energy density:
+				red = (float) Math.sqrt(red / norm) * value;
+				green = (float) Math.sqrt(green / norm) * value;
+				blue = (float) Math.sqrt(blue / norm) * value;
+
+				scaleProperties.putValue(EfieldSquared + BfieldSquared);
+
+				if (k > 0) {
+					gl2.glColor3f( previousRed[k], previousGreen[k], previousBlue[k]);
+					gl2.glVertex3f( xstart2, ystart2, heightScale * previousValue[k]);
+					gl2.glColor3f( red, green, blue);
+					gl2.glVertex3f( xstart3, ystart2, heightScale * (float) value);
+				}
+				previousValue[k] = (float) value;
+				previousRed[k] = (float) red;
+				previousGreen[k] = (float) green;
+				previousBlue[k] = (float) blue;
+			}
+			gl2.glEnd();
+		}
+		scaleProperties.calculateAutomaticScale(1.0);
+	}
+
+	private int mouseOldX, mouseOldY;
+
+	class MouseListener extends MouseAdapter {
+		public void mousePressed(MouseEvent e) {
+			//System.out.println("Pressed "+e.getX() + " : " + e.getY());
+			mouseOldX = e.getX();
+			mouseOldY = e.getY();
+			super.mousePressed(e);
+		}
+
+		public void mouseDragged(MouseEvent e) {
+			//System.out.println("D "+e.getX() + " : " + e.getY());
+			double deltaX = e.getX() - mouseOldX;
+			double deltaY = e.getY() - mouseOldY;
+			double factor = 0.01;
+			phi -= factor * deltaX;
+			theta -= factor * deltaY;
+			mouseOldX = e.getX();
+			mouseOldY = e.getY();
+			super.mouseDragged(e);
+			simulationAnimation.repaint();
+		}
+
+		public void mouseReleased(MouseEvent e) {
+			super.mouseReleased(e);
+			simulationAnimation.repaint();
+		}
+	}
+
+	public void addPropertyComponents(Box box) {
+		addLabel(box, "Energy density 2D (OpenGL) panel");
+		scaleProperties.addComponents(box);
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -168,12 +168,16 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 
 		// Enable color material
 		gl2.glEnable(GL2.GL_COLOR_MATERIAL);
-		gl2.glColorMaterial(GL2.GL_FRONT_AND_BACK, GL2.GL_DIFFUSE);
+		gl2.glColorMaterial(GL2.GL_FRONT_AND_BACK, GL2.GL_AMBIENT_AND_DIFFUSE);
+
+		float specReflection[] = { .8f, .8f, .8f, 1.0f };
+		gl2.glMaterialfv(GL2.GL_FRONT_AND_BACK, GL2.GL_SPECULAR, specReflection, 0);
+		gl2.glMateriali(GL2.GL_FRONT_AND_BACK, GL2.GL_SHININESS, 64);
 
 		// Light source 0
-		float light0_ambient[] = { 0f, 0f, 0f, 1f };
-		float light0_diffuse[] = { 1f, 1f, 1f, 1.0f };
-		float light0_specular[] = { 1f, 1f, 1f, 1.0f };
+		float light0_ambient[] = { .3f, .3f, .3f, 1f };
+		float light0_diffuse[] = { .7f, .7f, .7f, 1f };
+		float light0_specular[] = { .8f, .8f, .8f, 1.0f };
 		float light0_position[] = { 10 * size, 20 * size, 40 * size, 0.0f };
 
 		gl2.glEnable(GL2.GL_LIGHT0);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -163,6 +163,37 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		gl2.glEnable(GL.GL_BLEND);
 		gl2.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA);
 
+		// Enable lighting
+		gl2.glEnable(GL2.GL_LIGHTING);
+
+		// Enable color material
+		gl2.glEnable(GL2.GL_COLOR_MATERIAL);
+		gl2.glColorMaterial(GL2.GL_FRONT_AND_BACK, GL2.GL_DIFFUSE);
+
+		// Light source 0
+		float light0_ambient[] = { 0f, 0f, 0f, 1f };
+		float light0_diffuse[] = { 1f, 1f, 1f, 1.0f };
+		float light0_specular[] = { 1f, 1f, 1f, 1.0f };
+		float light0_position[] = { 10 * size, 20 * size, 40 * size, 0.0f };
+
+		gl2.glEnable(GL2.GL_LIGHT0);
+		gl2.glLightfv(GL2.GL_LIGHT0, GL2.GL_AMBIENT, light0_ambient, 0);
+		gl2.glLightfv(GL2.GL_LIGHT0, GL2.GL_DIFFUSE, light0_diffuse, 0);
+		gl2.glLightfv(GL2.GL_LIGHT0, GL2.GL_SPECULAR, light0_specular, 0);
+		gl2.glLightfv(GL2.GL_LIGHT0, GL2.GL_POSITION, light0_position, 0);
+
+		// Light source 1
+		float light1_ambient[] = { 0f, 0f, 0f, 1f };
+		float light1_diffuse[] = { .5f, .5f, .5f, 1.0f };
+		float light1_specular[] = { .5f, .5f, .5f, 1.0f };
+		float light1_position[] = { -20 * size, -40 * size, -10 * size, 0.0f };
+
+		gl2.glEnable(GL2.GL_LIGHT1);
+		gl2.glLightfv(GL2.GL_LIGHT1, GL2.GL_AMBIENT, light1_ambient, 0);
+		gl2.glLightfv(GL2.GL_LIGHT1, GL2.GL_DIFFUSE, light1_diffuse, 0);
+		gl2.glLightfv(GL2.GL_LIGHT1, GL2.GL_SPECULAR, light1_specular, 0);
+		gl2.glLightfv(GL2.GL_LIGHT1, GL2.GL_POSITION, light1_position, 0);
+
 		// Lattice spacing
 		double as = s.grid.getLatticeSpacing();
 
@@ -458,11 +489,13 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		gl2.glBegin(GL2.GL_QUADS); // Start Drawing The Cube
 
 		if (viewx > 0) {
+			gl2.glNormal3f(1f, 0, 0);
 			gl2.glVertex3f(1.0f, 1.0f, -1.0f); // Top Right Of The Quad (Right)
 			gl2.glVertex3f(1.0f, 1.0f, 1.0f); // Top Left Of The Quad
 			gl2.glVertex3f(1.0f, -1.0f, 1.0f); // Bottom Left Of The Quad
 			gl2.glVertex3f(1.0f, -1.0f, -1.0f); // Bottom Right Of The Quad
 		} else {
+			gl2.glNormal3f(-1f, 0, 0);
 			gl2.glVertex3f(-1.0f, 1.0f, 1.0f); // Top Right Of The Quad (Left)
 			gl2.glVertex3f(-1.0f, 1.0f, -1.0f); // Top Left Of The Quad (Left)
 			gl2.glVertex3f(-1.0f, -1.0f, -1.0f); // Bottom Left Of The Quad
@@ -470,11 +503,13 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		}
 
 		if (viewy > 0) {
+			gl2.glNormal3f(0, 1f, 0);
 			gl2.glVertex3f(1.0f, 1.0f, -1.0f); // Top Right Of The Quad (Top)
 			gl2.glVertex3f(-1.0f, 1.0f, -1.0f); // Top Left Of The Quad (Top)
 			gl2.glVertex3f(-1.0f, 1.0f, 1.0f); // Bottom Left Of The Quad (Top)
 			gl2.glVertex3f(1.0f, 1.0f, 1.0f); // Bottom Right Of The Quad (Top)
 		} else {
+			gl2.glNormal3f(0, -1f, 0);
 			gl2.glVertex3f(1.0f, -1.0f, 1.0f); // Top Right Of The Quad
 			gl2.glVertex3f(-1.0f, -1.0f, 1.0f); // Top Left Of The Quad
 			gl2.glVertex3f(-1.0f, -1.0f, -1.0f); // Bottom Left Of The Quad
@@ -482,11 +517,13 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		}
 
 		if (viewz > 0) {
+			gl2.glNormal3f(0, 0, 1f);
 			gl2.glVertex3f(1.0f, 1.0f, 1.0f); // Top Right Of The Quad (Front)
 			gl2.glVertex3f(-1.0f, 1.0f, 1.0f); // Top Left Of The Quad (Front)
 			gl2.glVertex3f(-1.0f, -1.0f, 1.0f); // Bottom Left Of The Quad
 			gl2.glVertex3f(1.0f, -1.0f, 1.0f); // Bottom Right Of The Quad
 		} else {
+			gl2.glNormal3f(0, 0, -1f);
 			gl2.glVertex3f(1.0f, -1.0f, -1.0f); // Bottom Left Of The Quad
 			gl2.glVertex3f(-1.0f, -1.0f, -1.0f); // Bottom Right Of The Quad
 			gl2.glVertex3f(-1.0f, 1.0f, -1.0f); // Top Right Of The Quad (Back)

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -44,6 +44,10 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 	public double phi;
 	public double theta;
 
+	public double centerx;
+	public double centery;
+	public double centerz;
+
 	/** Distance of viewer */
 	public double distanceFactor;
 
@@ -111,12 +115,12 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 				1, // distance to near clipping plane
 				2.5 * size); // distance to far clipping plane
 		glu.gluLookAt(
-				sizex / 2 + distance * Math.cos(phi) * Math.sin(theta), // where we stand
-				sizey / 2 + distance * Math.sin(phi) * Math.sin(theta),
-				sizez / 2 + distance * Math.cos(theta),
-				sizex / 2, // where we are viewing at
-				sizey / 2,
-				sizez / 2,
+				centerx + sizex / 2 + distance * Math.cos(phi) * Math.sin(theta), // where we stand
+				centery + sizey / 2 + distance * Math.sin(phi) * Math.sin(theta),
+				centerz + sizez / 2 + distance * Math.cos(theta),
+				centerx + sizex / 2, // where we are viewing at
+				centery + sizey / 2,
+				centerz + sizez / 2,
 				0, 0, 1); // "up" direction
 
 		// Lattice spacing and coupling constant
@@ -209,10 +213,26 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 			double deltaX = e.getX() - mouseOldX;
 			double deltaY = e.getY() - mouseOldY;
 			if (e.isControlDown()) {
+				// Change distance (Ctrl key)
 				double factor = 0.01;
 				distanceFactor -= factor * deltaY;
+			} else if (e.isShiftDown()) {
+				// Translate scene (Shift key)
+				double factor = 0.1;
+				double shiftphi = factor * deltaX;
+				double shifttheta = factor * deltaY;
+				double vectorphix = shiftphi * Math.sin(phi);
+				double vectorphiy = -shiftphi * Math.cos(phi);
+				double vectorphiz = 0;
+				double vectorthetax = -shifttheta * Math.cos(phi) * Math.cos(theta);
+				double vectorthetay = -shifttheta * Math.sin(phi) * Math.cos(theta);
+				double vectorthetaz = shifttheta * Math.sin(theta);
+				centerx += vectorphix + vectorthetax;
+				centery += vectorphiy + vectorthetay;
+				centerz += vectorphiz + vectorthetaz;
 			} else {
-				// No modifiers used
+				// No modifiers used:
+				// Rotate scene
 				double factor = 0.01;
 				phi -= factor * deltaX;
 				theta -= factor * deltaY;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -74,6 +74,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 	public DoubleProperties visibilityThresholdProperties;
 	public DoubleProperties opacityProperties;
 	public BooleanProperties showSimulationBoxProperties;
+	public BooleanProperties whiteBackgroundProperties;
 
 	public double phi;
 	public double theta;
@@ -96,6 +97,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		visibilityThresholdProperties = new DoubleProperties(simulationAnimation, "Visibility threshold", 0.0);
 		opacityProperties = new DoubleProperties(simulationAnimation, "Opacity", 1);
 		showSimulationBoxProperties = new BooleanProperties(simulationAnimation, "Show simulation box", false);
+		whiteBackgroundProperties = new BooleanProperties(simulationAnimation, "White background", false);
 
 		MouseListener l = new MouseListener();
 		addMouseListener(l);
@@ -136,6 +138,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		double visibilityThreshold = visibilityThresholdProperties.getValue();
 		double opacity = opacityProperties.getValue();
 		boolean showSimulationBox = showSimulationBoxProperties.getValue();
+		boolean whiteBackground = whiteBackgroundProperties.getValue();
 
 		// Perspective.
 		float sizex = (float) s.getSimulationBoxSize(0);
@@ -144,6 +147,12 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		float size = (float) Math.sqrt(sizex * sizex + sizey * sizey + sizez * sizez);
 		float distance = (float) distanceFactor * size;
 		float widthHeightRatio = (float) width / (float) height;
+
+		if (whiteBackground) {
+			gl2.glClearColor(1, 1, 1, 1);
+		} else {
+			gl2.glClearColor(0, 0, 0, 1);
+		}
 
 		gl2.glMatrixMode( GL2.GL_PROJECTION );
 		gl2.glLoadIdentity();
@@ -641,5 +650,6 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		visibilityThresholdProperties.addComponents(box);
 		opacityProperties.addComponents(box);
 		showSimulationBoxProperties.addComponents(box);
+		whiteBackgroundProperties.addComponents(box);
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -122,7 +122,6 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		int width = glautodrawable.getWidth();
 		int height = glautodrawable.getHeight();
 		gl2.glEnable(GL.GL_DEPTH_TEST);
-		gl2.glClear( GL.GL_COLOR_BUFFER_BIT | GL.GL_DEPTH_BUFFER_BIT );
 		gl2.glLoadIdentity();
 
 		// coordinate system origin at lower left with width and height same as the window
@@ -153,6 +152,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		} else {
 			gl2.glClearColor(0, 0, 0, 1);
 		}
+		gl2.glClear( GL.GL_COLOR_BUFFER_BIT | GL.GL_DEPTH_BUFFER_BIT );
 
 		gl2.glMatrixMode( GL2.GL_PROJECTION );
 		gl2.glLoadIdentity();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -136,7 +136,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		float sizex = (float) s.getSimulationBoxSize(0);
 		float sizey = (float) s.getSimulationBoxSize(1);
 		float sizez = (float) s.getSimulationBoxSize(2);
-		float size = Math.max(Math.max(sizex, sizey), sizez);
+		float size = (float) Math.sqrt(sizex * sizex + sizey * sizey + sizez * sizez);
 		float distance = (float) distanceFactor * size;
 		float widthHeightRatio = (float) width / (float) height;
 
@@ -146,7 +146,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 				45, // field of view angle, in degrees
 				widthHeightRatio, // aspect ratio of field of view
 				1, // distance to near clipping plane
-				2.5 * size); // distance to far clipping plane
+				2.5 * distance); // distance to far clipping plane
 		double viewx = Math.cos(phi) * Math.sin(theta);
 		double viewy = Math.sin(phi) * Math.sin(theta);
 		double viewz = Math.cos(theta);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -56,7 +56,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 			"Energy density transverse electric",
 			"Energy density transverse magnetic",
 			"Gauss violation",
-			"U longitudinal"
+			"U (along direction)"
 	};
 
 	String[] directionLabel = {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -27,6 +27,7 @@ import javax.media.opengl.GLAutoDrawable;
 import javax.media.opengl.glu.GLU;
 import javax.swing.Box;
 
+import org.openpixi.pixi.math.AlgebraElement;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.ui.SimulationAnimation;
 import org.openpixi.pixi.ui.panel.properties.ComboBoxProperties;
@@ -44,13 +45,15 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 	public static final int INDEX_ENERGY_DENSITY_LONGITUDINAL_MAGNETIC = 2;
 	public static final int INDEX_ENERGY_DENSITY_TRANSVERSE_ELECTRIC = 3;
 	public static final int INDEX_ENERGY_DENSITY_TRANSVERSE_MAGNETIC = 4;
+	public static final int INDEX_GAUSS_VIOLATION = 5;
 
 	String[] dataLabel = new String[] {
 			"Energy density",
 			"Energy density longitudinal electric",
 			"Energy density longitudinal magnetic",
 			"Energy density transverse electric",
-			"Energy density transverse magnetic"
+			"Energy density transverse magnetic",
+			"Gauss violation"
 	};
 
 	public static final int RED = 0;
@@ -251,6 +254,8 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 						case INDEX_ENERGY_DENSITY_TRANSVERSE_MAGNETIC:
 							value = getEnergyDensity(s, index, color, 0, false, true, false, true);
 							break;
+						case INDEX_GAUSS_VIOLATION:
+							value = getGaussViolation(s, index, color);
 						}
 					}
 					// Normalize
@@ -340,6 +345,17 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 		color[GREEN] = green;
 		color[BLUE] = blue;
 		return EfieldSquared + BfieldSquared;
+	}
+
+	private double getGaussViolation(Simulation s, int index, double[] color) {
+		AlgebraElement gaussAlg = s.grid.getGaussConstraint(index);
+
+		double value = gaussAlg.square();
+
+		color[RED] = Math.pow(gaussAlg.get(0), 2);
+		color[GREEN] = Math.pow(gaussAlg.get(1), 2);
+		color[BLUE] = Math.pow(gaussAlg.get(2), 2);
+		return value;
 	}
 
 	private int mouseOldX, mouseOldY;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -116,6 +116,10 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 				centerz + sizez / 2,
 				0, 0, 1); // "up" direction
 
+		// Turn on transparent drawing
+		gl2.glEnable(GL.GL_BLEND);
+		gl2.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA);
+
 		// Lattice spacing and coupling constant
 		double as = s.grid.getLatticeSpacing();
 		double g = s.getCouplingConstant();
@@ -144,6 +148,7 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 					float red = 0;
 					float green = 0;
 					float blue = 0;
+					float alpha = 0;
 					if(s.grid.isEvaluatable(index)) {
 						for (int w = 0; w < s.getNumberOfDimensions(); w++) {
 							EfieldSquared += s.grid.getEsquaredFromLinks(index, w) / (as * g * as * g) / 2;
@@ -173,15 +178,16 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 					double norm = Math.max(red + green + blue, 10E-20);
 					float value = (float) Math.min(1, scale * (EfieldSquared + BfieldSquared));
 
-					// Set color according to E-field, and brightness according
+					// Set color according to E-field, and transparency according
 					// to total energy density:
-					red = (float) Math.sqrt(red / norm) * value;
-					green = (float) Math.sqrt(green / norm) * value;
-					blue = (float) Math.sqrt(blue / norm) * value;
+					red = (float) Math.sqrt(red / norm);
+					green = (float) Math.sqrt(green / norm);
+					blue = (float) Math.sqrt(blue / norm);
+					alpha = value;
 
 					scaleProperties.putValue(EfieldSquared + BfieldSquared);
 
-					gl2.glColor3f( red, green, blue);
+					gl2.glColor4f( red, green, blue, alpha);
 					if (value >= visibilityThreshold) {
 						drawCube(gl2, x, y, z, (float) as * .5f);
 					}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -208,9 +208,15 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 			//System.out.println("D "+e.getX() + " : " + e.getY());
 			double deltaX = e.getX() - mouseOldX;
 			double deltaY = e.getY() - mouseOldY;
-			double factor = 0.01;
-			phi -= factor * deltaX;
-			theta -= factor * deltaY;
+			if (e.isControlDown()) {
+				double factor = 0.01;
+				distanceFactor -= factor * deltaY;
+			} else {
+				// No modifiers used
+				double factor = 0.01;
+				phi -= factor * deltaX;
+				theta -= factor * deltaY;
+			}
 			mouseOldX = e.getX();
 			mouseOldY = e.getY();
 			super.mouseDragged(e);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/EnergyDensityVoxelGLPanel.java
@@ -206,6 +206,10 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 			pos[w] = s.grid.getNumCells(w)/2;
 		}
 
+		gl2.glColor3f( .5f, .5f, .5f);
+		drawCubeWireframe(gl2, -(float) as * 0.5f, -(float) as * 0.5f, -(float) as * 0.5f,
+				sizex, sizey, sizez);
+
 		// Determine order of drawing which is important for transparent drawing
 		int loop1 = 0; // outermost loop
 		int loop2 = 1;
@@ -329,6 +333,78 @@ public class EnergyDensityVoxelGLPanel extends AnimationGLPanel {
 			}
 		}
 		scaleProperties.calculateAutomaticScale(1.0);
+	}
+
+	private void drawCubeWireframe(GL2 gl2, float x, float y, float z, float sizex, float sizey, float sizez) {
+		gl2.glPushMatrix();
+		gl2.glTranslatef(x, y, z);
+
+		gl2.glBegin(GL2.GL_QUADS);
+
+		double thickness = .1;
+
+		gl2.glVertex3d(0, 0, 0);
+		gl2.glVertex3d(sizex, 0, 0);
+		gl2.glVertex3d(sizex, 0, thickness);
+		gl2.glVertex3d(0, 0, thickness);
+
+		gl2.glVertex3d(0, 0, 0);
+		gl2.glVertex3d(0, sizey, 0);
+		gl2.glVertex3d(0, sizey, thickness);
+		gl2.glVertex3d(0, 0, thickness);
+
+		gl2.glVertex3d(0, sizey, 0);
+		gl2.glVertex3d(sizex, sizey, 0);
+		gl2.glVertex3d(sizex, sizey, thickness);
+		gl2.glVertex3d(0, sizey, thickness);
+
+		gl2.glVertex3d(sizex, 0, 0);
+		gl2.glVertex3d(sizex, sizey, 0);
+		gl2.glVertex3d(sizex, sizey, thickness);
+		gl2.glVertex3d(sizex, 0, thickness);
+
+		gl2.glVertex3d(0, 0, 0);
+		gl2.glVertex3d(0, 0, sizez);
+		gl2.glVertex3d(0, thickness, sizez);
+		gl2.glVertex3d(0, thickness, 0);
+
+		gl2.glVertex3d(sizex, 0, 0);
+		gl2.glVertex3d(sizex, 0, sizez);
+		gl2.glVertex3d(sizex, thickness, sizez);
+		gl2.glVertex3d(sizex, thickness, 0);
+
+		gl2.glVertex3d(0, sizey, 0);
+		gl2.glVertex3d(0, sizey, sizez);
+		gl2.glVertex3d(0, sizey + thickness, sizez);
+		gl2.glVertex3d(0, sizey + thickness, 0);
+
+		gl2.glVertex3d(sizex, sizey, 0);
+		gl2.glVertex3d(sizex, sizey, sizez);
+		gl2.glVertex3d(sizex, sizey + thickness, sizez);
+		gl2.glVertex3d(sizex, sizey + thickness, 0);
+
+		gl2.glVertex3d(0, 0, sizez);
+		gl2.glVertex3d(sizex, 0, sizez);
+		gl2.glVertex3d(sizex, 0, sizez + thickness);
+		gl2.glVertex3d(0, 0, sizez + thickness);
+
+		gl2.glVertex3d(0, 0, sizez);
+		gl2.glVertex3d(0, sizey, sizez);
+		gl2.glVertex3d(0, sizey, sizez + thickness);
+		gl2.glVertex3d(0, 0, sizez + thickness);
+
+		gl2.glVertex3d(0, sizey, sizez);
+		gl2.glVertex3d(sizex, sizey, sizez);
+		gl2.glVertex3d(sizex, sizey, sizez + thickness);
+		gl2.glVertex3d(0, sizey, sizez + thickness);
+
+		gl2.glVertex3d(sizex, 0, sizez);
+		gl2.glVertex3d(sizex, sizey, sizez);
+		gl2.glVertex3d(sizex, sizey, sizez + thickness);
+		gl2.glVertex3d(sizex, 0, sizez + thickness);
+
+		gl2.glEnd();
+		gl2.glPopMatrix();
 	}
 
 	/**

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/DoubleProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/DoubleProperties.java
@@ -1,0 +1,67 @@
+package org.openpixi.pixi.ui.panel.properties;
+
+import javax.swing.*;
+
+import org.openpixi.pixi.ui.SimulationAnimation;
+
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/**
+ * A generic text field for setting integer values.
+ */
+public class DoubleProperties {
+
+	private SimulationAnimation simulationAnimation;
+	private double value;
+	private String name;
+
+	private JLabel label;
+	private JTextField textField;
+
+	public DoubleProperties(SimulationAnimation simulationAnimation, String name, double initialValue)
+	{
+		this.simulationAnimation = simulationAnimation;
+		this.name = name;
+		textField = new JTextField();
+		this.setValue(initialValue);
+	}
+
+	public void addComponents(Box box)
+	{
+		Box settingControls = Box.createVerticalBox();
+
+		label = new JLabel(name, SwingConstants.CENTER);
+
+		textField.setText(Double.toString(value));
+		textField.addActionListener(new TextFieldListener());
+		textField.setMaximumSize(
+				new Dimension(400/*Integer.MAX_VALUE*/, textField.getPreferredSize().height));
+
+
+		settingControls.add(label);
+		settingControls.add(textField);
+		settingControls.add(Box.createVerticalGlue());
+
+		box.add(settingControls);
+	}
+
+	public double getValue()
+	{
+		return value;
+	}
+
+	public void setValue(double value)
+	{
+		this.value = value;
+		textField.setText(Double.toString(value));
+	}
+
+	class TextFieldListener implements ActionListener {
+		public void actionPerformed(ActionEvent event) {
+			value = Double.parseDouble(textField.getText());
+			simulationAnimation.repaint();
+		}
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlPanels.java
@@ -16,6 +16,7 @@ import org.openpixi.pixi.ui.panel.EnergyDensity2DPanel;
 import org.openpixi.pixi.ui.panel.chart.Chart2DPanel;
 import org.openpixi.pixi.ui.panel.gl.EnergyDensity2DGLPanel;
 import org.openpixi.pixi.ui.panel.gl.EnergyDensity3DGLPanel;
+import org.openpixi.pixi.ui.panel.gl.EnergyDensityVoxelGLPanel;
 import org.openpixi.pixi.ui.panel.gl.GaussViolation2DGLPanel;
 import org.openpixi.pixi.ui.panel.gl.OccupationNumbers2DGLPanel;
 import org.openpixi.pixi.ui.util.yaml.panels.*;
@@ -37,6 +38,7 @@ public class YamlPanels {
 	public YamlEnergyDensity2DPanel energyDensity2DPanel;
 	public YamlEnergyDensity2DGLPanel energyDensity2DGLPanel;
 	public YamlEnergyDensity3DGLPanel energyDensity3DGLPanel;
+	public YamlEnergyDensityVoxelGLPanel energyDensityVoxelGLPanel;
 	public YamlOccupationNumbers2DGLPanel occupationNumbers2DGLPanel;
 	public YamlGaussViolation2DGLPanel gaussViolation2DGLPanel;
 	public YamlChart2DPanel chartPanel;
@@ -89,6 +91,8 @@ public class YamlPanels {
 			energyDensity2DGLPanel = new YamlEnergyDensity2DGLPanel(component);
 		} else if (component instanceof EnergyDensity3DGLPanel) {
 			energyDensity3DGLPanel = new YamlEnergyDensity3DGLPanel(component);
+		} else if (component instanceof EnergyDensityVoxelGLPanel) {
+			energyDensityVoxelGLPanel = new YamlEnergyDensityVoxelGLPanel(component);
 		} else if (component instanceof OccupationNumbers2DGLPanel) {
 			occupationNumbers2DGLPanel = new YamlOccupationNumbers2DGLPanel(component);
 		} else if (component instanceof Chart2DPanel) {
@@ -129,6 +133,8 @@ public class YamlPanels {
 			component = energyDensity2DGLPanel.inflate(panelManager);
 		} else if (energyDensity3DGLPanel != null) {
 			component = energyDensity3DGLPanel.inflate(panelManager);
+		} else if (energyDensityVoxelGLPanel != null) {
+			component = energyDensityVoxelGLPanel.inflate(panelManager);
 		} else if (occupationNumbers2DGLPanel != null) {
 			component = occupationNumbers2DGLPanel.inflate(panelManager);
 		} else if (chartPanel != null) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
@@ -21,6 +21,7 @@ public class YamlEnergyDensityVoxelGLPanel {
 
 	// Boolean properties
 	public Boolean showSimulationBox;
+	public Boolean whiteBackground;
 
 	// Projection properties
 	public Double phi;
@@ -46,6 +47,7 @@ public class YamlEnergyDensityVoxelGLPanel {
 			visibilityThreshold = panel.visibilityThresholdProperties.getValue();
 			opacity = panel.opacityProperties.getValue();
 			showSimulationBox = panel.showSimulationBoxProperties.getValue();
+			whiteBackground = panel.whiteBackgroundProperties.getValue();
 			phi = panel.phi;
 			theta = panel.theta;
 			centerx = panel.centerx;
@@ -85,6 +87,10 @@ public class YamlEnergyDensityVoxelGLPanel {
 
 		if (showSimulationBox != null) {
 			panel.showSimulationBoxProperties.setValue(showSimulationBox);
+		}
+
+		if (whiteBackground != null) {
+			panel.whiteBackgroundProperties.setValue(whiteBackground);
 		}
 
 		if (phi != null) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
@@ -9,6 +9,7 @@ public class YamlEnergyDensityVoxelGLPanel {
 
 	// ComboBox properties
 	public String data;
+	public String direction;
 
 	// Scale properties
 	public Double scaleFactor;
@@ -36,6 +37,7 @@ public class YamlEnergyDensityVoxelGLPanel {
 		if (component instanceof EnergyDensityVoxelGLPanel) {
 			EnergyDensityVoxelGLPanel panel = (EnergyDensityVoxelGLPanel) component;
 			data = panel.dataProperties.getStringFromEntry();
+			direction = panel.directionProperties.getStringFromEntry();
 			scaleFactor = panel.scaleProperties.getScaleFactor();
 			automaticScaling = panel.scaleProperties.getAutomaticScaling();
 			visibilityThreshold = panel.visibilityThresholdProperties.getValue();
@@ -55,6 +57,10 @@ public class YamlEnergyDensityVoxelGLPanel {
 
 		if (data != null) {
 			panel.dataProperties.setEntryFromString(data);
+		}
+
+		if (direction != null) {
+			panel.directionProperties.setEntryFromString(direction);
 		}
 
 		if (scaleFactor != null) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
@@ -19,6 +19,9 @@ public class YamlEnergyDensityVoxelGLPanel {
 	public Double visibilityThreshold;
 	public Double opacity;
 
+	// Boolean properties
+	public Boolean showSimulationBox;
+
 	// Projection properties
 	public Double phi;
 	public Double theta;
@@ -42,6 +45,7 @@ public class YamlEnergyDensityVoxelGLPanel {
 			automaticScaling = panel.scaleProperties.getAutomaticScaling();
 			visibilityThreshold = panel.visibilityThresholdProperties.getValue();
 			opacity = panel.opacityProperties.getValue();
+			showSimulationBox = panel.showSimulationBoxProperties.getValue();
 			phi = panel.phi;
 			theta = panel.theta;
 			centerx = panel.centerx;
@@ -77,6 +81,10 @@ public class YamlEnergyDensityVoxelGLPanel {
 
 		if (opacity != null) {
 			panel.opacityProperties.setValue(opacity);
+		}
+
+		if (showSimulationBox != null) {
+			panel.showSimulationBoxProperties.setValue(showSimulationBox);
 		}
 
 		if (phi != null) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
@@ -11,15 +11,18 @@ public class YamlEnergyDensityVoxelGLPanel {
 	public Double scaleFactor;
 	public Boolean automaticScaling;
 
+	// Visibility threshold property
+	public Double visibilityThreshold;
+
 	// Projection properties
 	public Double phi;
 	public Double theta;
+	public Double centerx;
+	public Double centery;
+	public Double centerz;
 
 	/** Distance of viewer */
 	public Double distanceFactor;
-
-	/** Maximum height of values */
-	public Double heightFactor;
 
 	/** Empty constructor called by SnakeYaml */
 	public YamlEnergyDensityVoxelGLPanel() {
@@ -30,10 +33,13 @@ public class YamlEnergyDensityVoxelGLPanel {
 			EnergyDensityVoxelGLPanel panel = (EnergyDensityVoxelGLPanel) component;
 			scaleFactor = panel.scaleProperties.getScaleFactor();
 			automaticScaling = panel.scaleProperties.getAutomaticScaling();
+			visibilityThreshold = panel.visibilityThresholdProperties.getValue();
 			phi = panel.phi;
 			theta = panel.theta;
+			centerx = panel.centerx;
+			centery = panel.centery;
+			centerz = panel.centerz;
 			distanceFactor = panel.distanceFactor;
-			heightFactor = panel.heightFactor;
 		}
 	}
 
@@ -49,6 +55,10 @@ public class YamlEnergyDensityVoxelGLPanel {
 			panel.scaleProperties.setAutomaticScaling(automaticScaling);
 		}
 
+		if (visibilityThreshold != null) {
+			panel.visibilityThresholdProperties.setValue(visibilityThreshold);
+		}
+
 		if (phi != null) {
 			panel.phi = phi;
 		}
@@ -57,12 +67,20 @@ public class YamlEnergyDensityVoxelGLPanel {
 			panel.theta = theta;
 		}
 
-		if (distanceFactor != null) {
-			panel.distanceFactor = distanceFactor;
+		if (centerx != null) {
+			panel.centerx = centerx;
 		}
 
-		if (heightFactor != null) {
-			panel.heightFactor = heightFactor;
+		if (centery != null) {
+			panel.centery = centery;
+		}
+
+		if (centerz != null) {
+			panel.centerz = centerz;
+		}
+
+		if (distanceFactor != null) {
+			panel.distanceFactor = distanceFactor;
 		}
 
 		return panel;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
@@ -7,6 +7,9 @@ import org.openpixi.pixi.ui.panel.gl.EnergyDensityVoxelGLPanel;
 
 public class YamlEnergyDensityVoxelGLPanel {
 
+	// ComboBox properties
+	public String data;
+
 	// Scale properties
 	public Double scaleFactor;
 	public Boolean automaticScaling;
@@ -32,6 +35,7 @@ public class YamlEnergyDensityVoxelGLPanel {
 	public YamlEnergyDensityVoxelGLPanel(Component component) {
 		if (component instanceof EnergyDensityVoxelGLPanel) {
 			EnergyDensityVoxelGLPanel panel = (EnergyDensityVoxelGLPanel) component;
+			data = panel.dataProperties.getStringFromEntry();
 			scaleFactor = panel.scaleProperties.getScaleFactor();
 			automaticScaling = panel.scaleProperties.getAutomaticScaling();
 			visibilityThreshold = panel.visibilityThresholdProperties.getValue();
@@ -48,6 +52,10 @@ public class YamlEnergyDensityVoxelGLPanel {
 	public Component inflate(PanelManager panelManager) {
 
 		EnergyDensityVoxelGLPanel panel = new EnergyDensityVoxelGLPanel(panelManager.getSimulationAnimation());
+
+		if (data != null) {
+			panel.dataProperties.setEntryFromString(data);
+		}
 
 		if (scaleFactor != null) {
 			panel.scaleProperties.setScaleFactor(scaleFactor);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
@@ -1,0 +1,70 @@
+package org.openpixi.pixi.ui.util.yaml.panels;
+
+import java.awt.Component;
+
+import org.openpixi.pixi.ui.PanelManager;
+import org.openpixi.pixi.ui.panel.gl.EnergyDensityVoxelGLPanel;
+
+public class YamlEnergyDensityVoxelGLPanel {
+
+	// Scale properties
+	public Double scaleFactor;
+	public Boolean automaticScaling;
+
+	// Projection properties
+	public Double phi;
+	public Double theta;
+
+	/** Distance of viewer */
+	public Double distanceFactor;
+
+	/** Maximum height of values */
+	public Double heightFactor;
+
+	/** Empty constructor called by SnakeYaml */
+	public YamlEnergyDensityVoxelGLPanel() {
+	}
+
+	public YamlEnergyDensityVoxelGLPanel(Component component) {
+		if (component instanceof EnergyDensityVoxelGLPanel) {
+			EnergyDensityVoxelGLPanel panel = (EnergyDensityVoxelGLPanel) component;
+			scaleFactor = panel.scaleProperties.getScaleFactor();
+			automaticScaling = panel.scaleProperties.getAutomaticScaling();
+			phi = panel.phi;
+			theta = panel.theta;
+			distanceFactor = panel.distanceFactor;
+			heightFactor = panel.heightFactor;
+		}
+	}
+
+	public Component inflate(PanelManager panelManager) {
+
+		EnergyDensityVoxelGLPanel panel = new EnergyDensityVoxelGLPanel(panelManager.getSimulationAnimation());
+
+		if (scaleFactor != null) {
+			panel.scaleProperties.setScaleFactor(scaleFactor);
+		}
+
+		if (automaticScaling != null) {
+			panel.scaleProperties.setAutomaticScaling(automaticScaling);
+		}
+
+		if (phi != null) {
+			panel.phi = phi;
+		}
+
+		if (theta != null) {
+			panel.theta = theta;
+		}
+
+		if (distanceFactor != null) {
+			panel.distanceFactor = distanceFactor;
+		}
+
+		if (heightFactor != null) {
+			panel.heightFactor = heightFactor;
+		}
+
+		return panel;
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
@@ -11,8 +11,9 @@ public class YamlEnergyDensityVoxelGLPanel {
 	public Double scaleFactor;
 	public Boolean automaticScaling;
 
-	// Visibility threshold property
+	// Double properties
 	public Double visibilityThreshold;
+	public Double opacity;
 
 	// Projection properties
 	public Double phi;
@@ -34,6 +35,7 @@ public class YamlEnergyDensityVoxelGLPanel {
 			scaleFactor = panel.scaleProperties.getScaleFactor();
 			automaticScaling = panel.scaleProperties.getAutomaticScaling();
 			visibilityThreshold = panel.visibilityThresholdProperties.getValue();
+			opacity = panel.opacityProperties.getValue();
 			phi = panel.phi;
 			theta = panel.theta;
 			centerx = panel.centerx;
@@ -57,6 +59,10 @@ public class YamlEnergyDensityVoxelGLPanel {
 
 		if (visibilityThreshold != null) {
 			panel.visibilityThresholdProperties.setValue(visibilityThreshold);
+		}
+
+		if (opacity != null) {
+			panel.opacityProperties.setValue(opacity);
 		}
 
 		if (phi != null) {


### PR DESCRIPTION
A new panel for displaying voxels (= 3D pixels made from small cubes).
- Right-click to select the "Energy Density Voxel (Open GL)" panel.
- To navigate:
  - Drag the mouse to rotate the scene.
  - Press Ctrl-key + mouse button and move up and down to zoom in and out of the scene.
  - Press Shift-key + mouse button to translate the scene.
- Select total energy, electric or magnetic components of longitudinal or transversal contributions, gauss violation, or the value of the U link.
- Use automatic scaling or set a scale manually
- Visibility threshold controls above which threshold voxels are drawn
- Opacity controls an additional overall transparency
- The option "show simulation box" displays a wireframe of the simulation box. In this case, when translating the scene (Shift-key + drag mouse), the corresponding box around the origin is shown for orientation.
- The option "white background" switches to white background
- The panel definition can be written to a YAML file.
- A demo YAML file for creating a movie is provided in "pixi/input/CGC/MV model/MVModel_NGP_movie.yaml"

Technical remarks:
- The scene is always drawn from the back to the front, to allow for proper transparency. Some heuristics is used to traverse the simulation box grid in the right order.
- Only the three visible sides of each cube are drawn.
- OpenGL lighting with two light sources and ambient light is used.
