### PR TITLE
Optimization with "super particles"

### DIFF
--- a/pixi/input/CGC/MV model/MVModel_new_optimized.yaml
+++ b/pixi/input/CGC/MV model/MVModel_new_optimized.yaml
@@ -1,0 +1,94 @@
+simulationType: temporal optimized cgc ngp
+gridStep: 1
+couplingConstant: 2
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 8
+gridCells: [128, 32, 32]
+timeStep: 0.5
+duration: 64
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+initialConditions:
+  CGC:
+    poissonSolver: improved full
+    computeTadpole: true
+    tadpoleFilename: tadpole_test.dat
+    computeDipole: true
+    dipoleFilename: dipole_test.dat
+    MVModel:
+      - direction: 0
+        orientation: 1
+        longitudinalLocation: 32
+        longitudinalWidth: 2
+        randomSeed: 5
+        mu: .2
+        ultravioletCutoffTransverse: 2
+        longitudinalCoherenceLength: 4
+        infraredCoefficient: 0.2
+      - direction: 0
+        orientation: -1
+        longitudinalLocation: 96
+        longitudinalWidth: 2
+        randomSeed: 6
+        mu: .2
+        ultravioletCutoffTransverse: 2
+        longitudinalCoherenceLength: 4
+        infraredCoefficient: 0.2
+
+
+
+# Generated panel code:
+panels:
+  dividerLocation: 785
+  leftPanel:
+    dividerLocation: 484
+    leftPanel:
+      chartPanel:
+        logarithmicScale: false
+        showCharts:
+        - Gauss law violation
+        - E squared
+        - B squared
+        - Energy density
+    orientation: 0
+    rightPanel:
+      dividerLocation: 386
+      leftPanel:
+        electricFieldPanel:
+          automaticScaling: true
+          colorIndex: 0
+          directionIndex: 0
+          scaleFactor: 2500.0
+          showCoordinates: x, i, 0
+          showFields:
+          - E
+          - B
+          - Gauss
+      orientation: 1
+      rightPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 1
+          scaleFactor: 25.0
+          showCoordinates: x, i, 4
+          showFields:
+          - E
+          - U
+  orientation: 1
+  rightPanel:
+    energyDensity2DGLPanel:
+      automaticScaling: false
+      data: Energy density
+      scaleFactor: 10000.0
+      showCoordinates: x, y, 16
+  windowHeight: 1053
+  windowWidth: 1920

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
@@ -521,11 +521,16 @@ public class Settings {
 				setInterpolator(new CGCParticleInterpolation());
 				break;
 			case TemporalCGCNGP:
-
 				setBoundary(GeneralBoundaryType.Absorbing);
 				setFieldSolver(new FastTYMSolver());
 				setParticleSolver(new CGCParticleSolver());
 				setInterpolator(new CGCParticleInterpolationNGP());
+				break;
+			case TemporalOptimizedCGCNGP:
+				setBoundary(GeneralBoundaryType.Absorbing);
+				setFieldSolver(new FastTYMSolver());
+				setParticleSolver(new CGCSuperParticleSolver());
+				setInterpolator(new CGCSuperParticleInterpolationNGP());
 				break;
 			case LorenzYangMills:
 				setBoundary(GeneralBoundaryType.Periodic);

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Settings.java
@@ -190,6 +190,10 @@ public class Settings {
 		return useGrid;
 	}
 
+	public int getNumOfThreads() {
+		return numOfThreads;
+	}
+
 	public ArrayList<IFieldGenerator> getFieldGenerators() {
 		return this.fieldGenerators;
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
@@ -230,6 +230,7 @@ public class Simulation {
 		} else {
 			turnGridForceOff();
 		}
+		grid.setSimulationSteps(totalSimulationSteps);
 
 		// Regions
 		if(settings.isEvaluationRegionEnabled()) {
@@ -375,6 +376,7 @@ public class Simulation {
 		// 2) Step counter
 		totalSimulationSteps++;
 		totalSimulationTime =  totalSimulationSteps * tstep;
+		grid.setSimulationSteps(totalSimulationSteps);
 
 		// 3) Reassign particle charges, positions and gauge links
 		mover.reassign(particles);

--- a/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/Simulation.java
@@ -80,6 +80,11 @@ public class Simulation {
 	public double totalSimulationTime;
 
 	/**
+	 * Number of threads.
+     */
+	public int numberOfThreads;
+
+	/**
 	 * Contains all Particle2D objects
 	 */
 	public ArrayList<IParticle> particles;
@@ -223,6 +228,8 @@ public class Simulation {
 				settings.getParticleSolver(),
 				particleBoundaryConditions,
 				settings.getParticleIterator());
+
+		numberOfThreads = settings.getNumOfThreads();
 
 		grid = new Grid(settings);
 		if (settings.useGrid()) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/SimulationType.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/SimulationType.java
@@ -5,5 +5,6 @@ public enum SimulationType {
 	LorenzYangMills,
 	TemporalCGC,
 	TemporalCGCNGP,
+	TemporalOptimizedCGCNGP,
 	BoostInvariantCGC
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCSuperParticleInterpolationNGP.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCSuperParticleInterpolationNGP.java
@@ -1,5 +1,7 @@
 package org.openpixi.pixi.physics.grid;
 
+import org.openpixi.pixi.math.AlgebraElement;
+import org.openpixi.pixi.math.GroupElement;
 import org.openpixi.pixi.physics.particles.CGCSuperParticle;
 import org.openpixi.pixi.physics.particles.IParticle;
 
@@ -12,16 +14,31 @@ import org.openpixi.pixi.physics.particles.IParticle;
  */
 public class CGCSuperParticleInterpolationNGP implements  InterpolatorAlgorithm {
 	public void interpolateToGrid(IParticle p, Grid g) {
-		// Not implemented yet.
+		double at = g.getTemporalSpacing();
+		double as = g.getLatticeSpacing();
+
+		CGCSuperParticle P = (CGCSuperParticle) p;
+		if(P.needsUpdate(g.getSimulationSteps())) {
+			int indexOffset = P.getCurrentOffset(g.getSimulationSteps());
+			if(P.orientation > 0) {
+				for (int i = 0; i < P.numberOfParticles; i++) {
+					int index = i + indexOffset;
+					AlgebraElement J = P.Q[i].mult(as / at);
+					g.addJ(index, 0, J); // Optimizations only work for x-direction!
+					GroupElement U = g.getUnext(index, 0);
+					P.Q[i].actAssign(U.adj());
+				}
+			} else {
+				// Other orientation not yet implemented.
+			}
+		}
 	}
 
 	public void interpolateChargedensity(IParticle p, Grid g) {
-		// Not implemented yet.
 		CGCSuperParticle P = (CGCSuperParticle) p;
-		int indexOffset = P.indexOffset;
-		int ngpShift = (P.subLatticeShift < P.particlePerCell/2) ? 0 : P.particlesPerPlane;
+		int indexOffset = P.getCurrentNGPOffset(g.getSimulationSteps());
 		for (int i = 0; i < P.numberOfParticles; i++) {
-			int index = i + indexOffset + ngpShift;
+			int index = i + indexOffset;
 			g.addRho(index, P.Q[i]);
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCSuperParticleInterpolationNGP.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCSuperParticleInterpolationNGP.java
@@ -1,0 +1,27 @@
+package org.openpixi.pixi.physics.grid;
+
+import org.openpixi.pixi.physics.particles.IParticle;
+
+/**
+ * This interpolation algorithm is used for the optimized version of CGC simulations in the lab frame. The particles
+ * in this type of simulation merely act as 'static' sources for the current. It is assumed that this kind of particle
+ * moves along a grid axis such that there is no ambiguity in defining parallel transport for the color charges of the
+ * particles. The super particle classes encapsulate larger collections of particles whose relative positions are fixed
+ * during the simulation and whose charges are updated at the same time when they cross into other cells.
+ */
+public class CGCSuperParticleInterpolationNGP implements  InterpolatorAlgorithm {
+	public void interpolateToGrid(IParticle p, Grid g) {
+		// Not implemented yet.
+	}
+
+	public void interpolateChargedensity(IParticle p, Grid g) {
+		// Not implemented yet.
+	}
+
+	public void interpolateToParticle(IParticle p, Grid g) {
+		/*
+		Usually this method would tell the particles what gauge links are currently acting on them. In the case of
+		the optimized super particle classes, parallel transport is taken care of by interpolateToGrid().
+		 */
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCSuperParticleInterpolationNGP.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCSuperParticleInterpolationNGP.java
@@ -1,5 +1,6 @@
 package org.openpixi.pixi.physics.grid;
 
+import org.openpixi.pixi.physics.particles.CGCSuperParticle;
 import org.openpixi.pixi.physics.particles.IParticle;
 
 /**
@@ -16,6 +17,13 @@ public class CGCSuperParticleInterpolationNGP implements  InterpolatorAlgorithm 
 
 	public void interpolateChargedensity(IParticle p, Grid g) {
 		// Not implemented yet.
+		CGCSuperParticle P = (CGCSuperParticle) p;
+		int indexOffset = P.indexOffset;
+		int ngpShift = (P.subLatticeShift < P.particlePerCell/2) ? 0 : P.particlesPerPlane;
+		for (int i = 0; i < P.numberOfParticles; i++) {
+			int index = i + indexOffset + ngpShift;
+			g.addRho(index, P.Q[i]);
+		}
 	}
 
 	public void interpolateToParticle(IParticle p, Grid g) {

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCSuperParticleInterpolationNGP.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCSuperParticleInterpolationNGP.java
@@ -16,13 +16,14 @@ public class CGCSuperParticleInterpolationNGP implements InterpolatorAlgorithm {
     public void interpolateToGrid(IParticle p, Grid g) {
         double at = g.getTemporalSpacing();
         double as = g.getLatticeSpacing();
+        int totalNumberOfCells = g.getTotalNumberOfCells();
 
         CGCSuperParticle P = (CGCSuperParticle) p;
         if (P.needsUpdate(g.getSimulationSteps())) {
             int indexOffset = P.getCurrentOffset(g.getSimulationSteps());
             if (P.orientation > 0) {
                 for (int i = 0; i < P.numberOfParticles; i++) {
-                    int index = i + indexOffset;
+                    int index = Math.min(Math.max(i + indexOffset, 0), totalNumberOfCells - 1);
                     AlgebraElement J = P.Q[i].mult(as / at);
                     g.addJ(index, 0, J); // Optimizations only work for x-direction!
                     GroupElement U = g.getUnext(index, 0);
@@ -30,7 +31,7 @@ public class CGCSuperParticleInterpolationNGP implements InterpolatorAlgorithm {
                 }
             } else {
                 for (int i = 0; i < P.numberOfParticles; i++) {
-                    int index = Math.max(i + indexOffset, 0);
+                    int index = Math.min(Math.max(i + indexOffset, 0), totalNumberOfCells - 1);
                     GroupElement U = g.getUnext(index, 0);
                     P.Q[i].actAssign(U);
                     AlgebraElement J = P.Q[i].mult(-as / at);
@@ -43,6 +44,7 @@ public class CGCSuperParticleInterpolationNGP implements InterpolatorAlgorithm {
     public void interpolateChargedensity(IParticle p, Grid g) {
         CGCSuperParticle P = (CGCSuperParticle) p;
         int indexOffset = P.getCurrentNGPOffset(g.getSimulationSteps());
+        int totalNumberOfCells = g.getTotalNumberOfCells();
         /*
         Note: the orientation of super particles has no effect on the interpolation of single charges. Traversing the
         charges alternately however decreases interference of the parallel particle iterators and therefore improves
@@ -50,12 +52,12 @@ public class CGCSuperParticleInterpolationNGP implements InterpolatorAlgorithm {
          */
         if (P.orientation > 0) {
             for (int i = 0; i < P.numberOfParticles; i++) {
-                int index = Math.max(i + indexOffset, 0);
+                int index = Math.min(Math.max(i + indexOffset, 0), totalNumberOfCells - 1);
                 g.addRho(index, P.Q[i]);
             }
         } else {
             for (int i = P.numberOfParticles - 1; i >= 0; i--) {
-                int index = Math.max(i + indexOffset, 0);
+                int index = Math.min(Math.max(i + indexOffset, 0), totalNumberOfCells - 1);
                 g.addRho(index, P.Q[i]);
             }
         }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCSuperParticleInterpolationNGP.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCSuperParticleInterpolationNGP.java
@@ -16,14 +16,14 @@ public class CGCSuperParticleInterpolationNGP implements InterpolatorAlgorithm {
 
 	private boolean useOffset = false;
 
-    public void interpolateToGrid(IParticle p, Grid g) {
-        double at = g.getTemporalSpacing();
-        double as = g.getLatticeSpacing();
-        int totalNumberOfCells = g.getTotalNumberOfCells();
+	public void interpolateToGrid(IParticle p, Grid g) {
+		double at = g.getTemporalSpacing();
+		double as = g.getLatticeSpacing();
+		int totalNumberOfCells = g.getTotalNumberOfCells();
 
-        CGCSuperParticle P = (CGCSuperParticle) p;
-        if (P.needsUpdate(g.getSimulationSteps())) {
-            int indexOffset = P.getCurrentOffset(g.getSimulationSteps());
+		CGCSuperParticle P = (CGCSuperParticle) p;
+		if (P.needsUpdate(g.getSimulationSteps())) {
+			int indexOffset = P.getCurrentOffset(g.getSimulationSteps());
 
 	        /*
 	         * Set limits for iterating over particle charges inside the super particle:
@@ -35,59 +35,59 @@ public class CGCSuperParticleInterpolationNGP implements InterpolatorAlgorithm {
 	         * shifts the order in which particle charges are interpolated on the grid. As a result different threads
 	         * do not write to the same cell at the same time, which should improve multithreading performance.
 	         */
-	        int imin = (indexOffset < 0) ? -indexOffset : 0;
-	        int imax = Math.max(Math.min(indexOffset + P.numberOfParticles, totalNumberOfCells) - indexOffset, 0);
-	        int ireg = imax - imin;
-	        int offset = 0;
-	        if(useOffset) {
-		        offset = ireg * P.subLatticeShift / P.particlePerCell;
-	        }
-            if (P.orientation > 0) {
-                for (int i = 0; i < ireg; i++) {
-	                int j = (i + offset) % ireg + imin;
-                    int index = indexOffset + j;
-                    AlgebraElement J = P.Q[j].mult(as / at);
-                    g.addJ(index, 0, J); // Optimizations only work for x-direction!
-                    GroupElement U = g.getUnext(index, 0);
-                    P.Q[j].actAssign(U.adj());
-                }
-            } else {
-                for (int i = 0; i < ireg; i++) {
-	                int j = (i + offset) % ireg + imin;
-                    int index = indexOffset + j;
-                    GroupElement U = g.getUnext(index, 0);
-                    P.Q[j].actAssign(U);
-                    AlgebraElement J = P.Q[j].mult(-as / at);
-                    g.addJ(index, 0, J); // Optimizations only work for x-direction!
-                }
-            }
-        }
-    }
+			int imin = (indexOffset < 0) ? -indexOffset : 0;
+			int imax = Math.max(Math.min(indexOffset + P.numberOfParticles, totalNumberOfCells) - indexOffset, 0);
+			int ireg = imax - imin;
+			int offset = 0;
+			if (useOffset) {
+				offset = ireg * P.subLatticeShift / P.particlePerCell;
+			}
+			if (P.orientation > 0) {
+				for (int i = 0; i < ireg; i++) {
+					int j = (i + offset) % ireg + imin;
+					int index = indexOffset + j;
+					AlgebraElement J = P.Q[j].mult(as / at);
+					g.addJ(index, 0, J); // Optimizations only work for x-direction!
+					GroupElement U = g.getUnext(index, 0);
+					P.Q[j].actAssign(U.adj());
+				}
+			} else {
+				for (int i = 0; i < ireg; i++) {
+					int j = (i + offset) % ireg + imin;
+					int index = indexOffset + j;
+					GroupElement U = g.getUnext(index, 0);
+					P.Q[j].actAssign(U);
+					AlgebraElement J = P.Q[j].mult(-as / at);
+					g.addJ(index, 0, J); // Optimizations only work for x-direction!
+				}
+			}
+		}
+	}
 
-    public void interpolateChargedensity(IParticle p, Grid g) {
-        CGCSuperParticle P = (CGCSuperParticle) p;
-        int indexOffset = P.getCurrentNGPOffset(g.getSimulationSteps());
-        int totalNumberOfCells = g.getTotalNumberOfCells();
+	public void interpolateChargedensity(IParticle p, Grid g) {
+		CGCSuperParticle P = (CGCSuperParticle) p;
+		int indexOffset = P.getCurrentNGPOffset(g.getSimulationSteps());
+		int totalNumberOfCells = g.getTotalNumberOfCells();
 
-	    // Set the limits of the for loop. See comment in interpolateToGrid() for explanation.
-	    int imin = (indexOffset < 0) ? -indexOffset : 0;
-	    int imax = Math.max(Math.min(indexOffset + P.numberOfParticles, totalNumberOfCells) - indexOffset, 0);
-	    int ireg = imax - imin;
-	    int offset = 0;
-	    if(useOffset) {
-		    offset = ireg * P.subLatticeShift / P.particlePerCell;
-	    }
-	    for (int i = 0; i < ireg; i++) {
-		    int j = (i + offset) % ireg + imin;
-		    int index = indexOffset + j;
-            g.addRho(index, P.Q[j]);
-	    }
-    }
+		// Set the limits of the for loop. See comment in interpolateToGrid() for explanation.
+		int imin = (indexOffset < 0) ? -indexOffset : 0;
+		int imax = Math.max(Math.min(indexOffset + P.numberOfParticles, totalNumberOfCells) - indexOffset, 0);
+		int ireg = imax - imin;
+		int offset = 0;
+		if (useOffset) {
+			offset = ireg * P.subLatticeShift / P.particlePerCell;
+		}
+		for (int i = 0; i < ireg; i++) {
+			int j = (i + offset) % ireg + imin;
+			int index = indexOffset + j;
+			g.addRho(index, P.Q[j]);
+		}
+	}
 
-    public void interpolateToParticle(IParticle p, Grid g) {
-        /*
+	public void interpolateToParticle(IParticle p, Grid g) {
+	    /*
 		Usually this method would tell the particles what gauge links are currently acting on them. In the case of
 		the optimized super particle classes, parallel transport is taken care of by interpolateToGrid().
 		 */
-    }
+	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCSuperParticleInterpolationNGP.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/CGCSuperParticleInterpolationNGP.java
@@ -12,43 +12,43 @@ import org.openpixi.pixi.physics.particles.IParticle;
  * particles. The super particle classes encapsulate larger collections of particles whose relative positions are fixed
  * during the simulation and whose charges are updated at the same time when they cross into other cells.
  */
-public class CGCSuperParticleInterpolationNGP implements  InterpolatorAlgorithm {
-	public void interpolateToGrid(IParticle p, Grid g) {
-		double at = g.getTemporalSpacing();
-		double as = g.getLatticeSpacing();
+public class CGCSuperParticleInterpolationNGP implements InterpolatorAlgorithm {
+    public void interpolateToGrid(IParticle p, Grid g) {
+        double at = g.getTemporalSpacing();
+        double as = g.getLatticeSpacing();
 
-		CGCSuperParticle P = (CGCSuperParticle) p;
-		if(P.needsUpdate(g.getSimulationSteps())) {
-			int indexOffset = P.getCurrentOffset(g.getSimulationSteps());
-			if(P.orientation > 0) {
-				for (int i = 0; i < P.numberOfParticles; i++) {
-					int index = i + indexOffset;
-					AlgebraElement J = P.Q[i].mult(as / at);
-					g.addJ(index, 0, J); // Optimizations only work for x-direction!
-					GroupElement U = g.getUnext(index, 0);
-					P.Q[i].actAssign(U.adj());
-				}
-			} else {
-				for (int i = 0; i < P.numberOfParticles; i++) {
-					int index = Math.max(i + indexOffset, 0);
-					GroupElement U = g.getUnext(index, 0);
-					P.Q[i].actAssign(U);
-					AlgebraElement J = P.Q[i].mult(- as / at);
-					g.addJ(index, 0, J); // Optimizations only work for x-direction!
-				}
-			}
-		}
-	}
+        CGCSuperParticle P = (CGCSuperParticle) p;
+        if (P.needsUpdate(g.getSimulationSteps())) {
+            int indexOffset = P.getCurrentOffset(g.getSimulationSteps());
+            if (P.orientation > 0) {
+                for (int i = 0; i < P.numberOfParticles; i++) {
+                    int index = i + indexOffset;
+                    AlgebraElement J = P.Q[i].mult(as / at);
+                    g.addJ(index, 0, J); // Optimizations only work for x-direction!
+                    GroupElement U = g.getUnext(index, 0);
+                    P.Q[i].actAssign(U.adj());
+                }
+            } else {
+                for (int i = 0; i < P.numberOfParticles; i++) {
+                    int index = Math.max(i + indexOffset, 0);
+                    GroupElement U = g.getUnext(index, 0);
+                    P.Q[i].actAssign(U);
+                    AlgebraElement J = P.Q[i].mult(-as / at);
+                    g.addJ(index, 0, J); // Optimizations only work for x-direction!
+                }
+            }
+        }
+    }
 
-	public void interpolateChargedensity(IParticle p, Grid g) {
-		CGCSuperParticle P = (CGCSuperParticle) p;
-		int indexOffset = P.getCurrentNGPOffset(g.getSimulationSteps());
+    public void interpolateChargedensity(IParticle p, Grid g) {
+        CGCSuperParticle P = (CGCSuperParticle) p;
+        int indexOffset = P.getCurrentNGPOffset(g.getSimulationSteps());
         /*
         Note: the orientation of super particles has no effect on the interpolation of single charges. Traversing the
         charges alternately however decreases interference of the parallel particle iterators and therefore improves
         multithreading performance.
          */
-        if(P.orientation > 0) {
+        if (P.orientation > 0) {
             for (int i = 0; i < P.numberOfParticles; i++) {
                 int index = Math.max(i + indexOffset, 0);
                 g.addRho(index, P.Q[i]);
@@ -59,12 +59,12 @@ public class CGCSuperParticleInterpolationNGP implements  InterpolatorAlgorithm 
                 g.addRho(index, P.Q[i]);
             }
         }
-	}
+    }
 
-	public void interpolateToParticle(IParticle p, Grid g) {
-		/*
+    public void interpolateToParticle(IParticle p, Grid g) {
+        /*
 		Usually this method would tell the particles what gauge links are currently acting on them. In the case of
 		the optimized super particle classes, parallel transport is taken care of by interpolateToGrid().
 		 */
-	}
+    }
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -81,6 +81,19 @@ public class Grid {
 	protected ElementFactory factory;
 
 	/**
+	 * Number of passed simulation steps.
+	 */
+	protected int simulationSteps;
+
+	public void setSimulationSteps(int simulationSteps) {
+		this.simulationSteps = simulationSteps;
+	}
+
+	public int getSimulationSteps() {
+		return simulationSteps;
+	}
+
+	/**
 	 * Returns the FieldSolver instance currently used.
 	 * @return  Instance of the FieldSolver
 	 */

--- a/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/CGCInitialCondition.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/CGCInitialCondition.java
@@ -72,11 +72,17 @@ public class CGCInitialCondition implements IInitialCondition {
 		}
 
 		// Spawn particles.
-		if(s.getSimulationType() == SimulationType.TemporalCGCNGP) {
-			initialParticleCreator = new LightConeNGPParticleCreator();
-		} else {
-			System.out.println("CGCInitialCondition: simulation type not supported!");
+		switch (s.getSimulationType()) {
+			case TemporalCGCNGP:
+				initialParticleCreator = new LightConeNGPParticleCreator();
+				break;
+			case TemporalOptimizedCGCNGP:
+				initialParticleCreator = new LightConeNGPSuperParticleCreator();
+				break;
+			default:
+				throw new RuntimeException("CGCInitialCondition: simulation type not supported!");
 		}
+
 		initialParticleCreator.setGaussConstraint(solver.getGaussViolation());
 		initialParticleCreator.initialize(s, direction, orientation);
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
@@ -2,6 +2,7 @@ package org.openpixi.pixi.physics.initial.CGC;
 
 import org.openpixi.pixi.math.AlgebraElement;
 import org.openpixi.pixi.physics.Simulation;
+import org.openpixi.pixi.physics.particles.CGCSuperParticle;
 import org.openpixi.pixi.physics.util.GridFunctions;
 
 import java.util.ArrayList;
@@ -150,6 +151,29 @@ public class LightConeNGPSuperParticleCreator implements IParticleCreator {
 					zEnd = z;
 					break;
 				}
+			}
+		}
+
+		// Spawn super particles.
+		int numberOfParticlesPerSuperParticle = totalTransversalCells * (zEnd - zStart);
+		int indexOffset = zStart * totalTransversalCells;
+		CGCSuperParticle[] superParticles = new CGCSuperParticle[particlesPerLink];
+		for (int j = 0; j < particlesPerCell; j++) {
+			superParticles[j] = new CGCSuperParticle(orientation,
+					numberOfParticlesPerSuperParticle,
+					indexOffset,
+					totalTransversalCells,
+					j,
+					particlesPerCell);
+			s.particles.add(superParticles[j]);
+		}
+		for (int i = 0; i < numberOfParticlesPerSuperParticle; i++) {
+			int index = indexOffset + i;
+			for (int j = 0; j < particlesPerCell; j++) {
+				int ngp = (j < particlesPerCell/2) ? index : s.grid.shift(index, direction, 1);
+				AlgebraElement charge = gaussConstraint[ngp].copy();
+				charge.multAssign(1.0 / particlesPerCell);
+				superParticles[j].Q[i] = charge;
 			}
 		}
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
@@ -156,7 +156,7 @@ public class LightConeNGPSuperParticleCreator implements IParticleCreator {
 		int blockWidth = zEnd - zStart;
 
 		// Spawn super particles.
-        int numberOfSubdivisions = 1;   // still need to make this dependent on number of threads.
+        int numberOfSubdivisions = s.numberOfThreads;   // still need to make this dependent on number of threads.
         int numberOfSuperParticles = numberOfSubdivisions * particlesPerCell;
         int totalNumberOfParticles = totalTransversalCells * blockWidth * particlesPerCell;
         int indexOffset = zStart * totalTransversalCells;

--- a/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
@@ -5,311 +5,309 @@ import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.particles.CGCSuperParticle;
 import org.openpixi.pixi.physics.util.GridFunctions;
 
-import java.util.ArrayList;
-
 /**
  * This particle generator creates particles to correctly interpolate the charge density
  * on the grid according to CGC initial conditions.
  */
 public class LightConeNGPSuperParticleCreator implements IParticleCreator {
 
-    /**
-     * Direction of movement of the charge density. Values range from 0 to numberOfDimensions-1.
-     */
-    protected int direction;
+	/**
+	 * Direction of movement of the charge density. Values range from 0 to numberOfDimensions-1.
+	 */
+	protected int direction;
 
-    /**
-     * Orientation of movement. Values are -1 or 1.
-     */
-    protected int orientation;
+	/**
+	 * Orientation of movement. Values are -1 or 1.
+	 */
+	protected int orientation;
 
-    /**
-     * Longitudinal width of the charge density.
-     */
-    protected double longitudinalWidth;
+	/**
+	 * Longitudinal width of the charge density.
+	 */
+	protected double longitudinalWidth;
 
-    /**
-     * Array containing the size of the transversal grid.
-     */
-    protected int[] transversalNumCells;
+	/**
+	 * Array containing the size of the transversal grid.
+	 */
+	protected int[] transversalNumCells;
 
-    /**
-     * Gauss constraint..
-     */
-    protected AlgebraElement[] gaussConstraint;
+	/**
+	 * Gauss constraint..
+	 */
+	protected AlgebraElement[] gaussConstraint;
 
-    /**
-     * Total number of cells in the transversal grid.
-     */
-    protected int totalTransversalCells;
+	/**
+	 * Total number of cells in the transversal grid.
+	 */
+	protected int totalTransversalCells;
 
-    /**
-     * Lattice spacing of the grid.
-     */
-    protected double as;
+	/**
+	 * Lattice spacing of the grid.
+	 */
+	protected double as;
 
-    /**
-     * Time step used in the simulation.
-     */
-    protected double at;
+	/**
+	 * Time step used in the simulation.
+	 */
+	protected double at;
 
-    /**
-     * Coupling constant used in the simulation.
-     */
-    protected double g;
+	/**
+	 * Coupling constant used in the simulation.
+	 */
+	protected double g;
 
-    /**
-     * Number of particles per cell.
-     */
-    protected int particlesPerCell = 1;
+	/**
+	 * Number of particles per cell.
+	 */
+	protected int particlesPerCell = 1;
 
-    /**
-     * Sets the initial Gauss constraint.
-     *
-     * @param gaussConstraint
-     */
-    public void setGaussConstraint(AlgebraElement[] gaussConstraint) {
-        this.gaussConstraint = gaussConstraint;
-    }
+	/**
+	 * Sets the initial Gauss constraint.
+	 *
+	 * @param gaussConstraint
+	 */
+	public void setGaussConstraint(AlgebraElement[] gaussConstraint) {
+		this.gaussConstraint = gaussConstraint;
+	}
 
-    /**
-     * Initializes the particles.
-     *
-     * @param s
-     */
-    public void initialize(Simulation s, int direction, int orientation) {
-        this.direction = direction;
-        this.orientation = orientation;
+	/**
+	 * Initializes the particles.
+	 *
+	 * @param s
+	 */
+	public void initialize(Simulation s, int direction, int orientation) {
+		this.direction = direction;
+		this.orientation = orientation;
 
-        // Define some variables.
-        particlesPerCell = (int) (s.grid.getLatticeSpacing() / s.getTimeStep());
-        as = s.grid.getLatticeSpacing();
-        at = s.getTimeStep();
-        g = s.getCouplingConstant();
-        transversalNumCells = GridFunctions.reduceGridPos(s.grid.getNumCells(), direction);
-        totalTransversalCells = GridFunctions.getTotalNumberOfCells(transversalNumCells);
+		// Define some variables.
+		particlesPerCell = (int) (s.grid.getLatticeSpacing() / s.getTimeStep());
+		as = s.grid.getLatticeSpacing();
+		at = s.getTimeStep();
+		g = s.getCouplingConstant();
+		transversalNumCells = GridFunctions.reduceGridPos(s.grid.getNumCells(), direction);
+		totalTransversalCells = GridFunctions.getTotalNumberOfCells(transversalNumCells);
 
-        // Interpolate grid charge and current density.
-        initializeParticles(s, particlesPerCell);
-    }
+		// Interpolate grid charge and current density.
+		initializeParticles(s, particlesPerCell);
+	}
 
-    /**
-     * Initializes the particles according to the field initial conditions. The charge density is computed from the
-     * Gauss law violations of the initial fields. The particles are then sampled from this charge density.
-     * Particles in transverse planes which cross NGP boundaries at the same time during the simulation are consolidated
-     * in super particles.
-     *
-     * @param s
-     * @param particlesPerLink
-     */
-    public void initializeParticles(Simulation s, int particlesPerLink) {
-        /*
+	/**
+	 * Initializes the particles according to the field initial conditions. The charge density is computed from the
+	 * Gauss law violations of the initial fields. The particles are then sampled from this charge density.
+	 * Particles in transverse planes which cross NGP boundaries at the same time during the simulation are consolidated
+	 * in super particles.
+	 *
+	 * @param s
+	 * @param particlesPerLink
+	 */
+	public void initializeParticles(Simulation s, int particlesPerLink) {
+	    /*
 		Detect particle 'block': Find region where Gauss constraint is strongly violated (i.e. where charges are to be
 		placed) and ignore the rest. This reduces the total number of particle charges we need to describe the initial
 		condition, because most of space will be empty anyways. Note: this introduces very small violations of the Gauss
 		law at the boundaries of the regions, but these errors are (supposed to be) negligible.
 		 */
 
-	    // Find max charges in transverse planes for each longitudinal coordinate and global charge maximum.
-	    int lnum = s.grid.getNumCells(0);
-	    double[] maxCharges = new double[lnum];
-	    double globalMax = 0.0;
-	    for (int z = 0; z < lnum; z++) {
-		    double max = 0.0;
-		    for (int j = 0; j < totalTransversalCells; j++) {
-			    int index = z * totalTransversalCells + j;
-			    double charge = Math.sqrt(gaussConstraint[index].square());
-			    if(max < charge) {
-				    max = charge;
-			    }
-		    }
-		    maxCharges[z] = max;
-		    if(globalMax < max) {
-			    globalMax = max;
-		    }
-	    }
-	    double cutoffCharge = globalMax * 10E-10;
+		// Find max charges in transverse planes for each longitudinal coordinate and global charge maximum.
+		int lnum = s.grid.getNumCells(0);
+		double[] maxCharges = new double[lnum];
+		double globalMax = 0.0;
+		for (int z = 0; z < lnum; z++) {
+			double max = 0.0;
+			for (int j = 0; j < totalTransversalCells; j++) {
+				int index = z * totalTransversalCells + j;
+				double charge = Math.sqrt(gaussConstraint[index].square());
+				if (max < charge) {
+					max = charge;
+				}
+			}
+			maxCharges[z] = max;
+			if (globalMax < max) {
+				globalMax = max;
+			}
+		}
+		double cutoffCharge = globalMax * 10E-10;
 
-	    // Find start of block starting from the left boundary.
-	    int zStart = 0;
-	    for (int z = 0; z < lnum; z++) {
-		    if(maxCharges[z] > cutoffCharge) {
-			    zStart = z;
-			    break;
-		    }
-	    }
+		// Find start of block starting from the left boundary.
+		int zStart = 0;
+		for (int z = 0; z < lnum; z++) {
+			if (maxCharges[z] > cutoffCharge) {
+				zStart = z;
+				break;
+			}
+		}
 
-	    // Find end of block starting from the right boundary.
-	    int zEnd = lnum - 1;
-	    for (int z = zEnd-1; z >= 0; z--) {
-		    if(maxCharges[z] > cutoffCharge) {
-			    zEnd = z;
-			    break;
-		    }
-	    }
+		// Find end of block starting from the right boundary.
+		int zEnd = lnum - 1;
+		for (int z = zEnd - 1; z >= 0; z--) {
+			if (maxCharges[z] > cutoffCharge) {
+				zEnd = z;
+				break;
+			}
+		}
 
-	    // Set width of particle block.
-	    int blockWidth = zEnd - zStart;
+		// Set width of particle block.
+		int blockWidth = zEnd - zStart;
 
-        // Spawn super particles.
+		// Spawn super particles.
 
-        // Number of subdivisions of the particle block
-        int numberOfSubdivisions = Math.min(s.numberOfThreads, blockWidth);
+		// Number of subdivisions of the particle block
+		int numberOfSubdivisions = Math.min(s.numberOfThreads, blockWidth);
 
-        // Compute efficient partitioning of the block width
-	    int ws = blockWidth / numberOfSubdivisions;         // width of small subdivision
-	    int wl = blockWidth / numberOfSubdivisions + 1;     // width of large subdivision
-	    int ps = ws * totalTransversalCells;                // particle number per small subdivision
-	    int pl = wl * totalTransversalCells;                // particle number oer large subdivision
-	    int ns = numberOfSubdivisions * wl - blockWidth;    // number of small subdivisions
-	    int nl = blockWidth - numberOfSubdivisions * ws;    // number of large subdivisions
+		// Compute efficient partitioning of the block width
+		int ws = blockWidth / numberOfSubdivisions;         // width of small subdivision
+		int wl = blockWidth / numberOfSubdivisions + 1;     // width of large subdivision
+		int ps = ws * totalTransversalCells;                // particle number per small subdivision
+		int pl = wl * totalTransversalCells;                // particle number oer large subdivision
+		int ns = numberOfSubdivisions * wl - blockWidth;    // number of small subdivisions
+		int nl = blockWidth - numberOfSubdivisions * ws;    // number of large subdivisions
 
-        int numberOfSuperParticles = numberOfSubdivisions * particlesPerCell;
-        int indexOffset = zStart * totalTransversalCells;
-        int numberOfLongitudinalParticles = blockWidth * particlesPerCell;
+		int numberOfSuperParticles = numberOfSubdivisions * particlesPerCell;
+		int indexOffset = zStart * totalTransversalCells;
+		int numberOfLongitudinalParticles = blockWidth * particlesPerCell;
 
-        // Create lists for particle refinement.
-        AlgebraElement[][] longitudinalParticleArray = new AlgebraElement[totalTransversalCells][numberOfLongitudinalParticles];
-        for (int i = 0; i < totalTransversalCells; i++) {
-            for (int j = 0; j < numberOfLongitudinalParticles; j++) {
-                longitudinalParticleArray[i][j] = s.grid.getElementFactory().algebraZero();
-            }
-        }
+		// Create lists for particle refinement.
+		AlgebraElement[][] longitudinalParticleArray = new AlgebraElement[totalTransversalCells][numberOfLongitudinalParticles];
+		for (int i = 0; i < totalTransversalCells; i++) {
+			for (int j = 0; j < numberOfLongitudinalParticles; j++) {
+				longitudinalParticleArray[i][j] = s.grid.getElementFactory().algebraZero();
+			}
+		}
 
-        // Spawn super particles.
-        CGCSuperParticle[] superParticles = new CGCSuperParticle[numberOfSuperParticles];
-        for (int j = 0; j < numberOfSubdivisions; j++) {
-            // Initialize super particles for subdivision of the particle block.
-            for (int k = 0; k < particlesPerCell; k++) {
-                if (j < nl) {
-                    superParticles[particlesPerCell * j + k] = new CGCSuperParticle(orientation,
-                            pl,
-                            indexOffset,
-                            totalTransversalCells,
-                            k,
-                            particlesPerCell);
-                } else {
-                    superParticles[particlesPerCell * j + k] = new CGCSuperParticle(orientation,
-                            ps,
-                            indexOffset,
-                            totalTransversalCells,
-                            k,
-                            particlesPerCell);
-                }
-                s.particles.add(superParticles[particlesPerCell * j + k]);
-            }
+		// Spawn super particles.
+		CGCSuperParticle[] superParticles = new CGCSuperParticle[numberOfSuperParticles];
+		for (int j = 0; j < numberOfSubdivisions; j++) {
+			// Initialize super particles for subdivision of the particle block.
+			for (int k = 0; k < particlesPerCell; k++) {
+				if (j < nl) {
+					superParticles[particlesPerCell * j + k] = new CGCSuperParticle(orientation,
+							pl,
+							indexOffset,
+							totalTransversalCells,
+							k,
+							particlesPerCell);
+				} else {
+					superParticles[particlesPerCell * j + k] = new CGCSuperParticle(orientation,
+							ps,
+							indexOffset,
+							totalTransversalCells,
+							k,
+							particlesPerCell);
+				}
+				s.particles.add(superParticles[particlesPerCell * j + k]);
+			}
 
-            // Set super particle charges for subdivision.
-            int maxParticleNum = (j < nl) ? pl : ps;
-            for (int i = 0; i < maxParticleNum; i++) {
-                int index = indexOffset + i;
-                for (int k = 0; k < particlesPerCell; k++) {
-                    int ngp = (k < particlesPerCell / 2) ? index : s.grid.shift(index, 0, 1);
-                    AlgebraElement charge = gaussConstraint[ngp].copy();
-                    charge.multAssign(1.0 / particlesPerCell);
-                    superParticles[j * particlesPerCell + k].Q[i] = charge;
+			// Set super particle charges for subdivision.
+			int maxParticleNum = (j < nl) ? pl : ps;
+			for (int i = 0; i < maxParticleNum; i++) {
+				int index = indexOffset + i;
+				for (int k = 0; k < particlesPerCell; k++) {
+					int ngp = (k < particlesPerCell / 2) ? index : s.grid.shift(index, 0, 1);
+					AlgebraElement charge = gaussConstraint[ngp].copy();
+					charge.multAssign(1.0 / particlesPerCell);
+					superParticles[j * particlesPerCell + k].Q[i] = charge;
 
-                    int transverseIndex = index % totalTransversalCells;
-                    int shiftedIndex = index - zStart * totalTransversalCells;
-                    int longitudinalIndex = (int) Math.floor(shiftedIndex / totalTransversalCells) * particlesPerCell + k;
-                    longitudinalParticleArray[transverseIndex][longitudinalIndex] = superParticles[j * particlesPerCell + k].Q[i];
-                }
-            }
-            if (j < nl) {
-                indexOffset += pl;
-            } else {
-                indexOffset += ps;
-            }
-        }
+					int transverseIndex = index % totalTransversalCells;
+					int shiftedIndex = index - zStart * totalTransversalCells;
+					int longitudinalIndex = (int) Math.floor(shiftedIndex / totalTransversalCells) * particlesPerCell + k;
+					longitudinalParticleArray[transverseIndex][longitudinalIndex] = superParticles[j * particlesPerCell + k].Q[i];
+				}
+			}
+			if (j < nl) {
+				indexOffset += pl;
+			} else {
+				indexOffset += ps;
+			}
+		}
 
-        // Charge refinement
-        int numberOfIterations = 100;
+		// Charge refinement
+		int numberOfIterations = 100;
 
-        for (int i = 0; i < totalTransversalCells; i++) {
-            AlgebraElement[] particleList = longitudinalParticleArray[i];
-            // 2nd order refinement
-            int jmin = 0;
-            int jmax = particleList.length;
-            for (int iteration = 0; iteration < numberOfIterations; iteration++) {
-                for (int j = jmin; j < jmax; j++) {
-                    refine2(j, particleList, particlesPerCell);
-                }
-            }
+		for (int i = 0; i < totalTransversalCells; i++) {
+			AlgebraElement[] particleList = longitudinalParticleArray[i];
+			// 2nd order refinement
+			int jmin = 0;
+			int jmax = particleList.length;
+			for (int iteration = 0; iteration < numberOfIterations; iteration++) {
+				for (int j = jmin; j < jmax; j++) {
+					refine2(j, particleList, particlesPerCell);
+				}
+			}
 
-            // 4th order refinement
-            for (int iteration = 0; iteration < numberOfIterations; iteration++) {
-                for (int j = jmin; j < jmax; j++) {
-                    refine4(j, particleList, particlesPerCell);
-                }
-            }
-        }
-    }
+			// 4th order refinement
+			for (int iteration = 0; iteration < numberOfIterations; iteration++) {
+				for (int j = jmin; j < jmax; j++) {
+					refine4(j, particleList, particlesPerCell);
+				}
+			}
+		}
+	}
 
-    private void refine2(int i, AlgebraElement[] list, int particlesPerLink) {
-        int jmod = (i + particlesPerCell / 2) % particlesPerLink;
-        int n = list.length;
-        // Refinement can not be applied to the last charge in an NGP cell.
-        if (jmod >= 0 && jmod < particlesPerLink - 1) {
-            int i0 = p(i - 1, n);
-            int i1 = p(i + 0, n);
-            int i2 = p(i + 1, n);
-            int i3 = p(i + 2, n);
+	private void refine2(int i, AlgebraElement[] list, int particlesPerLink) {
+		int jmod = (i + particlesPerCell / 2) % particlesPerLink;
+		int n = list.length;
+		// Refinement can not be applied to the last charge in an NGP cell.
+		if (jmod >= 0 && jmod < particlesPerLink - 1) {
+			int i0 = p(i - 1, n);
+			int i1 = p(i + 0, n);
+			int i2 = p(i + 1, n);
+			int i3 = p(i + 2, n);
 
-            AlgebraElement Q0 = list[i0];
-            AlgebraElement Q1 = list[i1];
-            AlgebraElement Q2 = list[i2];
-            AlgebraElement Q3 = list[i3];
+			AlgebraElement Q0 = list[i0];
+			AlgebraElement Q1 = list[i1];
+			AlgebraElement Q2 = list[i2];
+			AlgebraElement Q3 = list[i3];
 
-            AlgebraElement DQ = Q0.mult(-1);
-            DQ.addAssign(Q1.mult(3));
-            DQ.addAssign(Q2.mult(-3));
-            DQ.addAssign(Q3.mult(1));
-            DQ.multAssign(1.0 / 4.0);
+			AlgebraElement DQ = Q0.mult(-1);
+			DQ.addAssign(Q1.mult(3));
+			DQ.addAssign(Q2.mult(-3));
+			DQ.addAssign(Q3.mult(1));
+			DQ.multAssign(1.0 / 4.0);
 
-            Q1.addAssign(DQ.mult(-1.0));
-            Q2.addAssign(DQ.mult(1.0));
-        }
-    }
+			Q1.addAssign(DQ.mult(-1.0));
+			Q2.addAssign(DQ.mult(1.0));
+		}
+	}
 
 
-    private void refine4(int i, AlgebraElement[] list, int particlesPerLink) {
-        int jmod = (i + particlesPerCell / 2) % particlesPerLink;
-        int n = list.length;
-        // Refinement can not be applied to the last charge in an NGP cell.
-        if (jmod >= 0 && jmod < particlesPerLink - 1) {
-            int i0 = p(i - 2, n);
-            int i1 = p(i - 1, n);
-            int i2 = p(i + 0, n);
-            int i3 = p(i + 1, n);
-            int i4 = p(i + 2, n);
-            int i5 = p(i + 3, n);
+	private void refine4(int i, AlgebraElement[] list, int particlesPerLink) {
+		int jmod = (i + particlesPerCell / 2) % particlesPerLink;
+		int n = list.length;
+		// Refinement can not be applied to the last charge in an NGP cell.
+		if (jmod >= 0 && jmod < particlesPerLink - 1) {
+			int i0 = p(i - 2, n);
+			int i1 = p(i - 1, n);
+			int i2 = p(i + 0, n);
+			int i3 = p(i + 1, n);
+			int i4 = p(i + 2, n);
+			int i5 = p(i + 3, n);
 
-            AlgebraElement Q0 = list[i0];
-            AlgebraElement Q1 = list[i1];
-            AlgebraElement Q2 = list[i2];
-            AlgebraElement Q3 = list[i3];
-            AlgebraElement Q4 = list[i4];
-            AlgebraElement Q5 = list[i5];
+			AlgebraElement Q0 = list[i0];
+			AlgebraElement Q1 = list[i1];
+			AlgebraElement Q2 = list[i2];
+			AlgebraElement Q3 = list[i3];
+			AlgebraElement Q4 = list[i4];
+			AlgebraElement Q5 = list[i5];
 
-            AlgebraElement DQ = Q0.mult(+1);
-            DQ.addAssign(Q1.mult(-5));
-            DQ.addAssign(Q2.mult(+10));
-            DQ.addAssign(Q3.mult(-10));
-            DQ.addAssign(Q4.mult(+5));
-            DQ.addAssign(Q5.mult(-1));
-            DQ.multAssign(1.0 / 12.0);
+			AlgebraElement DQ = Q0.mult(+1);
+			DQ.addAssign(Q1.mult(-5));
+			DQ.addAssign(Q2.mult(+10));
+			DQ.addAssign(Q3.mult(-10));
+			DQ.addAssign(Q4.mult(+5));
+			DQ.addAssign(Q5.mult(-1));
+			DQ.multAssign(1.0 / 12.0);
 
-            Q2.addAssign(DQ.mult(-1.0));
-            Q3.addAssign(DQ.mult(1.0));
-        }
-    }
+			Q2.addAssign(DQ.mult(-1.0));
+			Q3.addAssign(DQ.mult(1.0));
+		}
+	}
 
-    private int p(int i, int n) {
-        return (i % n + n) % n;
-    }
+	private int p(int i, int n) {
+		return (i % n + n) % n;
+	}
 
-    protected AlgebraElement interpolateChargeFromGrid(Simulation s, double[] particlePosition) {
-        int[] ngp = GridFunctions.nearestGridPoint(particlePosition, as);
-        return gaussConstraint[s.grid.getCellIndex(ngp)].copy();
-    }
+	protected AlgebraElement interpolateChargeFromGrid(Simulation s, double[] particlePosition) {
+		int[] ngp = GridFunctions.nearestGridPoint(particlePosition, as);
+		return gaussConstraint[s.grid.getCellIndex(ngp)].copy();
+	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
@@ -13,149 +13,149 @@ import java.util.ArrayList;
  */
 public class LightConeNGPSuperParticleCreator implements IParticleCreator {
 
-	/**
-	 * Direction of movement of the charge density. Values range from 0 to numberOfDimensions-1.
-	 */
-	protected int direction;
+    /**
+     * Direction of movement of the charge density. Values range from 0 to numberOfDimensions-1.
+     */
+    protected int direction;
 
-	/**
-	 * Orientation of movement. Values are -1 or 1.
-	 */
-	protected int orientation;
+    /**
+     * Orientation of movement. Values are -1 or 1.
+     */
+    protected int orientation;
 
-	/**
-	 * Longitudinal width of the charge density.
-	 */
-	protected double longitudinalWidth;
+    /**
+     * Longitudinal width of the charge density.
+     */
+    protected double longitudinalWidth;
 
-	/**
-	 * Array containing the size of the transversal grid.
-	 */
-	protected int[] transversalNumCells;
+    /**
+     * Array containing the size of the transversal grid.
+     */
+    protected int[] transversalNumCells;
 
-	/**
-	 * Gauss constraint..
-	 */
-	protected AlgebraElement[] gaussConstraint;
+    /**
+     * Gauss constraint..
+     */
+    protected AlgebraElement[] gaussConstraint;
 
-	/**
-	 * Total number of cells in the transversal grid.
-	 */
-	protected int totalTransversalCells;
+    /**
+     * Total number of cells in the transversal grid.
+     */
+    protected int totalTransversalCells;
 
-	/**
-	 * Lattice spacing of the grid.
-	 */
-	protected double as;
+    /**
+     * Lattice spacing of the grid.
+     */
+    protected double as;
 
-	/**
-	 * Time step used in the simulation.
-	 */
-	protected double at;
+    /**
+     * Time step used in the simulation.
+     */
+    protected double at;
 
-	/**
-	 * Coupling constant used in the simulation.
-	 */
-	protected double g;
+    /**
+     * Coupling constant used in the simulation.
+     */
+    protected double g;
 
-	/**
-	 * Number of particles per cell.
-	 */
-	protected int particlesPerCell = 1;
+    /**
+     * Number of particles per cell.
+     */
+    protected int particlesPerCell = 1;
 
-	/**
-	 * Sets the initial Gauss constraint.
-	 *
-	 * @param gaussConstraint
-	 */
-	public void setGaussConstraint(AlgebraElement[] gaussConstraint) {
-		this.gaussConstraint = gaussConstraint;
-	}
+    /**
+     * Sets the initial Gauss constraint.
+     *
+     * @param gaussConstraint
+     */
+    public void setGaussConstraint(AlgebraElement[] gaussConstraint) {
+        this.gaussConstraint = gaussConstraint;
+    }
 
-	/**
-	 * Initializes the particles.
-	 *
-	 * @param s
-	 */
-	public void initialize(Simulation s, int direction, int orientation) {
-		this.direction = direction;
-		this.orientation = orientation;
+    /**
+     * Initializes the particles.
+     *
+     * @param s
+     */
+    public void initialize(Simulation s, int direction, int orientation) {
+        this.direction = direction;
+        this.orientation = orientation;
 
-		// Define some variables.
-		particlesPerCell = (int) (s.grid.getLatticeSpacing() / s.getTimeStep());
-		as = s.grid.getLatticeSpacing();
-		at = s.getTimeStep();
-		g = s.getCouplingConstant();
-		transversalNumCells = GridFunctions.reduceGridPos(s.grid.getNumCells(), direction);
-		totalTransversalCells = GridFunctions.getTotalNumberOfCells(transversalNumCells);
+        // Define some variables.
+        particlesPerCell = (int) (s.grid.getLatticeSpacing() / s.getTimeStep());
+        as = s.grid.getLatticeSpacing();
+        at = s.getTimeStep();
+        g = s.getCouplingConstant();
+        transversalNumCells = GridFunctions.reduceGridPos(s.grid.getNumCells(), direction);
+        totalTransversalCells = GridFunctions.getTotalNumberOfCells(transversalNumCells);
 
-		// Interpolate grid charge and current density.
-		initializeParticles(s, particlesPerCell);
-	}
+        // Interpolate grid charge and current density.
+        initializeParticles(s, particlesPerCell);
+    }
 
-	/**
-	 * Initializes the particles according to the field initial conditions. The charge density is computed from the
-	 * Gauss law violations of the initial fields. The particles are then sampled from this charge density.
-	 * Particles in transverse planes which cross NGP boundaries at the same time during the simulation are consolidated
-	 * in super particles.
-	 *
-	 * @param s
-	 * @param particlesPerLink
-	 */
-	public void initializeParticles(Simulation s, int particlesPerLink) {
-		/*
+    /**
+     * Initializes the particles according to the field initial conditions. The charge density is computed from the
+     * Gauss law violations of the initial fields. The particles are then sampled from this charge density.
+     * Particles in transverse planes which cross NGP boundaries at the same time during the simulation are consolidated
+     * in super particles.
+     *
+     * @param s
+     * @param particlesPerLink
+     */
+    public void initializeParticles(Simulation s, int particlesPerLink) {
+        /*
 		Detect particle 'block': Find region where Gauss constraint is strongly violated (i.e. where charges are to be
 		placed) and ignore the rest. This reduces the total number of particle charges we need to describe the initial
 		condition, because most of space will be empty anyways. Note: this introduces very small violations of the Gauss
 		law at the boundaries of the regions, but these errors are (supposed to be) negligible.
 		 */
 
-		// Iterate through grid and find maximum charge in the grid.
-		double maxCharge = 0.0;
-		for (int i = 0; i < s.grid.getTotalNumberOfCells(); i++) {
-			double charge = Math.sqrt(gaussConstraint[i].square());
-			if(maxCharge < charge) {
-				maxCharge = charge;
-			}
-		}
+        // Iterate through grid and find maximum charge in the grid.
+        double maxCharge = 0.0;
+        for (int i = 0; i < s.grid.getTotalNumberOfCells(); i++) {
+            double charge = Math.sqrt(gaussConstraint[i].square());
+            if (maxCharge < charge) {
+                maxCharge = charge;
+            }
+        }
 
-		// Set cutoff charge to small fraction of maximum charge.
-		//double cutoffCharge = 10E-12 * Math.pow( g * as, 1) / (Math.pow(as, 3) * particlesPerLink);
-		double cutoffCharge = maxCharge * 10E-10;
+        // Set cutoff charge to small fraction of maximum charge.
+        //double cutoffCharge = 10E-12 * Math.pow( g * as, 1) / (Math.pow(as, 3) * particlesPerLink);
+        double cutoffCharge = maxCharge * 10E-10;
 
-		// Iterate through longitudinal sheets and find dimensions of the particle block.
-		int zStart = 0;
-		int zEnd =  s.grid.getNumCells(0);
-		boolean foundStartOfBlock = false;
-		int longitudinalCells = s.grid.getNumCells(0);
-		for (int z = 0; z < longitudinalCells; z++) {
-			// Find max charge in transverse plane
-			maxCharge = 0;
-			for (int k = 0; k < totalTransversalCells; k++) {
-				int[] transPos = GridFunctions.getCellPos(k, transversalNumCells);
-				int[] gridPos = GridFunctions.insertGridPos(transPos, 0, z);
-				int i = s.grid.getCellIndex(gridPos);
+        // Iterate through longitudinal sheets and find dimensions of the particle block.
+        int zStart = 0;
+        int zEnd = s.grid.getNumCells(0);
+        boolean foundStartOfBlock = false;
+        int longitudinalCells = s.grid.getNumCells(0);
+        for (int z = 0; z < longitudinalCells; z++) {
+            // Find max charge in transverse plane
+            maxCharge = 0;
+            for (int k = 0; k < totalTransversalCells; k++) {
+                int[] transPos = GridFunctions.getCellPos(k, transversalNumCells);
+                int[] gridPos = GridFunctions.insertGridPos(transPos, 0, z);
+                int i = s.grid.getCellIndex(gridPos);
 
-				double charge = Math.sqrt(gaussConstraint[i].square());
-				if(charge > maxCharge) {
-					maxCharge = charge;
-				}
-			}
-			if(!foundStartOfBlock) {
-				if(maxCharge > cutoffCharge) {
-					zStart = z;
-					foundStartOfBlock = true;
-				}
-			} else {
-				if(maxCharge < cutoffCharge) {
-					zEnd = z;
-					break;
-				}
-			}
-		}
-		int blockWidth = zEnd - zStart;
+                double charge = Math.sqrt(gaussConstraint[i].square());
+                if (charge > maxCharge) {
+                    maxCharge = charge;
+                }
+            }
+            if (!foundStartOfBlock) {
+                if (maxCharge > cutoffCharge) {
+                    zStart = z;
+                    foundStartOfBlock = true;
+                }
+            } else {
+                if (maxCharge < cutoffCharge) {
+                    zEnd = z;
+                    break;
+                }
+            }
+        }
+        int blockWidth = zEnd - zStart;
 
-		// Spawn super particles.
+        // Spawn super particles.
         int numberOfSubdivisions = s.numberOfThreads;   // still need to make this dependent on number of threads.
         int numberOfSuperParticles = numberOfSubdivisions * particlesPerCell;
         int totalNumberOfParticles = totalTransversalCells * blockWidth * particlesPerCell;
@@ -165,7 +165,7 @@ public class LightConeNGPSuperParticleCreator implements IParticleCreator {
         int totalNumberOfCells = s.grid.getTotalNumberOfCells();
 
         int widthForLastSubdivision, particlesInLastSubdivision;
-        if(numberOfSubdivisions > 1) {
+        if (numberOfSubdivisions > 1) {
             widthForLastSubdivision = blockWidth % widthPerSubdivision;
             particlesInLastSubdivision = widthForLastSubdivision * totalTransversalCells;
         } else {
@@ -187,7 +187,7 @@ public class LightConeNGPSuperParticleCreator implements IParticleCreator {
         for (int j = 0; j < numberOfSubdivisions; j++) {
             // Initialize super particles for subdivision of the particle block.
             for (int k = 0; k < particlesPerCell; k++) {
-                if(j < numberOfSubdivisions - 1) {
+                if (j < numberOfSubdivisions - 1) {
                     superParticles[particlesPerCell * j + k] = new CGCSuperParticle(orientation,
                             numberOfParticlesPerSuperParticle,
                             indexOffset,
@@ -210,7 +210,7 @@ public class LightConeNGPSuperParticleCreator implements IParticleCreator {
             for (int i = 0; i < maxParticleNum; i++) {
                 int index = indexOffset + i;
                 for (int k = 0; k < particlesPerCell; k++) {
-                    int ngp = (k < particlesPerCell/2) ? index : s.grid.shift(index, 0, 1);
+                    int ngp = (k < particlesPerCell / 2) ? index : s.grid.shift(index, 0, 1);
                     AlgebraElement charge = gaussConstraint[ngp].copy();
                     charge.multAssign(1.0 / particlesPerCell);
                     superParticles[j * particlesPerCell + k].Q[i] = charge;
@@ -225,96 +225,94 @@ public class LightConeNGPSuperParticleCreator implements IParticleCreator {
             indexOffset += numberOfParticlesPerSuperParticle;
         }
 
-		// Charge refinement
-		int numberOfIterations = 100;
+        // Charge refinement
+        int numberOfIterations = 100;
 
-		for (int i = 0; i < totalTransversalCells; i++) {
-			AlgebraElement[] particleList = longitudinalParticleArray[i];
-			// 2nd order refinement
+        for (int i = 0; i < totalTransversalCells; i++) {
+            AlgebraElement[] particleList = longitudinalParticleArray[i];
+            // 2nd order refinement
             int jmin = 0;
-            int jmax = particleList.length ;
-			for (int iteration = 0; iteration < numberOfIterations; iteration++) {
-				for (int j = jmin; j < jmax; j++) {
-					refine2(j, particleList, particlesPerCell);
-				}
-			}
-
-			// 4th order refinement
-			for (int iteration = 0; iteration < numberOfIterations; iteration++) {
+            int jmax = particleList.length;
+            for (int iteration = 0; iteration < numberOfIterations; iteration++) {
                 for (int j = jmin; j < jmax; j++) {
-					refine4(j, particleList, particlesPerCell);
-				}
-			}
-		}
-	}
+                    refine2(j, particleList, particlesPerCell);
+                }
+            }
 
-	private void refine2(int i, AlgebraElement[] list, int particlesPerLink) {
-		int jmod = (i + particlesPerCell/2) % particlesPerLink;
-		int n = list.length;
-		// Refinement can not be applied to the last charge in an NGP cell.
-		if(jmod >= 0 && jmod < particlesPerLink-1)
-		{
-			int i0 = p(i-1, n);
-			int i1 = p(i+0, n);
-			int i2 = p(i+1, n);
-			int i3 = p(i+2, n);
+            // 4th order refinement
+            for (int iteration = 0; iteration < numberOfIterations; iteration++) {
+                for (int j = jmin; j < jmax; j++) {
+                    refine4(j, particleList, particlesPerCell);
+                }
+            }
+        }
+    }
 
-			AlgebraElement Q0 = list[i0];
-			AlgebraElement Q1 = list[i1];
-			AlgebraElement Q2 = list[i2];
-			AlgebraElement Q3 = list[i3];
-
-			AlgebraElement DQ = Q0.mult(-1);
-			DQ.addAssign(Q1.mult(3));
-			DQ.addAssign(Q2.mult(-3));
-			DQ.addAssign(Q3.mult(1));
-			DQ.multAssign(1.0 / 4.0);
-
-			Q1.addAssign(DQ.mult(-1.0));
-			Q2.addAssign(DQ.mult(1.0));
-		}
-	}
-
-
-	private void refine4(int i, AlgebraElement[] list, int particlesPerLink) {
-		int jmod = (i + particlesPerCell/2) % particlesPerLink;
-		int n = list.length;
-		// Refinement can not be applied to the last charge in an NGP cell.
-		if(jmod >= 0 && jmod < particlesPerLink-1)
-		{
-			int i0 = p(i-2, n);
-			int i1 = p(i-1, n);
-			int i2 = p(i+0, n);
-			int i3 = p(i+1, n);
-			int i4 = p(i+2, n);
-			int i5 = p(i+3, n);
+    private void refine2(int i, AlgebraElement[] list, int particlesPerLink) {
+        int jmod = (i + particlesPerCell / 2) % particlesPerLink;
+        int n = list.length;
+        // Refinement can not be applied to the last charge in an NGP cell.
+        if (jmod >= 0 && jmod < particlesPerLink - 1) {
+            int i0 = p(i - 1, n);
+            int i1 = p(i + 0, n);
+            int i2 = p(i + 1, n);
+            int i3 = p(i + 2, n);
 
             AlgebraElement Q0 = list[i0];
             AlgebraElement Q1 = list[i1];
             AlgebraElement Q2 = list[i2];
             AlgebraElement Q3 = list[i3];
-			AlgebraElement Q4 = list[i4];
-			AlgebraElement Q5 = list[i5];
 
-			AlgebraElement DQ = Q0.mult(+1);
-			DQ.addAssign(Q1.mult(-5));
-			DQ.addAssign(Q2.mult(+10));
-			DQ.addAssign(Q3.mult(-10));
-			DQ.addAssign(Q4.mult(+5));
-			DQ.addAssign(Q5.mult(-1));
-			DQ.multAssign(1.0 / 12.0);
+            AlgebraElement DQ = Q0.mult(-1);
+            DQ.addAssign(Q1.mult(3));
+            DQ.addAssign(Q2.mult(-3));
+            DQ.addAssign(Q3.mult(1));
+            DQ.multAssign(1.0 / 4.0);
 
-			Q2.addAssign(DQ.mult(-1.0));
-			Q3.addAssign(DQ.mult(1.0));
-		}
-	}
+            Q1.addAssign(DQ.mult(-1.0));
+            Q2.addAssign(DQ.mult(1.0));
+        }
+    }
 
-	private int p(int i, int n) {
-		return (i % n + n) % n;
-	}
 
-	protected AlgebraElement interpolateChargeFromGrid(Simulation s, double[] particlePosition) {
-		int[] ngp = GridFunctions.nearestGridPoint(particlePosition, as);
-		return gaussConstraint[s.grid.getCellIndex(ngp)].copy();
-	}
+    private void refine4(int i, AlgebraElement[] list, int particlesPerLink) {
+        int jmod = (i + particlesPerCell / 2) % particlesPerLink;
+        int n = list.length;
+        // Refinement can not be applied to the last charge in an NGP cell.
+        if (jmod >= 0 && jmod < particlesPerLink - 1) {
+            int i0 = p(i - 2, n);
+            int i1 = p(i - 1, n);
+            int i2 = p(i + 0, n);
+            int i3 = p(i + 1, n);
+            int i4 = p(i + 2, n);
+            int i5 = p(i + 3, n);
+
+            AlgebraElement Q0 = list[i0];
+            AlgebraElement Q1 = list[i1];
+            AlgebraElement Q2 = list[i2];
+            AlgebraElement Q3 = list[i3];
+            AlgebraElement Q4 = list[i4];
+            AlgebraElement Q5 = list[i5];
+
+            AlgebraElement DQ = Q0.mult(+1);
+            DQ.addAssign(Q1.mult(-5));
+            DQ.addAssign(Q2.mult(+10));
+            DQ.addAssign(Q3.mult(-10));
+            DQ.addAssign(Q4.mult(+5));
+            DQ.addAssign(Q5.mult(-1));
+            DQ.multAssign(1.0 / 12.0);
+
+            Q2.addAssign(DQ.mult(-1.0));
+            Q3.addAssign(DQ.mult(1.0));
+        }
+    }
+
+    private int p(int i, int n) {
+        return (i % n + n) % n;
+    }
+
+    protected AlgebraElement interpolateChargeFromGrid(Simulation s, double[] particlePosition) {
+        int[] ngp = GridFunctions.nearestGridPoint(particlePosition, as);
+        return gaussConstraint[s.grid.getCellIndex(ngp)].copy();
+    }
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
@@ -121,7 +121,7 @@ public class LightConeNGPSuperParticleCreator implements IParticleCreator {
 
 		// Set cutoff charge to small fraction of maximum charge.
 		//double cutoffCharge = 10E-12 * Math.pow( g * as, 1) / (Math.pow(as, 3) * particlesPerLink);
-		double cutoffCharge = maxCharge * 10E-12;
+		double cutoffCharge = maxCharge * 10E-10;
 
 		// Iterate through longitudinal sheets and find dimensions of the particle block.
 		int zStart = 0;
@@ -156,7 +156,7 @@ public class LightConeNGPSuperParticleCreator implements IParticleCreator {
 		int blockWidth = zEnd - zStart;
 
 		// Spawn super particles.
-        int numberOfSubdivisions = 4;   // still need to make this dependent on number of threads.
+        int numberOfSubdivisions = 1;   // still need to make this dependent on number of threads.
         int numberOfSuperParticles = numberOfSubdivisions * particlesPerCell;
         int totalNumberOfParticles = totalTransversalCells * blockWidth * particlesPerCell;
         int indexOffset = zStart * totalTransversalCells;
@@ -164,8 +164,14 @@ public class LightConeNGPSuperParticleCreator implements IParticleCreator {
         int longitudinalParticlesPerSubdivision = numberOfSubdivisions * widthPerSubdivision * particlesPerCell;
         int totalNumberOfCells = s.grid.getTotalNumberOfCells();
 
-        int widthForLastSubdivision = blockWidth % widthPerSubdivision;
-        int particlesInLastSubdivision = widthForLastSubdivision * totalTransversalCells;
+        int widthForLastSubdivision, particlesInLastSubdivision;
+        if(numberOfSubdivisions > 1) {
+            widthForLastSubdivision = blockWidth % widthPerSubdivision;
+            particlesInLastSubdivision = widthForLastSubdivision * totalTransversalCells;
+        } else {
+            widthForLastSubdivision = blockWidth;
+            particlesInLastSubdivision = blockWidth * totalTransversalCells;
+        }
 
         // Create lists for particle refinement.
         AlgebraElement[][] longitudinalParticleArray = new AlgebraElement[totalTransversalCells][longitudinalParticlesPerSubdivision];

--- a/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
@@ -125,15 +125,15 @@ public class LightConeNGPSuperParticleCreator implements IParticleCreator {
 
 		// Iterate through longitudinal sheets and find dimensions of the particle block.
 		int zStart = 0;
-		int zEnd =  s.grid.getNumCells(direction);
+		int zEnd =  s.grid.getNumCells(0);
 		boolean foundStartOfBlock = false;
-		int longitudinalCells = s.grid.getNumCells(direction);
+		int longitudinalCells = s.grid.getNumCells(0);
 		for (int z = 0; z < longitudinalCells; z++) {
 			// Find max charge in transverse plane
 			maxCharge = 0;
 			for (int k = 0; k < totalTransversalCells; k++) {
 				int[] transPos = GridFunctions.getCellPos(k, transversalNumCells);
-				int[] gridPos = GridFunctions.insertGridPos(transPos, direction, z);
+				int[] gridPos = GridFunctions.insertGridPos(transPos, 0, z);
 				int i = s.grid.getCellIndex(gridPos);
 
 				double charge = Math.sqrt(gaussConstraint[i].square());
@@ -210,7 +210,7 @@ public class LightConeNGPSuperParticleCreator implements IParticleCreator {
             for (int i = 0; i < maxParticleNum; i++) {
                 int index = indexOffset + i;
                 for (int k = 0; k < particlesPerCell; k++) {
-                    int ngp = (k < particlesPerCell/2) ? index : s.grid.shift(index, direction, 1);
+                    int ngp = (k < particlesPerCell/2) ? index : s.grid.shift(index, 0, 1);
                     AlgebraElement charge = gaussConstraint[ngp].copy();
                     charge.multAssign(1.0 / particlesPerCell);
                     superParticles[j * particlesPerCell + k].Q[i] = charge;

--- a/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/LightConeNGPSuperParticleCreator.java
@@ -1,0 +1,199 @@
+package org.openpixi.pixi.physics.initial.CGC;
+
+import org.openpixi.pixi.math.AlgebraElement;
+import org.openpixi.pixi.physics.Simulation;
+import org.openpixi.pixi.physics.util.GridFunctions;
+
+import java.util.ArrayList;
+
+/**
+ * This particle generator creates particles to correctly interpolate the charge density
+ * on the grid according to CGC initial conditions.
+ */
+public class LightConeNGPSuperParticleCreator implements IParticleCreator {
+
+	/**
+	 * Direction of movement of the charge density. Values range from 0 to numberOfDimensions-1.
+	 */
+	protected int direction;
+
+	/**
+	 * Orientation of movement. Values are -1 or 1.
+	 */
+	protected int orientation;
+
+	/**
+	 * Longitudinal width of the charge density.
+	 */
+	protected double longitudinalWidth;
+
+	/**
+	 * Array containing the size of the transversal grid.
+	 */
+	protected int[] transversalNumCells;
+
+	/**
+	 * Gauss constraint..
+	 */
+	protected AlgebraElement[] gaussConstraint;
+
+	/**
+	 * Total number of cells in the transversal grid.
+	 */
+	protected int totalTransversalCells;
+
+	/**
+	 * Lattice spacing of the grid.
+	 */
+	protected double as;
+
+	/**
+	 * Time step used in the simulation.
+	 */
+	protected double at;
+
+	/**
+	 * Coupling constant used in the simulation.
+	 */
+	protected double g;
+
+	/**
+	 * Number of particles per cell.
+	 */
+	protected int particlesPerCell = 1;
+
+	/**
+	 * Sets the initial Gauss constraint.
+	 *
+	 * @param gaussConstraint
+	 */
+	public void setGaussConstraint(AlgebraElement[] gaussConstraint) {
+		this.gaussConstraint = gaussConstraint;
+	}
+
+	/**
+	 * Initializes the particles.
+	 *
+	 * @param s
+	 */
+	public void initialize(Simulation s, int direction, int orientation) {
+		this.direction = direction;
+		this.orientation = orientation;
+
+		// Define some variables.
+		particlesPerCell = (int) (s.grid.getLatticeSpacing() / s.getTimeStep());
+		as = s.grid.getLatticeSpacing();
+		at = s.getTimeStep();
+		g = s.getCouplingConstant();
+		transversalNumCells = GridFunctions.reduceGridPos(s.grid.getNumCells(), direction);
+		totalTransversalCells = GridFunctions.getTotalNumberOfCells(transversalNumCells);
+
+		// Interpolate grid charge and current density.
+		initializeParticles(s, particlesPerCell);
+	}
+
+	/**
+	 * Initializes the particles according to the field initial conditions. The charge density is computed from the
+	 * Gauss law violations of the initial fields. The particles are then sampled from this charge density.
+	 * Particles in transverse planes which cross NGP boundaries at the same time during the simulation are consolidated
+	 * in super particles.
+	 *
+	 * @param s
+	 * @param particlesPerLink
+	 */
+	public void initializeParticles(Simulation s, int particlesPerLink) {
+		ArrayList<ArrayList<AlgebraElement>> longitudinalParticleList = new ArrayList<>(totalTransversalCells);
+		for (int i = 0; i < totalTransversalCells; i++) {
+			longitudinalParticleList.add(new ArrayList<AlgebraElement>());
+		}
+
+		// Charge refinement
+		int numberOfIterations = 100;
+		for (int i = 0; i < totalTransversalCells; i++) {
+			ArrayList<AlgebraElement> particleList = longitudinalParticleList.get(i);
+			// 2nd order refinement
+			for (int iteration = 0; iteration < numberOfIterations; iteration++) {
+				for (int j = 0; j < particleList.size(); j++) {
+					refine2(j, particleList, particlesPerLink);
+				}
+			}
+
+			// 4th order refinement
+			for (int iteration = 0; iteration < numberOfIterations; iteration++) {
+				for (int j = 0; j < particleList.size(); j++) {
+					refine4(j, particleList, particlesPerLink);
+				}
+			}
+		}
+	}
+
+	private void refine2(int i, ArrayList<AlgebraElement> list, int particlesPerLink) {
+		int jmod = i % particlesPerLink;
+		int n = list.size();
+		// Refinement can not be applied to the last charge in an NGP cell.
+		if(jmod >= 0 && jmod < particlesPerLink-1)
+		{
+			int i0 = p(i-1, n);
+			int i1 = p(i+0, n);
+			int i2 = p(i+1, n);
+			int i3 = p(i+2, n);
+
+			AlgebraElement Q0 = list.get(i0);
+			AlgebraElement Q1 = list.get(i1);
+			AlgebraElement Q2 = list.get(i2);
+			AlgebraElement Q3 = list.get(i3);
+
+			AlgebraElement DQ = Q0.mult(-1);
+			DQ.addAssign(Q1.mult(3));
+			DQ.addAssign(Q2.mult(-3));
+			DQ.addAssign(Q3.mult(1));
+			DQ.multAssign(1.0 / 4.0);
+
+			Q1.addAssign(DQ.mult(-1.0));
+			Q2.addAssign(DQ.mult(1.0));
+		}
+	}
+
+
+	private void refine4(int i, ArrayList<AlgebraElement> list, int particlesPerLink) {
+		int jmod = i % particlesPerLink;
+		int n = list.size();
+		// Refinement can not be applied to the last charge in an NGP cell.
+		if(jmod >= 0 && jmod < particlesPerLink-1)
+		{
+			int i0 = p(i-2, n);
+			int i1 = p(i-1, n);
+			int i2 = p(i+0, n);
+			int i3 = p(i+1, n);
+			int i4 = p(i+2, n);
+			int i5 = p(i+3, n);
+
+			AlgebraElement Q0 = list.get(i0);
+			AlgebraElement Q1 = list.get(i1);
+			AlgebraElement Q2 = list.get(i2);
+			AlgebraElement Q3 = list.get(i3);
+			AlgebraElement Q4 = list.get(i4);
+			AlgebraElement Q5 = list.get(i5);
+
+			AlgebraElement DQ = Q0.mult(+1);
+			DQ.addAssign(Q1.mult(-5));
+			DQ.addAssign(Q2.mult(+10));
+			DQ.addAssign(Q3.mult(-10));
+			DQ.addAssign(Q4.mult(+5));
+			DQ.addAssign(Q5.mult(-1));
+			DQ.multAssign(1.0 / 12.0);
+
+			Q2.addAssign(DQ.mult(-1.0));
+			Q3.addAssign(DQ.mult(1.0));
+		}
+	}
+
+	private int p(int i, int n) {
+		return (i % n + n) % n;
+	}
+
+	protected AlgebraElement interpolateChargeFromGrid(Simulation s, double[] particlePosition) {
+		int[] ngp = GridFunctions.nearestGridPoint(particlePosition, as);
+		return gaussConstraint[s.grid.getCellIndex(ngp)].copy();
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/MVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/MVModel.java
@@ -3,6 +3,7 @@ package org.openpixi.pixi.physics.initial.CGC;
 import org.apache.commons.math3.analysis.function.Gaussian;
 import org.openpixi.pixi.math.AlgebraElement;
 import org.openpixi.pixi.physics.Simulation;
+
 import java.util.Random;
 
 public class MVModel implements IInitialChargeDensity {
@@ -69,21 +70,21 @@ public class MVModel implements IInitialChargeDensity {
 	 * regulated in Fourier space with a hard UV cutoff in the transverse and longitudinal directions. The IR modes are
 	 * regulated in the transverse plane with a 'gluon mass' term.
 	 *
-	 * @param direction                         index of the longitudinal direction
-	 * @param orientation                       orientation of movement in the longitudinal direction
-	 * @param location                          longitudinal position
-	 * @param longitudinalWidth                 longitudinal width of the MV model
-	 * @param mu                                MV model parameter
-	 * @param useSeed                           use a fixed seed for random number generation
-	 * @param seed                              seed of the random number generator
-	 * @param ultravioletCutoffTransverse       UV cutoff in transverse plane (in inverse lattice spacings)
-	 * @param longitudinalCoherenceLength       Longitudinal coherence length inside nucleus (in physical units)
-	 * @param infraredCoefficient               IR regulator coefficient in the transverse plane
+	 * @param direction                   index of the longitudinal direction
+	 * @param orientation                 orientation of movement in the longitudinal direction
+	 * @param location                    longitudinal position
+	 * @param longitudinalWidth           longitudinal width of the MV model
+	 * @param mu                          MV model parameter
+	 * @param useSeed                     use a fixed seed for random number generation
+	 * @param seed                        seed of the random number generator
+	 * @param ultravioletCutoffTransverse UV cutoff in transverse plane (in inverse lattice spacings)
+	 * @param longitudinalCoherenceLength Longitudinal coherence length inside nucleus (in physical units)
+	 * @param infraredCoefficient         IR regulator coefficient in the transverse plane
 	 */
 	public MVModel(int direction, int orientation, double location, double longitudinalWidth, double mu,
-				   boolean useSeed, int seed,
-				   double ultravioletCutoffTransverse, double longitudinalCoherenceLength,
-				   double infraredCoefficient){
+	               boolean useSeed, int seed,
+	               double ultravioletCutoffTransverse, double longitudinalCoherenceLength,
+	               double infraredCoefficient) {
 
 		this.direction = direction;
 		this.orientation = orientation;
@@ -108,7 +109,7 @@ public class MVModel implements IInitialChargeDensity {
 		}
 
 		Random rand = new Random();
-		if(useSeed) {
+		if (useSeed) {
 			rand.setSeed(seed);
 		}
 
@@ -117,7 +118,7 @@ public class MVModel implements IInitialChargeDensity {
 
 			// Place random charges on the grid (with longitudinal randomness and profile).
 			Gaussian gauss = new Gaussian(location, longitudinalWidth);
-			double randomColorWidth =  mu * s.getCouplingConstant() / Math.pow(s.grid.getLatticeSpacing(), 1.5);
+			double randomColorWidth = mu * s.getCouplingConstant() / Math.pow(s.grid.getLatticeSpacing(), 1.5);
 			for (int i = 0; i < s.grid.getTotalNumberOfCells(); i++) {
 				int[] pos = s.grid.getCellPos(i);
 				double longPos = pos[direction] * s.grid.getLatticeSpacing();
@@ -135,13 +136,13 @@ public class MVModel implements IInitialChargeDensity {
 			 longitudinal location of the MV model.
 			  */
 			double simulationBoxWidth = s.grid.getNumCells(direction) * s.grid.getLatticeSpacing();
-			double zmin = Math.max(this.location - simulationBoxWidth/2.0, 0.0);
-			double zmax = Math.min(this.location + simulationBoxWidth/2.0, simulationBoxWidth);
+			double zmin = Math.max(this.location - simulationBoxWidth / 2.0, 0.0);
+			double zmax = Math.min(this.location + simulationBoxWidth / 2.0, simulationBoxWidth);
 			int lmin = (int) Math.floor(zmin / s.grid.getLatticeSpacing());
 			int lmax = (int) Math.ceil(zmax / s.grid.getLatticeSpacing());
 			for (int i = 0; i < s.grid.getTotalNumberOfCells(); i++) {
 				int longPos = s.grid.getCellPos(i)[direction];
-				if(lmin < longPos && longPos < lmax && s.grid.isActive(i)) {
+				if (lmin < longPos && longPos < lmax && s.grid.isActive(i)) {
 					this.rho[i].set(j, tempRho[i]);
 				}
 			}
@@ -166,7 +167,7 @@ public class MVModel implements IInitialChargeDensity {
 		return orientation;
 	}
 
-	public String getInfo(){
+	public String getInfo() {
 		/*
 			mu   ... MV model parameter
 			w    ... longitudinal width

--- a/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/MVModelCoherent.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/MVModelCoherent.java
@@ -72,21 +72,21 @@ public class MVModelCoherent implements IInitialChargeDensity {
 	 * longitudinal cutoff should not have any effect. The IR modes are regulated in the transverse plane with a
 	 * 'gluon mass' term.
 	 *
-	 * @param direction                         index of the longitudinal direction
-	 * @param orientation                       orientation of movement in the longitudinal direction
-	 * @param location                          longitudinal position
-	 * @param longitudinalWidth                 longitudinal width of the MV model
-	 * @param mu                                MV model parameter
-	 * @param useSeed                           use a fixed seed for random number generation
-	 * @param seed                              seed of the random number generator
-	 * @param ultravioletCutoffTransverse       UV cutoff in transverse plane (in inverse lattice spacings)
-	 * @param ultravioletCutoffLongitudinal     UV cutoff in the longitudinal direction (in inverse lattice spacings)
-	 * @param infraredCoefficient               IR regulator coefficient in the transverse plane
+	 * @param direction                     index of the longitudinal direction
+	 * @param orientation                   orientation of movement in the longitudinal direction
+	 * @param location                      longitudinal position
+	 * @param longitudinalWidth             longitudinal width of the MV model
+	 * @param mu                            MV model parameter
+	 * @param useSeed                       use a fixed seed for random number generation
+	 * @param seed                          seed of the random number generator
+	 * @param ultravioletCutoffTransverse   UV cutoff in transverse plane (in inverse lattice spacings)
+	 * @param ultravioletCutoffLongitudinal UV cutoff in the longitudinal direction (in inverse lattice spacings)
+	 * @param infraredCoefficient           IR regulator coefficient in the transverse plane
 	 */
 	public MVModelCoherent(int direction, int orientation, double location, double longitudinalWidth, double mu,
-						   boolean useSeed, int seed,
-						   double ultravioletCutoffTransverse, double ultravioletCutoffLongitudinal,
-						   double infraredCoefficient){
+	                       boolean useSeed, int seed,
+	                       double ultravioletCutoffTransverse, double ultravioletCutoffLongitudinal,
+	                       double infraredCoefficient) {
 
 		this.direction = direction;
 		this.orientation = orientation;
@@ -111,7 +111,7 @@ public class MVModelCoherent implements IInitialChargeDensity {
 		}
 
 		Random rand = new Random();
-		if(useSeed) {
+		if (useSeed) {
 			rand.setSeed(seed);
 		}
 
@@ -151,13 +151,13 @@ public class MVModelCoherent implements IInitialChargeDensity {
 			 longitudinal location of the MV model.
 			  */
 			double simulationBoxWidth = s.grid.getNumCells(direction) * s.grid.getLatticeSpacing();
-			double zmin = Math.max(this.location - simulationBoxWidth/2.0, 0.0);
-			double zmax = Math.min(this.location + simulationBoxWidth/2.0, simulationBoxWidth);
+			double zmin = Math.max(this.location - simulationBoxWidth / 2.0, 0.0);
+			double zmax = Math.min(this.location + simulationBoxWidth / 2.0, simulationBoxWidth);
 			int lmin = (int) Math.floor(zmin / s.grid.getLatticeSpacing());
 			int lmax = (int) Math.ceil(zmax / s.grid.getLatticeSpacing());
 			for (int i = 0; i < s.grid.getTotalNumberOfCells(); i++) {
 				int longPos = s.grid.getCellPos(i)[direction];
-				if(lmin < longPos && longPos < lmax && s.grid.isActive(i)) {
+				if (lmin < longPos && longPos < lmax && s.grid.isActive(i)) {
 					this.rho[i].set(j, tempRho[i]);
 				}
 			}
@@ -182,7 +182,7 @@ public class MVModelCoherent implements IInitialChargeDensity {
 		return orientation;
 	}
 
-	public String getInfo(){
+	public String getInfo() {
 		/*
 			mu   ... MV model parameter
 			w    ... longitudinal width

--- a/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/MVModelCoherent.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/MVModelCoherent.java
@@ -146,9 +146,20 @@ public class MVModelCoherent implements IInitialChargeDensity {
 				tempRho[i] *= profile;
 			}
 
-			// Put everything into rho array.
+			/*
+			 Put everything into rho array, but exclude charges that lie outside of a simulation box centered around the
+			 longitudinal location of the MV model.
+			  */
+			double simulationBoxWidth = s.grid.getNumCells(direction) * s.grid.getLatticeSpacing();
+			double zmin = Math.max(this.location - simulationBoxWidth/2.0, 0.0);
+			double zmax = Math.min(this.location + simulationBoxWidth/2.0, simulationBoxWidth);
+			int lmin = (int) Math.floor(zmin / s.grid.getLatticeSpacing());
+			int lmax = (int) Math.ceil(zmax / s.grid.getLatticeSpacing());
 			for (int i = 0; i < s.grid.getTotalNumberOfCells(); i++) {
-				this.rho[i].set(j, tempRho[i]);
+				int longPos = s.grid.getCellPos(i)[direction];
+				if(lmin < longPos && longPos < lmax && s.grid.isActive(i)) {
+					this.rho[i].set(j, tempRho[i]);
+				}
 			}
 		}
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/movement/solver/CGCSuperParticleSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/movement/solver/CGCSuperParticleSolver.java
@@ -1,0 +1,27 @@
+package org.openpixi.pixi.physics.movement.solver;
+
+import org.openpixi.pixi.physics.force.Force;
+import org.openpixi.pixi.physics.particles.IParticle;
+
+/**
+ * Particle solver for the CGCSuperParticle class. Due to optimizations this class doesn't really do anything.
+ */
+public class CGCSuperParticleSolver implements ParticleSolver {
+
+	public void updatePosition(IParticle p, Force f, double dt) {
+		// Nothing to update here. Look into CGCSuperParticleInterpolationNGP.
+	}
+
+
+	public void updateCharge(IParticle p, Force f, double dt) {
+		// Nothing to update here. Look into CGCSuperParticleInterpolationNGP.
+	}
+
+	public void prepare(IParticle p, Force f, double step) {
+		// Not implemented.
+	}
+
+	public void complete(IParticle p, Force f, double step) {
+		// Not implemented.
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/movement/solver/CGCSuperParticleSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/movement/solver/CGCSuperParticleSolver.java
@@ -8,20 +8,20 @@ import org.openpixi.pixi.physics.particles.IParticle;
  */
 public class CGCSuperParticleSolver implements ParticleSolver {
 
-	public void updatePosition(IParticle p, Force f, double dt) {
-		// Nothing to update here. Look into CGCSuperParticleInterpolationNGP.
-	}
+    public void updatePosition(IParticle p, Force f, double dt) {
+        // Nothing to update here. Look into CGCSuperParticleInterpolationNGP.
+    }
 
 
-	public void updateCharge(IParticle p, Force f, double dt) {
-		// Nothing to update here. Look into CGCSuperParticleInterpolationNGP.
-	}
+    public void updateCharge(IParticle p, Force f, double dt) {
+        // Nothing to update here. Look into CGCSuperParticleInterpolationNGP.
+    }
 
-	public void prepare(IParticle p, Force f, double step) {
-		// Not implemented.
-	}
+    public void prepare(IParticle p, Force f, double step) {
+        // Not implemented.
+    }
 
-	public void complete(IParticle p, Force f, double step) {
-		// Not implemented.
-	}
+    public void complete(IParticle p, Force f, double step) {
+        // Not implemented.
+    }
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/movement/solver/CGCSuperParticleSolver.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/movement/solver/CGCSuperParticleSolver.java
@@ -8,20 +8,20 @@ import org.openpixi.pixi.physics.particles.IParticle;
  */
 public class CGCSuperParticleSolver implements ParticleSolver {
 
-    public void updatePosition(IParticle p, Force f, double dt) {
-        // Nothing to update here. Look into CGCSuperParticleInterpolationNGP.
-    }
+	public void updatePosition(IParticle p, Force f, double dt) {
+		// Nothing to update here. Look into CGCSuperParticleInterpolationNGP.
+	}
 
 
-    public void updateCharge(IParticle p, Force f, double dt) {
-        // Nothing to update here. Look into CGCSuperParticleInterpolationNGP.
-    }
+	public void updateCharge(IParticle p, Force f, double dt) {
+		// Nothing to update here. Look into CGCSuperParticleInterpolationNGP.
+	}
 
-    public void prepare(IParticle p, Force f, double step) {
-        // Not implemented.
-    }
+	public void prepare(IParticle p, Force f, double step) {
+		// Not implemented.
+	}
 
-    public void complete(IParticle p, Force f, double step) {
-        // Not implemented.
-    }
+	public void complete(IParticle p, Force f, double step) {
+		// Not implemented.
+	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
@@ -88,7 +88,7 @@ public class CGCSuperParticle implements IParticle{
 	 * @return      true/false if particle needs an update or needs to be interpolated to the grid.
 	 */
 	public boolean needsUpdate(int t) {
-		return 0 == (t + subLatticeShift) % particlePerCell;
+		return 0 == (t + subLatticeShift + particlePerCell/2 + 1) % particlePerCell;
 	}
 
 	// GETTERS

--- a/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
@@ -10,179 +10,179 @@ import java.awt.*;
  */
 public class CGCSuperParticle implements IParticle {
 
-    /**
-     * Array of charges containing all the particle charges associated with this super particle.
-     */
-    public AlgebraElement[] Q;
+	/**
+	 * Array of charges containing all the particle charges associated with this super particle.
+	 */
+	public AlgebraElement[] Q;
 
-    /**
-     * Orientation of the super particle (-1 or +1).
-     */
-    public int orientation;
+	/**
+	 * Orientation of the super particle (-1 or +1).
+	 */
+	public int orientation;
 
-    /**
-     * Total number of particles described by super particle.
-     */
-    public int numberOfParticles;
+	/**
+	 * Total number of particles described by super particle.
+	 */
+	public int numberOfParticles;
 
-    /**
-     * Longitudinal offset from z = 0 in terms of lattice indices.
-     */
-    public int indexOffset;
+	/**
+	 * Longitudinal offset from z = 0 in terms of lattice indices.
+	 */
+	public int indexOffset;
 
-    /**
-     * Number of particles within a transverse plane.
-     */
-    public int particlesPerPlane;
+	/**
+	 * Number of particles within a transverse plane.
+	 */
+	public int particlesPerPlane;
 
-    /**
-     * Offset/shift of the particles within a cell.
-     */
-    public int subLatticeShift;
+	/**
+	 * Offset/shift of the particles within a cell.
+	 */
+	public int subLatticeShift;
 
-    /**
-     * Number of particles per cell. Needed for relative position of super particles.
-     */
-    public int particlePerCell;
+	/**
+	 * Number of particles per cell. Needed for relative position of super particles.
+	 */
+	public int particlePerCell;
 
-    public CGCSuperParticle(int orientation,
-                            int numberOfParticles,
-                            int indexOffset,
-                            int particlesPerPlane,
-                            int subLatticeShift,
-                            int particlePerCell) {
-        this.orientation = orientation;
-        this.numberOfParticles = numberOfParticles;
-        this.indexOffset = indexOffset;
-        this.particlesPerPlane = particlesPerPlane;
-        this.subLatticeShift = subLatticeShift;
-        this.particlePerCell = particlePerCell;
+	public CGCSuperParticle(int orientation,
+	                        int numberOfParticles,
+	                        int indexOffset,
+	                        int particlesPerPlane,
+	                        int subLatticeShift,
+	                        int particlePerCell) {
+		this.orientation = orientation;
+		this.numberOfParticles = numberOfParticles;
+		this.indexOffset = indexOffset;
+		this.particlesPerPlane = particlesPerPlane;
+		this.subLatticeShift = subLatticeShift;
+		this.particlePerCell = particlePerCell;
 
-        this.Q = new AlgebraElement[numberOfParticles];
+		this.Q = new AlgebraElement[numberOfParticles];
 
-    }
+	}
 
-    /**
-     * Returns index offset at simulation time t. Add the particle index to get the cell index.
-     *
-     * @param t current simulation step
-     * @return index offset since beginning of simulation.
-     */
-    public int getCurrentOffset(int t) {
-        if (orientation > 0) {
-            return indexOffset + ((t + subLatticeShift) / particlePerCell) * particlesPerPlane;
-        }
-        int shift = ((int) Math.floor((-t + subLatticeShift) / (1.0 * particlePerCell))) * particlesPerPlane;
-        return indexOffset + shift;
-    }
+	/**
+	 * Returns index offset at simulation time t. Add the particle index to get the cell index.
+	 *
+	 * @param t current simulation step
+	 * @return index offset since beginning of simulation.
+	 */
+	public int getCurrentOffset(int t) {
+		if (orientation > 0) {
+			return indexOffset + ((t + subLatticeShift) / particlePerCell) * particlesPerPlane;
+		}
+		int shift = ((int) Math.floor((-t + subLatticeShift) / (1.0 * particlePerCell))) * particlesPerPlane;
+		return indexOffset + shift;
+	}
 
-    /**
-     * Returns the ngp index offset at simulation time t. Add the particle index to get the current ngp index.
-     *
-     * @param t current simulation step
-     * @return ngp index offset since beginning of simulation.
-     */
-    public int getCurrentNGPOffset(int t) {
-        int currentOffset = getCurrentOffset(t);
-        if (orientation > 0) {
-            return currentOffset + ((((t + subLatticeShift) % particlePerCell) < particlePerCell / 2) ? 0 : particlesPerPlane);
-        }
-        int shift = ((((t - subLatticeShift + particlePerCell + particlePerCell / 2 - 1) % particlePerCell) < particlePerCell / 2) ? 0 : particlesPerPlane);
-        return currentOffset + shift;
-    }
+	/**
+	 * Returns the ngp index offset at simulation time t. Add the particle index to get the current ngp index.
+	 *
+	 * @param t current simulation step
+	 * @return ngp index offset since beginning of simulation.
+	 */
+	public int getCurrentNGPOffset(int t) {
+		int currentOffset = getCurrentOffset(t);
+		if (orientation > 0) {
+			return currentOffset + ((((t + subLatticeShift) % particlePerCell) < particlePerCell / 2) ? 0 : particlesPerPlane);
+		}
+		int shift = ((((t - subLatticeShift + particlePerCell + particlePerCell / 2 - 1) % particlePerCell) < particlePerCell / 2) ? 0 : particlesPerPlane);
+		return currentOffset + shift;
+	}
 
-    /**
-     * Checks if particle will cross an ngp boundary in the *next* simulation step.
-     *
-     * @param t current simulation step
-     * @return true/false if particle needs an update or needs to be interpolated to the grid.
-     */
-    public boolean needsUpdate(int t) {
-        if (orientation > 0) {
-            return 0 == (t + subLatticeShift + particlePerCell / 2 + 1) % particlePerCell;
-        }
-        return 0 == (t - subLatticeShift + particlePerCell / 2) % particlePerCell;
-    }
+	/**
+	 * Checks if particle will cross an ngp boundary in the *next* simulation step.
+	 *
+	 * @param t current simulation step
+	 * @return true/false if particle needs an update or needs to be interpolated to the grid.
+	 */
+	public boolean needsUpdate(int t) {
+		if (orientation > 0) {
+			return 0 == (t + subLatticeShift + particlePerCell / 2 + 1) % particlePerCell;
+		}
+		return 0 == (t - subLatticeShift + particlePerCell / 2) % particlePerCell;
+	}
 
-    // GETTERS
+	// GETTERS
 
-    public double getPosition(int i) {
-        return 0;
-    }
+	public double getPosition(int i) {
+		return 0;
+	}
 
-    public double getPrevPosition(int i) {
-        return 0;
-    }
+	public double getPrevPosition(int i) {
+		return 0;
+	}
 
-    public double getVelocity(int i) {
-        return 0;
-    }
+	public double getVelocity(int i) {
+		return 0;
+	}
 
-    public double[] getPosition() {
-        return new double[]{0};
-    }
+	public double[] getPosition() {
+		return new double[]{0};
+	}
 
-    public double[] getPrevPosition() {
-        return new double[]{0};
-    }
+	public double[] getPrevPosition() {
+		return new double[]{0};
+	}
 
-    public double[] getVelocity() {
-        return new double[]{0};
-    }
+	public double[] getVelocity() {
+		return new double[]{0};
+	}
 
-    public double getRadius() {
-        return 0;
-    }
+	public double getRadius() {
+		return 0;
+	}
 
-    public Color getDisplayColor() {
-        return Color.BLACK;
-    }
+	public Color getDisplayColor() {
+		return Color.BLACK;
+	}
 
-    public int getNumberOfDimensions() {
-        return 0;
-    }
+	public int getNumberOfDimensions() {
+		return 0;
+	}
 
-    // SETTERS
+	// SETTERS
 
-    public void setPosition(int i, double value) {
+	public void setPosition(int i, double value) {
 
-    }
+	}
 
-    public void addPosition(int i, double value) {
+	public void addPosition(int i, double value) {
 
-    }
+	}
 
-    public void setPrevPosition(int i, double value) {
+	public void setPrevPosition(int i, double value) {
 
-    }
+	}
 
-    public void addPrevPosition(int i, double value) {
+	public void addPrevPosition(int i, double value) {
 
-    }
+	}
 
-    public void setVelocity(int i, double value) {
+	public void setVelocity(int i, double value) {
 
-    }
+	}
 
-    public void addVelocity(int i, double value) {
+	public void addVelocity(int i, double value) {
 
-    }
+	}
 
-    public void setNumberOfDimensions(int numberOfDimensions) {
-    }
+	public void setNumberOfDimensions(int numberOfDimensions) {
+	}
 
-    public void setRadius(double r) {
+	public void setRadius(double r) {
 
-    }
+	}
 
-    public void setDisplayColor(Color color) {
+	public void setDisplayColor(Color color) {
 
-    }
+	}
 
-    public void reassignValues() {
-    }
+	public void reassignValues() {
+	}
 
-    public IParticle copy() {
-        throw new RuntimeException("copy() method of CGCSuperParticle not implemented.");
-    }
+	public IParticle copy() {
+		throw new RuntimeException("copy() method of CGCSuperParticle not implemented.");
+	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
@@ -62,10 +62,34 @@ public class CGCSuperParticle implements IParticle{
 
 	}
 
-	public boolean needsUpdate(int t) {
-		return subLatticeShift == (t + subLatticeShift + 1) % particlePerCell;
+	/**
+	 * Returns index offset at simulation time t. Add the particle index to get the cell index.
+	 * @param t     current simulation step
+	 * @return      index offset since beginning of simulation.
+	 */
+	public int getCurrentOffset(int t) {
+		int movementShift = ((t + subLatticeShift) / particlePerCell) * particlesPerPlane;
+		return indexOffset + movementShift;
 	}
 
+	/**
+	 * Returns the ngp index offset at simulation time t. Add the particle index to get the current ngp index.
+	 * @param t     current simulation step
+	 * @return      ngp index offset since beginning of simulation.
+	 */
+	public int getCurrentNGPOffset(int t) {
+		int ngpShift = (((t+subLatticeShift) % particlePerCell) < particlePerCell/2) ? 0 : particlesPerPlane;
+		return getCurrentOffset(t) + ngpShift;
+	}
+
+	/**
+	 * Checks if particle will cross an ngp boundary in the *next* simulation step.
+	 * @param t     current simulation step
+	 * @return      true/false if particle needs an update or needs to be interpolated to the grid.
+	 */
+	public boolean needsUpdate(int t) {
+		return 0 == (t + subLatticeShift) % particlePerCell;
+	}
 
 	// GETTERS
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
@@ -1,0 +1,139 @@
+package org.openpixi.pixi.physics.particles;
+
+import org.openpixi.pixi.math.AlgebraElement;
+
+import java.awt.*;
+
+/**
+ * This particle class describes not single particles, but larger collections of particles as 'super particles'.
+ * It enables us to make use of optimizations specific to CGC simulations with fixed particle trajectories.
+ */
+public class CGCSuperParticle implements IParticle{
+
+	/**
+	 * Array of charges containing all the particle charges associated with this super particle.
+	 */
+	public AlgebraElement[] Q;
+
+	/**
+	 * Orientation of the super particle (-1 or +1).
+	 */
+	public int orientation;
+
+	/**
+	 * Total number of particles described by super particle.
+	 */
+	public int numberOfParticles;
+
+	/**
+	 * Longitudinal offset from z = 0 in terms of lattice indices.
+	 */
+	public int indexOffset;
+
+	/**
+	 * Number of particles within a transverse plane.
+	 */
+	public int particlesPerPlane;
+
+	/**
+	 * Offset/shift of the particles within a cell.
+	 */
+	public int subLatticeShift;
+
+	public CGCSuperParticle(int orientation,
+							int numberOfParticles,
+							int indexOffset,
+	                        int particlesPerPlane,
+	                        int subLatticeShift) {
+		this.orientation = orientation;
+		this.numberOfParticles = numberOfParticles;
+		this.indexOffset = indexOffset;
+		this.particlesPerPlane = particlesPerPlane;
+		this.subLatticeShift = subLatticeShift;
+
+		this.Q = new AlgebraElement[numberOfParticles];
+
+	}
+
+	// GETTERS
+
+	public double getPosition(int i) {
+		return 0;
+	}
+
+	public double getPrevPosition(int i) {
+		return 0;
+	}
+
+	public double getVelocity(int i) {
+		return 0;
+	}
+
+	public double[] getPosition() {
+		return new double[]{0};
+	}
+
+	public double[] getPrevPosition() {
+		return new double[]{0};
+	}
+
+	public double[] getVelocity() {
+		return new double[]{0};
+	}
+
+	public double getRadius() {
+		return 0;
+	}
+
+	public Color getDisplayColor() {
+		return Color.BLACK;
+	}
+
+	public int getNumberOfDimensions() {
+		return 0;
+	}
+
+	// SETTERS
+
+	public void setPosition(int i, double value) {
+
+	}
+
+	public void addPosition(int i, double value) {
+
+	}
+
+	public void setPrevPosition(int i, double value) {
+
+	}
+
+	public void addPrevPosition(int i, double value) {
+
+	}
+
+	public void setVelocity(int i, double value) {
+
+	}
+
+	public void addVelocity(int i, double value) {
+
+	}
+
+	public void setNumberOfDimensions(int numberOfDimensions) {
+	}
+
+	public void setRadius(double r) {
+
+	}
+
+	public void setDisplayColor(Color color) {
+
+	}
+
+	public void reassignValues() {
+	}
+
+	public IParticle copy() {
+		throw new RuntimeException("copy() method of CGCSuperParticle not implemented.");
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
@@ -40,20 +40,32 @@ public class CGCSuperParticle implements IParticle{
 	 */
 	public int subLatticeShift;
 
+	/**
+	 * Number of particles per cell. Needed for relative position of super particles.
+	 */
+	public int particlePerCell;
+
 	public CGCSuperParticle(int orientation,
 							int numberOfParticles,
 							int indexOffset,
 	                        int particlesPerPlane,
-	                        int subLatticeShift) {
+	                        int subLatticeShift,
+	                        int particlePerCell) {
 		this.orientation = orientation;
 		this.numberOfParticles = numberOfParticles;
 		this.indexOffset = indexOffset;
 		this.particlesPerPlane = particlesPerPlane;
 		this.subLatticeShift = subLatticeShift;
+		this.particlePerCell = particlePerCell;
 
 		this.Q = new AlgebraElement[numberOfParticles];
 
 	}
+
+	public boolean needsUpdate(int t) {
+		return subLatticeShift == (t + subLatticeShift + 1) % particlePerCell;
+	}
+
 
 	// GETTERS
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
@@ -8,178 +8,181 @@ import java.awt.*;
  * This particle class describes not single particles, but larger collections of particles as 'super particles'.
  * It enables us to make use of optimizations specific to CGC simulations with fixed particle trajectories.
  */
-public class CGCSuperParticle implements IParticle{
+public class CGCSuperParticle implements IParticle {
 
-	/**
-	 * Array of charges containing all the particle charges associated with this super particle.
-	 */
-	public AlgebraElement[] Q;
+    /**
+     * Array of charges containing all the particle charges associated with this super particle.
+     */
+    public AlgebraElement[] Q;
 
-	/**
-	 * Orientation of the super particle (-1 or +1).
-	 */
-	public int orientation;
+    /**
+     * Orientation of the super particle (-1 or +1).
+     */
+    public int orientation;
 
-	/**
-	 * Total number of particles described by super particle.
-	 */
-	public int numberOfParticles;
+    /**
+     * Total number of particles described by super particle.
+     */
+    public int numberOfParticles;
 
-	/**
-	 * Longitudinal offset from z = 0 in terms of lattice indices.
-	 */
-	public int indexOffset;
+    /**
+     * Longitudinal offset from z = 0 in terms of lattice indices.
+     */
+    public int indexOffset;
 
-	/**
-	 * Number of particles within a transverse plane.
-	 */
-	public int particlesPerPlane;
+    /**
+     * Number of particles within a transverse plane.
+     */
+    public int particlesPerPlane;
 
-	/**
-	 * Offset/shift of the particles within a cell.
-	 */
-	public int subLatticeShift;
+    /**
+     * Offset/shift of the particles within a cell.
+     */
+    public int subLatticeShift;
 
-	/**
-	 * Number of particles per cell. Needed for relative position of super particles.
-	 */
-	public int particlePerCell;
+    /**
+     * Number of particles per cell. Needed for relative position of super particles.
+     */
+    public int particlePerCell;
 
-	public CGCSuperParticle(int orientation,
-							int numberOfParticles,
-							int indexOffset,
-	                        int particlesPerPlane,
-	                        int subLatticeShift,
-	                        int particlePerCell) {
-		this.orientation = orientation;
-		this.numberOfParticles = numberOfParticles;
-		this.indexOffset = indexOffset;
-		this.particlesPerPlane = particlesPerPlane;
-		this.subLatticeShift = subLatticeShift;
-		this.particlePerCell = particlePerCell;
+    public CGCSuperParticle(int orientation,
+                            int numberOfParticles,
+                            int indexOffset,
+                            int particlesPerPlane,
+                            int subLatticeShift,
+                            int particlePerCell) {
+        this.orientation = orientation;
+        this.numberOfParticles = numberOfParticles;
+        this.indexOffset = indexOffset;
+        this.particlesPerPlane = particlesPerPlane;
+        this.subLatticeShift = subLatticeShift;
+        this.particlePerCell = particlePerCell;
 
-		this.Q = new AlgebraElement[numberOfParticles];
+        this.Q = new AlgebraElement[numberOfParticles];
 
-	}
+    }
 
-	/**
-	 * Returns index offset at simulation time t. Add the particle index to get the cell index.
-	 * @param t     current simulation step
-	 * @return      index offset since beginning of simulation.
-	 */
-	public int getCurrentOffset(int t) {
-		if(orientation > 0) {
-			return indexOffset + ((t + subLatticeShift) / particlePerCell) * particlesPerPlane;
-		}
-		int shift = ((int) Math.floor((- t + subLatticeShift) / (1.0 * particlePerCell))) * particlesPerPlane;
-		return indexOffset + shift;
-	}
+    /**
+     * Returns index offset at simulation time t. Add the particle index to get the cell index.
+     *
+     * @param t current simulation step
+     * @return index offset since beginning of simulation.
+     */
+    public int getCurrentOffset(int t) {
+        if (orientation > 0) {
+            return indexOffset + ((t + subLatticeShift) / particlePerCell) * particlesPerPlane;
+        }
+        int shift = ((int) Math.floor((-t + subLatticeShift) / (1.0 * particlePerCell))) * particlesPerPlane;
+        return indexOffset + shift;
+    }
 
-	/**
-	 * Returns the ngp index offset at simulation time t. Add the particle index to get the current ngp index.
-	 * @param t     current simulation step
-	 * @return      ngp index offset since beginning of simulation.
-	 */
-	public int getCurrentNGPOffset(int t) {
-		int currentOffset = getCurrentOffset(t);
-		if(orientation > 0) {
-			return currentOffset + ((((t+subLatticeShift) % particlePerCell) < particlePerCell/2) ? 0 : particlesPerPlane);
-		}
-		int shift = ((((t - subLatticeShift + particlePerCell + particlePerCell/2 - 1) % particlePerCell) < particlePerCell/2) ? 0 : particlesPerPlane);
-		return currentOffset + shift;
-	}
+    /**
+     * Returns the ngp index offset at simulation time t. Add the particle index to get the current ngp index.
+     *
+     * @param t current simulation step
+     * @return ngp index offset since beginning of simulation.
+     */
+    public int getCurrentNGPOffset(int t) {
+        int currentOffset = getCurrentOffset(t);
+        if (orientation > 0) {
+            return currentOffset + ((((t + subLatticeShift) % particlePerCell) < particlePerCell / 2) ? 0 : particlesPerPlane);
+        }
+        int shift = ((((t - subLatticeShift + particlePerCell + particlePerCell / 2 - 1) % particlePerCell) < particlePerCell / 2) ? 0 : particlesPerPlane);
+        return currentOffset + shift;
+    }
 
-	/**
-	 * Checks if particle will cross an ngp boundary in the *next* simulation step.
-	 * @param t     current simulation step
-	 * @return      true/false if particle needs an update or needs to be interpolated to the grid.
-	 */
-	public boolean needsUpdate(int t) {
-		if(orientation > 0) {
-			return 0 == (t + subLatticeShift + particlePerCell / 2 + 1) % particlePerCell;
-		}
-		return 0 == (t - subLatticeShift + particlePerCell / 2 ) % particlePerCell;
-	}
+    /**
+     * Checks if particle will cross an ngp boundary in the *next* simulation step.
+     *
+     * @param t current simulation step
+     * @return true/false if particle needs an update or needs to be interpolated to the grid.
+     */
+    public boolean needsUpdate(int t) {
+        if (orientation > 0) {
+            return 0 == (t + subLatticeShift + particlePerCell / 2 + 1) % particlePerCell;
+        }
+        return 0 == (t - subLatticeShift + particlePerCell / 2) % particlePerCell;
+    }
 
-	// GETTERS
+    // GETTERS
 
-	public double getPosition(int i) {
-		return 0;
-	}
+    public double getPosition(int i) {
+        return 0;
+    }
 
-	public double getPrevPosition(int i) {
-		return 0;
-	}
+    public double getPrevPosition(int i) {
+        return 0;
+    }
 
-	public double getVelocity(int i) {
-		return 0;
-	}
+    public double getVelocity(int i) {
+        return 0;
+    }
 
-	public double[] getPosition() {
-		return new double[]{0};
-	}
+    public double[] getPosition() {
+        return new double[]{0};
+    }
 
-	public double[] getPrevPosition() {
-		return new double[]{0};
-	}
+    public double[] getPrevPosition() {
+        return new double[]{0};
+    }
 
-	public double[] getVelocity() {
-		return new double[]{0};
-	}
+    public double[] getVelocity() {
+        return new double[]{0};
+    }
 
-	public double getRadius() {
-		return 0;
-	}
+    public double getRadius() {
+        return 0;
+    }
 
-	public Color getDisplayColor() {
-		return Color.BLACK;
-	}
+    public Color getDisplayColor() {
+        return Color.BLACK;
+    }
 
-	public int getNumberOfDimensions() {
-		return 0;
-	}
+    public int getNumberOfDimensions() {
+        return 0;
+    }
 
-	// SETTERS
+    // SETTERS
 
-	public void setPosition(int i, double value) {
+    public void setPosition(int i, double value) {
 
-	}
+    }
 
-	public void addPosition(int i, double value) {
+    public void addPosition(int i, double value) {
 
-	}
+    }
 
-	public void setPrevPosition(int i, double value) {
+    public void setPrevPosition(int i, double value) {
 
-	}
+    }
 
-	public void addPrevPosition(int i, double value) {
+    public void addPrevPosition(int i, double value) {
 
-	}
+    }
 
-	public void setVelocity(int i, double value) {
+    public void setVelocity(int i, double value) {
 
-	}
+    }
 
-	public void addVelocity(int i, double value) {
+    public void addVelocity(int i, double value) {
 
-	}
+    }
 
-	public void setNumberOfDimensions(int numberOfDimensions) {
-	}
+    public void setNumberOfDimensions(int numberOfDimensions) {
+    }
 
-	public void setRadius(double r) {
+    public void setRadius(double r) {
 
-	}
+    }
 
-	public void setDisplayColor(Color color) {
+    public void setDisplayColor(Color color) {
 
-	}
+    }
 
-	public void reassignValues() {
-	}
+    public void reassignValues() {
+    }
 
-	public IParticle copy() {
-		throw new RuntimeException("copy() method of CGCSuperParticle not implemented.");
-	}
+    public IParticle copy() {
+        throw new RuntimeException("copy() method of CGCSuperParticle not implemented.");
+    }
 }

--- a/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/particles/CGCSuperParticle.java
@@ -68,8 +68,11 @@ public class CGCSuperParticle implements IParticle{
 	 * @return      index offset since beginning of simulation.
 	 */
 	public int getCurrentOffset(int t) {
-		int movementShift = ((t + subLatticeShift) / particlePerCell) * particlesPerPlane;
-		return indexOffset + movementShift;
+		if(orientation > 0) {
+			return indexOffset + ((t + subLatticeShift) / particlePerCell) * particlesPerPlane;
+		}
+		int shift = ((int) Math.floor((- t + subLatticeShift) / (1.0 * particlePerCell))) * particlesPerPlane;
+		return indexOffset + shift;
 	}
 
 	/**
@@ -78,8 +81,12 @@ public class CGCSuperParticle implements IParticle{
 	 * @return      ngp index offset since beginning of simulation.
 	 */
 	public int getCurrentNGPOffset(int t) {
-		int ngpShift = (((t+subLatticeShift) % particlePerCell) < particlePerCell/2) ? 0 : particlesPerPlane;
-		return getCurrentOffset(t) + ngpShift;
+		int currentOffset = getCurrentOffset(t);
+		if(orientation > 0) {
+			return currentOffset + ((((t+subLatticeShift) % particlePerCell) < particlePerCell/2) ? 0 : particlesPerPlane);
+		}
+		int shift = ((((t - subLatticeShift + particlePerCell + particlePerCell/2 - 1) % particlePerCell) < particlePerCell/2) ? 0 : particlesPerPlane);
+		return currentOffset + shift;
 	}
 
 	/**
@@ -88,7 +95,10 @@ public class CGCSuperParticle implements IParticle{
 	 * @return      true/false if particle needs an update or needs to be interpolated to the grid.
 	 */
 	public boolean needsUpdate(int t) {
-		return 0 == (t + subLatticeShift + particlePerCell/2 + 1) % particlePerCell;
+		if(orientation > 0) {
+			return 0 == (t + subLatticeShift + particlePerCell / 2 + 1) % particlePerCell;
+		}
+		return 0 == (t - subLatticeShift + particlePerCell / 2 ) % particlePerCell;
 	}
 
 	// GETTERS

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlSettings.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/YamlSettings.java
@@ -57,6 +57,7 @@ public class YamlSettings {
 			map.put("temporal yang-mills", SimulationType.TemporalYangMills);
 			map.put("temporal cgc", SimulationType.TemporalCGC);
 			map.put("temporal cgc ngp", SimulationType.TemporalCGCNGP);
+			map.put("temporal optimized cgc ngp", SimulationType.TemporalOptimizedCGCNGP);
 			map.put("lorenz yang-mills", SimulationType.LorenzYangMills);
 			map.put("boost-invariant cgc", SimulationType.BoostInvariantCGC);
 


### PR DESCRIPTION
This pull request adds a new simulation type: _SimulationType.TemporalOptimizedCGCNGP_  or "temporal optimized cgc ngp" in YAML configurations.

Using this simulation type CGC simulations can be sped up and need less memory. Instead of having a large number of independent colored particles, particle charges are now grouped together to form a number of "super particles". Since the relative distances of the color charges in a single nucleus do not change during the simulation, we can exploit this fact to not only use less memory but also simplify the interpolation routines dramatically.

Notes:
- These very specific optimizations work only when the propagation direction of the initial conditions is set to 0.
- Due to a slightly altered method of cutting off negligible Gauss law violations in the initial conditions the numerical results of optimized simulations might not agree with the results of un-optimized simulations down to the last digit. 
### Benchmarks

Configuration: collision using incoherent MV model on a 128x64^2 grid.
System: i7 6700k (stock), 32gb

_Without optimizations_: 
Simulation time: 18 s (average **576ms**/step), heap dump\* ~**1.32gb**
_Super particles_: 
Simulation time: 10 s (average **342ms**/step), heap dump\* ~ **0.93gb**
_Super particles + SU(2) improvements_ #184 :
Simulation time: 6 s (average **204ms**/step), heap dump\* ~ **0.69gb**

*) heap dump saved after initialization.
