### PR TITLE
Absolute paths for diagnostics (now 100% more mergeable).

### DIFF
--- a/pixi/input/CGC/Tests/absolute_path_test.yaml
+++ b/pixi/input/CGC/Tests/absolute_path_test.yaml
@@ -46,7 +46,7 @@ output:
       direction: 0
   timeMeasurement:
     - path: "/tmp/output/time_writetest.txt"
-      interval: 0.025
+      interval: 0.5
 
 
 

--- a/pixi/input/CGC/Tests/absolute_path_test.yaml
+++ b/pixi/input/CGC/Tests/absolute_path_test.yaml
@@ -1,0 +1,99 @@
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: 2
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 8
+gridCells: [128, 32, 32]
+timeStep: 0.5
+duration: 64
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+initialConditions:
+  CGC:
+    poissonSolver: improved full
+    computeTadpole: true
+    tadpoleFilename: /tmp/output/tadpole_test_coherent.dat
+    MVModelCoherent:
+      - direction: 0
+        orientation: 1
+        longitudinalLocation: 32
+        longitudinalWidth: 8
+        randomSeed: 5
+        mu: .2
+        ultravioletCutoffTransverse: 2
+        infraredCoefficient: 0.2
+      - direction: 0
+        orientation: -1
+        longitudinalLocation: 96
+        longitudinalWidth: 8
+        randomSeed: 6
+        mu: .2
+        ultravioletCutoffTransverse: 2
+        infraredCoefficient: 0.2
+
+output:
+  projectedEnergyDensity:
+    - path: '/tmp/output/pe_writetest.dat'
+      interval: 0.5
+      direction: 0
+  timeMeasurement:
+    - path: "/tmp/output/time_writetest.txt"
+      interval: 0.025
+
+
+
+# Generated panel code:
+panels:
+  dividerLocation: 785
+  leftPanel:
+    dividerLocation: 484
+    leftPanel:
+      chartPanel:
+        logarithmicScale: false
+        showCharts:
+        - Gauss law violation
+        - E squared
+        - B squared
+        - Energy density
+    orientation: 0
+    rightPanel:
+      dividerLocation: 386
+      leftPanel:
+        electricFieldPanel:
+          automaticScaling: true
+          colorIndex: 0
+          directionIndex: 0
+          scaleFactor: 2500.0
+          showCoordinates: x, i, 0
+          showFields:
+          - E
+          - B
+          - Gauss
+      orientation: 1
+      rightPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 1
+          scaleFactor: 25.0
+          showCoordinates: x, i, 4
+          showFields:
+          - E
+          - U
+  orientation: 1
+  rightPanel:
+    energyDensity2DGLPanel:
+      automaticScaling: false
+      data: Energy density
+      scaleFactor: 10000.0
+      showCoordinates: x, y, 16
+  windowHeight: 1053
+  windowWidth: 1920

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/FileFunctions.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/FileFunctions.java
@@ -14,12 +14,18 @@ public class FileFunctions {
 	 * @return     File instance
 	 */
 	public static File getFile(String path) {
-		File file = new File(path);
+		// Prepend 'output/' if path is relative. This only works for unix paths.
+		String newPath = path;
+		if(path.charAt(0) != '/') {
+			newPath = "output/" + path;
+		}
+
+		File file = new File(newPath);
 		File folder = file.getParentFile();
 		if(!folder.exists()) {
 			boolean result = folder.mkdirs();
 			if(!result) {
-				System.out.println("FileFunctions: Error creating path for file " + path);
+				System.out.println("FileFunctions: Error creating path for file " + newPath);
 			}
 		}
 		return file;
@@ -31,11 +37,17 @@ public class FileFunctions {
 	 * @param path String with path or filename
 	 */
 	public static void clearFile(String path) {
-		File file = new File(path);
+		// Prepend 'output/' if path is relative. This only works for unix paths.
+		String newPath = path;
+		if(path.charAt(0) != '/') {
+			newPath = "output/" + path;
+		}
+
+		File file = new File(newPath);
 		if(file.exists()) {
 			boolean result = file.delete();
 			if(!result) {
-				System.out.println("FileFunctions: Error deleting file " + path);
+				System.out.println("FileFunctions: Error deleting file " + newPath);
 			}
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/BulkQuantitiesInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/BulkQuantitiesInTime.java
@@ -51,7 +51,7 @@ public class BulkQuantitiesInTime implements Diagnostics {
 	public void initialize(Simulation s)
 	{
 		this.s = s;
-		this.stepInterval = (int) (timeInterval / this.s.getTimeStep());
+		this.stepInterval = (int) Math.max((timeInterval / this.s.getTimeStep()), 1);
 		this.fieldMeasurements = new FieldMeasurements();
 
 		if(!supressOutput) {

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/BulkQuantitiesInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/BulkQuantitiesInTime.java
@@ -51,7 +51,7 @@ public class BulkQuantitiesInTime implements Diagnostics {
 	public void initialize(Simulation s)
 	{
 		this.s = s;
-		this.stepInterval = (int) Math.max((timeInterval / this.s.getTimeStep()), 1);
+		this.stepInterval = (int) Math.max(Math.round((timeInterval / this.s.getTimeStep())), 1);
 		this.fieldMeasurements = new FieldMeasurements();
 
 		if(!supressOutput) {

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/BulkQuantitiesInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/BulkQuantitiesInTime.java
@@ -56,10 +56,10 @@ public class BulkQuantitiesInTime implements Diagnostics {
 
 		if(!supressOutput) {
 			// Create/delete file.
-			FileFunctions.clearFile("output/" + path);
+			FileFunctions.clearFile(path);
 
 			// Write first line.
-			File file = FileFunctions.getFile("output/" + path);
+			File file = FileFunctions.getFile(path);
 			try {
 				FileWriter pw = new FileWriter(file, true);
 				pw.write("#time \t E^2 \t B^2 \t P_x \t P_y \t P_z \t G");
@@ -98,7 +98,7 @@ public class BulkQuantitiesInTime implements Diagnostics {
 			gaussViolation = fieldMeasurements.calculateGaussConstraint(grid);
 
 			if(!supressOutput) {
-				File file = FileFunctions.getFile("output/" + path);
+				File file = FileFunctions.getFile(path);
 				FileWriter pw = new FileWriter(file, true);
 				DecimalFormat formatter = new DecimalFormat("0.################E0");
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/CoulombGaugeInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/CoulombGaugeInTime.java
@@ -26,7 +26,7 @@ public class CoulombGaugeInTime implements Diagnostics {
 
 	@Override
 	public void initialize(Simulation s) {
-		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
+		this.stepInterval = (int) Math.max(Math.round((timeInterval / s.getTimeStep())), 1);
 		this.stepOffset = (int) (timeOffset / s.getTimeStep());
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/CoulombGaugeInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/CoulombGaugeInTime.java
@@ -26,7 +26,7 @@ public class CoulombGaugeInTime implements Diagnostics {
 
 	@Override
 	public void initialize(Simulation s) {
-		this.stepInterval = (int) (timeInterval / s.getTimeStep());
+		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
 		this.stepOffset = (int) (timeOffset / s.getTimeStep());
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/DipoleInitialBinned.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/DipoleInitialBinned.java
@@ -47,10 +47,10 @@ public class DipoleInitialBinned implements Diagnostics {
 
 		if(!supressOutput) {
 			// Create/delete file.
-			FileFunctions.clearFile("output/" + path);
+			FileFunctions.clearFile(path);
 
 			// Write first line.
-			File file = FileFunctions.getFile("output/" + path);
+			File file = FileFunctions.getFile(path);
 			try {
 				FileWriter pw = new FileWriter(file, true);
 				pw.write("#|x - y| \t tr[V_x V_y^dagger]");
@@ -158,7 +158,7 @@ public class DipoleInitialBinned implements Diagnostics {
 		}
 
 		if(!supressOutput) {
-			File file = FileFunctions.getFile("output/" + path);
+			File file = FileFunctions.getFile(path);
 			FileWriter pw = new FileWriter(file, true);
 			DecimalFormat formatter = new DecimalFormat("0.################E0");
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/GaussConstraintRestoration.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/GaussConstraintRestoration.java
@@ -53,7 +53,7 @@ public class GaussConstraintRestoration implements Diagnostics {
 	}
 
 	public void initialize(Simulation s) {
-		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
+		this.stepInterval = (int) Math.max(Math.round((timeInterval / s.getTimeStep())), 1);
 		this.stepOffset = (int) (timeOffset / s.getTimeStep());
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/GaussConstraintRestoration.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/GaussConstraintRestoration.java
@@ -53,7 +53,7 @@ public class GaussConstraintRestoration implements Diagnostics {
 	}
 
 	public void initialize(Simulation s) {
-		this.stepInterval = (int) (timeInterval / s.getTimeStep());
+		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
 		this.stepOffset = (int) (timeOffset / s.getTimeStep());
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -64,7 +64,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 
 
 		if(!outputType.equals(OUTPUT_NONE)) {
-			FileFunctions.clearFile("output/" + outputFileName);
+			FileFunctions.clearFile(outputFileName);
 		}
 
 		if (!Arrays.asList(supportedOutputTypes).contains(outputType)) {
@@ -295,7 +295,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 	 * @param path	Path to output file
 	 */
 	public void writeHeader(String path) {
-		File file = FileFunctions.getFile("output/" + path);
+		File file = FileFunctions.getFile(path);
 
 		try {
 			FileWriter pw = new FileWriter(file, true);
@@ -323,7 +323,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 	 * @param path	Path to the output file
 	 */
 	private void writeMomentumVectors(String path) {
-		File file = FileFunctions.getFile("output/" + path);
+		File file = FileFunctions.getFile(path);
 		try {
 			FileWriter pw = new FileWriter(file, true);
 			for(int i = 0; i < s.grid.getTotalNumberOfCells(); i++) {
@@ -361,7 +361,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 	 */
 	private void writeCSVFile(String path, boolean includeOccupationNumbers)
 	{
-		File file = FileFunctions.getFile("output/" + path);
+		File file = FileFunctions.getFile(path);
 		try {
 			FileWriter pw = new FileWriter(file, true);
 			pw.write(this.generateCSVString(includeOccupationNumbers));

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -85,7 +85,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 
 	public void initialize(Simulation s) {
 		this.s = s;
-		this.stepInterval = (int) (this.timeInterval / s.getTimeStep());
+		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
 		this.numberOfComponents = s.getNumberOfColors() * s.getNumberOfColors() - 1;
 		effectiveNumberOfDimensions = getEffectiveNumberOfDimensions(s.grid.getNumCells());
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -85,7 +85,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 
 	public void initialize(Simulation s) {
 		this.s = s;
-		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
+		this.stepInterval = (int) Math.max(Math.round((timeInterval / s.getTimeStep())), 1);
 		this.numberOfComponents = s.getNumberOfColors() * s.getNumberOfColors() - 1;
 		effectiveNumberOfDimensions = getEffectiveNumberOfDimensions(s.grid.getNumCells());
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ParticlesInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ParticlesInTime.java
@@ -33,7 +33,7 @@ public class ParticlesInTime implements Diagnostics {
 	public void initialize(Simulation s)
 	{
 		this.s = s;
-		stepInterval =  (int) (this.timeInterval / s.getTimeStep());
+		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
 
 		// Create/delete file.
 		FileFunctions.clearFile(path);

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ParticlesInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ParticlesInTime.java
@@ -33,7 +33,7 @@ public class ParticlesInTime implements Diagnostics {
 	public void initialize(Simulation s)
 	{
 		this.s = s;
-		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
+		this.stepInterval = (int) Math.max(Math.round((timeInterval / s.getTimeStep())), 1);
 
 		// Create/delete file.
 		FileFunctions.clearFile(path);

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ParticlesInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ParticlesInTime.java
@@ -36,11 +36,11 @@ public class ParticlesInTime implements Diagnostics {
 		stepInterval =  (int) (this.timeInterval / s.getTimeStep());
 
 		// Create/delete file.
-		FileFunctions.clearFile("output/" + path);
+		FileFunctions.clearFile(path);
 
 		// Write first line.
 		String[] directionNames = new String[] {"x", "y", "z"};
-		File file = FileFunctions.getFile("output/" + path);
+		File file = FileFunctions.getFile(path);
 		try {
 			FileWriter pw = new FileWriter(file, true);
 			pw.write("#time\t");
@@ -77,7 +77,7 @@ public class ParticlesInTime implements Diagnostics {
 	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps) throws IOException {
 		if(steps % stepInterval == 0) {
 
-			File file = FileFunctions.getFile("output/" + path);;
+			File file = FileFunctions.getFile(path);
 			FileWriter pw = new FileWriter(file, true);
 			pw.write(steps * s.getTimeStep() + "\t");
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
@@ -52,7 +52,7 @@ public class PlanarFields implements Diagnostics {
 		this.transNumCells = GridFunctions.reduceGridPos(s.grid.getNumCells(), direction);
 		this.totalTransCells =  GridFunctions.getTotalNumberOfCells(transNumCells);
 
-		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
+		this.stepInterval = (int) Math.max(Math.round((timeInterval / s.getTimeStep())), 1);
 		this.startingStep = (int) (startingTime / s.getTimeStep());
 		this.finalStep = (int) (finalTime / s.getTimeStep());
 		this.effDimensions = GridFunctions.getEffectiveNumberOfDimensions(s.grid.getNumCells());

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
@@ -52,7 +52,7 @@ public class PlanarFields implements Diagnostics {
 		this.transNumCells = GridFunctions.reduceGridPos(s.grid.getNumCells(), direction);
 		this.totalTransCells =  GridFunctions.getTotalNumberOfCells(transNumCells);
 
-		this.stepInterval = (int) (timeInterval / s.getTimeStep());
+		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
 		this.startingStep = (int) (startingTime / s.getTimeStep());
 		this.finalStep = (int) (finalTime / s.getTimeStep());
 		this.effDimensions = GridFunctions.getEffectiveNumberOfDimensions(s.grid.getNumCells());

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PlanarFields.java
@@ -46,7 +46,7 @@ public class PlanarFields implements Diagnostics {
 	}
 
 	public void initialize(Simulation s) {
-		FileFunctions.clearFile("output/" + outputName);
+		FileFunctions.clearFile(outputName);
 
 		this.s = s;
 		this.transNumCells = GridFunctions.reduceGridPos(s.grid.getNumCells(), direction);
@@ -83,7 +83,7 @@ public class PlanarFields implements Diagnostics {
 					}
 				}
 
-				File file = FileFunctions.getFile("output/" + outputName);
+				File file = FileFunctions.getFile(outputName);
 				try {
 					FileWriter pw = new FileWriter(file, true);
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
@@ -50,10 +50,10 @@ public class PoyntingTheoremInTime implements Diagnostics {
 
 		if(!supressOutput) {
 			// Create/delete file.
-			FileFunctions.clearFile("output/" + path);
+			FileFunctions.clearFile(path);
 
 			// Write first line.
-			File file = FileFunctions.getFile("output/" + path);
+			File file = FileFunctions.getFile(path);
 			try {
 				FileWriter pw = new FileWriter(file, true);
 				pw.write("#time");
@@ -105,7 +105,7 @@ public class PoyntingTheoremInTime implements Diagnostics {
 		if(steps % stepInterval == 0) {
 
 			if(!supressOutput) {
-				File file = FileFunctions.getFile("output/" + path);
+				File file = FileFunctions.getFile(path);
 				FileWriter pw = new FileWriter(file, true);
 				DecimalFormat formatter = new DecimalFormat("0.################E0");
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
@@ -44,7 +44,7 @@ public class PoyntingTheoremInTime implements Diagnostics {
 	public void initialize(Simulation s)
 	{
 		this.s = s;
-		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
+		this.stepInterval = (int) Math.max(Math.round((timeInterval / s.getTimeStep())), 1);
 		poyntingTheorem = PoyntingTheoremBuffer.getOrAppendInstance(s);
 		//poyntingTheorem.initialize(s);
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/PoyntingTheoremInTime.java
@@ -44,7 +44,7 @@ public class PoyntingTheoremInTime implements Diagnostics {
 	public void initialize(Simulation s)
 	{
 		this.s = s;
-		this.stepInterval = (int) (timeInterval / this.s.getTimeStep());
+		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
 		poyntingTheorem = PoyntingTheoremBuffer.getOrAppendInstance(s);
 		//poyntingTheorem.initialize(s);
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
@@ -62,7 +62,7 @@ public class ProjectedEnergyDensity implements Diagnostics {
 	}
 
 	public void initialize(Simulation s) {
-		this.stepInterval = (int) Math.round(timeInterval / s.getTimeStep());
+		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
 
 		if(computeEnergyDensity) {
 			energyDensityComputation.initialize(s.grid, direction);

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
@@ -62,7 +62,7 @@ public class ProjectedEnergyDensity implements Diagnostics {
 	}
 
 	public void initialize(Simulation s) {
-		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
+		this.stepInterval = (int) Math.max(Math.round((timeInterval / s.getTimeStep())), 1);
 
 		if(computeEnergyDensity) {
 			energyDensityComputation.initialize(s.grid, direction);

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ProjectedEnergyDensity.java
@@ -71,7 +71,7 @@ public class ProjectedEnergyDensity implements Diagnostics {
 			poyntingComputation.initialize(s.grid, direction);
 		}
 
-		FileFunctions.clearFile("output/" + path);
+		FileFunctions.clearFile(path);
 	}
 
 	public void calculate(Grid grid, ArrayList<IParticle> particles, int steps) throws IOException {
@@ -88,7 +88,7 @@ public class ProjectedEnergyDensity implements Diagnostics {
 			}
 
 			// Write to file
-			File file = FileFunctions.getFile("output/" + path);
+			File file = FileFunctions.getFile(path);
 			try {
 				FileWriter pw = new FileWriter(file, true);
 				Double time = steps * grid.getTemporalSpacing();

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/RandomGaugeInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/RandomGaugeInTime.java
@@ -32,7 +32,7 @@ public class RandomGaugeInTime implements Diagnostics {
 
 	@Override
 	public void initialize(Simulation s) {
-		this.stepInterval = (int) (timeInterval / s.getTimeStep());
+		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
 		this.stepOffset = (int) (timeOffset / s.getTimeStep());
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/RandomGaugeInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/RandomGaugeInTime.java
@@ -32,7 +32,7 @@ public class RandomGaugeInTime implements Diagnostics {
 
 	@Override
 	public void initialize(Simulation s) {
-		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
+		this.stepInterval = (int) Math.max(Math.round((timeInterval / s.getTimeStep())), 1);
 		this.stepOffset = (int) (timeOffset / s.getTimeStep());
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
@@ -115,7 +115,7 @@ public class ScreenshotInTime implements Diagnostics {
 				int counter = steps / stepInterval;
 				String counterString = String.format("%05d", counter);
 				String pathWithNumber = path.replace("{counter}", counterString);
-				File file = FileFunctions.getFile("output/" + pathWithNumber);
+				File file = FileFunctions.getFile(pathWithNumber);
 				ImageIO.write(im, "png", file);
 			}
 		}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
@@ -59,7 +59,7 @@ public class ScreenshotInTime implements Diagnostics {
 
 	@Override
 	public void initialize(Simulation s) {
-		this.stepInterval = (int) (timeInterval / s.getTimeStep());
+		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
 		this.stepOffset = (int) (timeOffset / s.getTimeStep());
 		this.stepIterations = s.getIterations();
 		finished = false;

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
@@ -59,7 +59,7 @@ public class ScreenshotInTime implements Diagnostics {
 
 	@Override
 	public void initialize(Simulation s) {
-		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
+		this.stepInterval = (int) Math.max(Math.round((timeInterval / s.getTimeStep())), 1);
 		this.stepOffset = (int) (timeOffset / s.getTimeStep());
 		this.stepIterations = s.getIterations();
 		finished = false;

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/TimeMeasurement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/TimeMeasurement.java
@@ -42,7 +42,7 @@ public class TimeMeasurement implements Diagnostics {
 	public void initialize(Simulation simulation)
 	{
 		this.simulation = simulation;
-		this.stepInterval = (int) Math.max((timeInterval / simulation.getTimeStep()), 1);
+		this.stepInterval = (int) Math.max(Math.round((timeInterval / simulation.getTimeStep())), 1);
 
 		runtime = Runtime.getRuntime();
 		stept0 = System.nanoTime();

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/TimeMeasurement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/TimeMeasurement.java
@@ -37,7 +37,7 @@ public class TimeMeasurement implements Diagnostics {
 	 * Initializes the TimeMeasurement object.
 	 * It sets the step interval and creates/deletes the output file.
 	 *
-	 * @param s    Instance of the simulation object
+	 * @param simulation    Instance of the simulation object
 	 */
 	public void initialize(Simulation simulation)
 	{
@@ -50,10 +50,10 @@ public class TimeMeasurement implements Diagnostics {
 		long jvmUpTime = ManagementFactory.getRuntimeMXBean().getUptime();
 
 		// Create/delete file.
-		FileFunctions.clearFile("output/" + path);
+		FileFunctions.clearFile(path);
 
 		// Write first line.
-		File file = FileFunctions.getFile("output/" + path);
+		File file = FileFunctions.getFile(path);
 		try {
 			FileWriter pw = new FileWriter(file, true);
 			pw.write("Initialization time: " + jvmUpTime + "ms\n");
@@ -83,7 +83,7 @@ public class TimeMeasurement implements Diagnostics {
 			double memory = ((int) (100 * runtime.totalMemory() / GIGABYTE)) / 100.0;
 			int mempercent = (int) (100 * runtime.totalMemory() / runtime.maxMemory());
 
-			File file = FileFunctions.getFile("output/" + path);
+			File file = FileFunctions.getFile(path);
 			FileWriter pw = new FileWriter(file, true);
 
 			pw.write("step " + currentTime + "/" + totalTime + " (" + stepdt + "ms)\n");

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/TimeMeasurement.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/TimeMeasurement.java
@@ -42,7 +42,7 @@ public class TimeMeasurement implements Diagnostics {
 	public void initialize(Simulation simulation)
 	{
 		this.simulation = simulation;
-		this.stepInterval = (int) (timeInterval / this.simulation.getTimeStep());
+		this.stepInterval = (int) Math.max((timeInterval / simulation.getTimeStep()), 1);
 
 		runtime = Runtime.getRuntime();
 		stept0 = System.nanoTime();

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/UnitarityTester.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/UnitarityTester.java
@@ -24,7 +24,7 @@ public class UnitarityTester implements Diagnostics {
 
 	public void initialize(Simulation s) {
 		this.s = s;
-		this.stepInterval = (int) (this.timeInterval / s.getTimeStep());
+		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
 		this.numberOfColors = s.getNumberOfColors();
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/UnitarityTester.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/UnitarityTester.java
@@ -24,7 +24,7 @@ public class UnitarityTester implements Diagnostics {
 
 	public void initialize(Simulation s) {
 		this.s = s;
-		this.stepInterval = (int) Math.max((timeInterval / s.getTimeStep()), 1);
+		this.stepInterval = (int) Math.max(Math.round((timeInterval / s.getTimeStep())), 1);
 		this.numberOfColors = s.getNumberOfColors();
 	}
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/fields/currentgenerators/DualMVModel.java
@@ -169,8 +169,8 @@ public class DualMVModel implements ICurrentGenerator {
 			}
 
 			// File output ((d-1)x3 transversal gauge field components, 1x3 longitudinal electric field component)
-			FileFunctions.clearFile("output/" + outputFile);
-			File file = FileFunctions.getFile("output/" + outputFile);
+			FileFunctions.clearFile(outputFile);
+			File file = FileFunctions.getFile(outputFile);
 			try {
 				FileWriter pw = new FileWriter(file, true);
 

--- a/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/WilsonLineObservables.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/initial/CGC/WilsonLineObservables.java
@@ -49,7 +49,7 @@ public class WilsonLineObservables {
 
 		// Write to file
 		try {
-			File file = FileFunctions.getFile("output/" + filename);
+			File file = FileFunctions.getFile(filename);
 			FileWriter pw = new FileWriter(file, true);
 			pw.write(output);
 			pw.close();
@@ -116,7 +116,7 @@ public class WilsonLineObservables {
 
 		// Write data to file.
 		try {
-			File file = FileFunctions.getFile("output/" + filename);
+			File file = FileFunctions.getFile(filename);
 			FileWriter pw = new FileWriter(file, true);
 			pw.write(density.getInfo()+"\n");
 			pw.write("d\ttr(V V^t)\n");


### PR DESCRIPTION
It is now possible to also set absolute paths for all kinds of diagnostics.

Example (see YAML file): 

**Relative paths:**
`path: energy.dat`
This redirects to './output/energy.dat' as before.

**Aboslute paths:**
`path: /tmp/output/energy.dat`

Note: This only works for Linux/Unix because the methods in FileFunctions simply detect if the path starts with a '/' or not. 