### PR TITLE
Fix calculation of occupation numbers with mirrored gauge fixing

### DIFF
--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -111,18 +111,6 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		/** Scaling factor for the displayed panel in y-direction*/
 		double sy = height / s.getSimulationBoxSize(yAxisIndex);
 
-		if(mirrorProperties.getValue()) {
-			if(mirrorDirection == xAxisIndex) {
-				xAxisNumCells *= 2;
-				sx *= 0.5;
-			}
-			if(mirrorDirection == yAxisIndex) {
-				yAxisNumCells *= 2;
-				sy *= 0.5;
-			}
-		}
-
-
 		for(int i = 0; i < xAxisNumCells; i++) {
 			gl2.glBegin( GL2.GL_QUAD_STRIP );
 			for(int k = 0; k < yAxisNumCells; k++)
@@ -185,9 +173,6 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 	private int getMomentumIndex(int[] pos)
 	{
 		int[] numGridCells = simulation.grid.getNumCells().clone();
-		if(mirrorProperties.getValue()) {
-			numGridCells[mirrorDirection] *= 2;
-		}
 		int[] pos2 = new int[pos.length];
 		System.arraycopy(pos, 0, pos2, 0, pos.length);
 


### PR DESCRIPTION
This fixes the calculation of occupation numbers that use mirrored gauge fixing in the following way:
Unmirror the Coulomb gauged grid before calculating occupation numbers.
Display only the unmirrored grid content in OccupationNumbers2DGLPanel.

It can be tested with:
input/YM/pulses/Occupation_Numbers_2D.yaml
