### PR TITLE
Small fixes to force "US" locale for output and let text editor scroll to top position

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainBatch.java
@@ -28,6 +28,7 @@ import org.openpixi.pixi.ui.util.yaml.YamlParser;
 
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.util.Locale;
 
 public class MainBatch {
 
@@ -53,6 +54,10 @@ public class MainBatch {
 	 * </pre>
 	 */
 	public static void main(String[] args) throws FileNotFoundException, IOException, InterruptedException {
+
+		// Set US locale for numeric output ("1.23"[US] instead of "1,23"[DE])
+		Locale.setDefault(Locale.US);
+
 		//Debug.checkAssertsEnabled();
 		// Checks if the user has specified at least one parameter.
 		// If so creates a parser and uses the parameter as the

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
@@ -22,6 +22,7 @@ import java.awt.*;
 import javax.swing.*;
 
 import java.awt.event.*;
+import java.util.Locale;
 
 import javax.swing.event.*;
 
@@ -125,6 +126,9 @@ public class MainControlApplet extends JApplet
 	 */
 	public MainControlApplet() {
 		Debug.checkAssertsEnabled();
+
+		// Set US locale for numeric output ("1.23"[US] instead of "1,23"[DE])
+		Locale.setDefault(Locale.US);
 
 		simulationAnimation = new SimulationAnimation();
 		panelManager = new PanelManager(this);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
@@ -92,6 +92,7 @@ public class FileTab extends Box {
 				try {
 					String content = FileIO.readFile(file);
 					fileTextArea.setText(content);
+					fileTextArea.setCaretPosition(0); // Jump to top position
 					applyTextAreaSettings();
 					applyTextAreaPanelSettings();
 				} catch (IOException e) {


### PR DESCRIPTION
- Set locale to "US" for numeric output by default.
  - String formatter for numbers is forced to use the US format ("1.23") instead of other formats like DE format ("1,23").
- Let the text editor jump to top position when opening a new YAML file.
  - (The previous behavior was that it jumped to the bottom of the YAML file.)
