### PR TITLE
Throw exceptions in threads instead of hiding them.

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/parallel/cellaccess/ParallelCellIterator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/parallel/cellaccess/ParallelCellIterator.java
@@ -6,7 +6,9 @@ import org.openpixi.pixi.physics.util.IntBox;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 /**
  * Executes action upon cells in parallel using threads.
@@ -39,8 +41,15 @@ public class ParallelCellIterator extends CellIterator {
 		this.grid = grid;
 		this.action = action;
 		try {
-			threadExecutor.invokeAll(tasks);
+			List<Future<Object>> futures = threadExecutor.invokeAll(tasks);
+			for (Future<Object> f : futures) {
+				// Retrieving the result throws possible exceptions
+				f.get();
+			}
 		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		} catch (ExecutionException e) {
+			// Throw exceptions that happened in a thread
 			throw new RuntimeException(e);
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/parallel/cellaccess/ParallelCellIterator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/parallel/cellaccess/ParallelCellIterator.java
@@ -46,9 +46,7 @@ public class ParallelCellIterator extends CellIterator {
 				// Retrieving the result throws possible exceptions
 				f.get();
 			}
-		} catch (InterruptedException e) {
-			throw new RuntimeException(e);
-		} catch (ExecutionException e) {
+		} catch (InterruptedException | ExecutionException e) {
 			// Throw exceptions that happened in a thread
 			throw new RuntimeException(e);
 		}

--- a/pixi/src/main/java/org/openpixi/pixi/parallel/particleaccess/ParallelParticleIterator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/parallel/particleaccess/ParallelParticleIterator.java
@@ -44,9 +44,7 @@ public class ParallelParticleIterator implements ParticleIterator {
 				// Retrieving the result throws possible exceptions
 				f.get();
 			}
-		} catch (InterruptedException e) {
-			throw new RuntimeException(e);
-		} catch (ExecutionException e) {
+		} catch (InterruptedException | ExecutionException e) {
 			// Throw exceptions that happened in a thread
 			throw new RuntimeException(e);
 		}

--- a/pixi/src/main/java/org/openpixi/pixi/parallel/particleaccess/ParallelParticleIterator.java
+++ b/pixi/src/main/java/org/openpixi/pixi/parallel/particleaccess/ParallelParticleIterator.java
@@ -5,7 +5,9 @@ import org.openpixi.pixi.physics.particles.IParticle;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 /**
  * Executes action upon particles in parallel using threads.
@@ -37,8 +39,15 @@ public class ParallelParticleIterator implements ParticleIterator {
 		this.particles = particles;
 
 		try {
-			threadExecutor.invokeAll(tasks);
+			List<Future<Object>> futures = threadExecutor.invokeAll(tasks);
+			for (Future<Object> f : futures) {
+				// Retrieving the result throws possible exceptions
+				f.get();
+			}
 		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		} catch (ExecutionException e) {
+			// Throw exceptions that happened in a thread
 			throw new RuntimeException(e);
 		}
 	}


### PR DESCRIPTION
Throw exceptions in threads instead of hiding them.

This modification affects:
- ParallelCellIterator
- ParallelParticleIterator
