### PR TITLE
Implement window function for calculation of occupation numbers

### DIFF
--- a/pixi/input/CGC/MV model/MVModel_Occupation_numbers.yaml
+++ b/pixi/input/CGC/MV model/MVModel_Occupation_numbers.yaml
@@ -1,0 +1,134 @@
+simulationType: temporal cgc ngp
+gridStep: 1
+couplingConstant: 2
+numberOfDimensions: 3
+numberOfColors: 2
+numberOfThreads: 8
+gridCells: [128, 8, 8] #[128, 64, 64]
+timeStep: 0.25
+duration: 96
+evaluationRegion:
+  enabled: true
+  point1: [2, 0, 0]
+  point2: [-3, -1, -1]
+activeRegion:
+  enabled: true
+  point1: [1, 0, 0]
+  point2: [-2, -1, -1]
+
+# (Au+Au, 25 percent area at 128^2)
+# a = 0.04 fm; (1/a=5 GeV)
+# L = a * 64 = 2.56 fm
+# UV at 10GeV
+# IR at 0.2 GeV (1fm confinement radius)
+# mu at 0.505 GeV (MV parameter for SU(3) and Au 197)
+# Gamma of 22.5 corresponds to width of 4.0
+currents:
+  MVModels:
+    - direction: 0
+      orientation: 1
+      longitudinalLocation: 32
+      longitudinalWidth: 3.0
+      mu: 0.102
+      randomSeed: 1
+      lowPassCoefficient: 2.001
+      infraredCoefficient: 0.04
+    - direction: 0
+      orientation: -1
+      longitudinalLocation: -32
+      longitudinalWidth: 3.0
+      mu: 0.102
+      randomSeed: 2
+      lowPassCoefficient: 2.001
+      infraredCoefficient: 0.04
+
+output:
+  bulkQuantitiesInTime:
+    - path: "bulk.dat"
+      interval: 1.0
+  occupationNumbersInTime:
+    - path: "occupation_tukey.csv"
+      outputType: csv_with_vectors
+      interval: 8.0
+      colorful: true
+      useMirroredGrid: true
+      mirroredDirection: 0
+      useRectangularWindow: false
+      useGaussianWindow: false
+      useTukeyWindow: true
+      collisionPosition: [64, 0, 0]
+      collisionTime: 32.0
+      coneVelocity: [.7, 0., 0.]
+      tukeyWidth: 0.2
+
+# Generated panel code:
+panels:
+  dividerLocation: 727
+  leftPanel:
+    dividerLocation: 344
+    leftPanel:
+      occupationNumbers2DGLPanel:
+        automaticScaling: true
+        collisionPosition: 64, 0, 0
+        collisionTime: 32.0
+        colorful: true
+        coneRestriction: false
+        cutConeVelocity: .7, 0., 0.
+        frameSkip: 2
+        gaussianWindow: false
+        mirrorX: true
+        scaleFactor: 1.0
+        showCoordinates: x, y, 4
+        tukeyWidth: 0.2
+        tukeyWindow: true
+    orientation: 0
+    rightPanel:
+      dividerLocation: 355
+      leftPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 0
+          scaleFactor: 25.0
+          showCoordinates: x, i, 0
+          showFields:
+          - E
+          - Gauss
+      orientation: 1
+      rightPanel:
+        electricFieldPanel:
+          automaticScaling: false
+          colorIndex: 0
+          directionIndex: 1
+          scaleFactor: 25.0
+          showCoordinates: x, i, 4
+          showFields:
+          - E
+  orientation: 1
+  rightPanel:
+    dividerLocation: 276
+    leftPanel:
+      energyDensityVoxelGLPanel:
+        automaticScaling: true
+        centerx: 0.0
+        centery: 0.0
+        centerz: 0.0
+        data: Energy density
+        direction: x
+        distanceFactor: 0.52
+        opacity: 1.0
+        phi: -2.3407963267948966
+        scaleFactor: 1.0
+        showSimulationBox: false
+        theta: 1.5353981633974487
+        unequalScaling: false
+        visibilityThreshold: 0.0
+        whiteBackground: false
+    orientation: 0
+    rightPanel:
+      gaussViolation2DGLPanel:
+        automaticScaling: true
+        scaleFactor: 1.0
+        showCoordinates: x, y, 0
+  windowHeight: 782
+  windowWidth: 1455

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -152,14 +152,15 @@ public class OccupationNumbersInTime implements Diagnostics {
 		if (steps % stepInterval == 0) {
 			Grid grid = grid_reference;
 			// Create copy and cut cone into grid
+
+			if (useGaussianWindow) {
+				grid = new GaussianConeRestrictedGrid(grid, collisionTime, collisionPosition, coneVelocity);
+			}
+			if (useTukeyWindow) {
+				grid = new TukeyConeRestrictedGrid(grid, collisionTime, collisionPosition, coneVelocity, tukeyWidth);
+			}
 			if (useCone) {
-				if (useGaussianWindow) {
-					grid = new GaussianConeRestrictedGrid(grid, collisionTime, collisionPosition, coneVelocity);
-				} else if (useTukeyWindow) {
-					grid = new TukeyConeRestrictedGrid(grid, collisionTime, collisionPosition, coneVelocity, tukeyWidth);
-				} else {
-					grid = new ConeRestrictedGrid(grid, collisionTime, collisionPosition, coneVelocity);
-				}
+				grid = new ConeRestrictedGrid(grid, collisionTime, collisionPosition, coneVelocity);
 			}
 
 			// Apply Coulomb gauge.
@@ -506,6 +507,16 @@ public class OccupationNumbersInTime implements Diagnostics {
 
 				if (isWithinCone) {
 					cells[i] = grid.getCell(i).copy();
+				} else {
+//					cells[i] = grid.getCell(i).copy();
+//					// Adjust all values by suppression factor
+//					for(int j = 0; j < grid.getNumberOfDimensions(); j++) {
+//						cells[i].getE(j).multAssign(0);
+//						cells[i].getJ(j).multAssign(0);
+//						cells[i].getU(j).multAssign(0);
+//						cells[i].getUnext(j).multAssign(0);
+//					}
+//					cells[i].getRho().multAssign(0);
 				}
 			}
 		}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -52,6 +52,11 @@ public class OccupationNumbersInTime implements Diagnostics {
 	private boolean useTukeyWindow;
 	private double tukeyWidth;
 
+	private Grid windowGrid;
+	private Grid mirrorWindowGrid;
+	private Grid gaugeMirrorWindowGrid;
+	private Grid finalWindowGrid;
+
 	private String separator = ", ";
 	private String linebreak = "\n";
 
@@ -110,6 +115,14 @@ public class OccupationNumbersInTime implements Diagnostics {
 		this.tukeyWidth = tukeyWidth;
 	}
 
+	public Grid getWindowGrid() { return windowGrid; }
+
+	public Grid getMirrorWindowGrid() { return mirrorWindowGrid; }
+
+	public Grid getGaugeMirrorWindowGrid() { return gaugeMirrorWindowGrid; }
+
+	public Grid getFinalWindowGrid() { return finalWindowGrid; }
+
 	public void initialize(Simulation s) {
 		this.s = s;
 		this.stepInterval = (int) Math.max(Math.round((timeInterval / s.getTimeStep())), 1);
@@ -163,18 +176,27 @@ public class OccupationNumbersInTime implements Diagnostics {
 				grid = new ConeRestrictedGrid(grid, collisionTime, collisionPosition, coneVelocity);
 			}
 
+			windowGrid = grid;
+
 			// Apply Coulomb gauge.
 			if(useMirroredGrid) {
 				grid = new MirroredGrid(grid, mirroredDirection);
 			} else {
 				grid = new Grid(grid);	// Copy grid.
 			}
+
+			mirrorWindowGrid = grid;
+
 			CoulombGauge coulombGauge = new CoulombGauge(grid);
 			coulombGauge.applyGaugeTransformation(grid);
+
+			gaugeMirrorWindowGrid = grid;
 
 			if(useMirroredGrid) {
 				grid = new UnmirroredGrid(grid, mirroredDirection);
 			}
+
+			finalWindowGrid = grid;
 
 			// Fill arrays for FFT.
 			double gainv = 1.0 / (grid.getLatticeSpacing() * grid.getGaugeCoupling());

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/OccupationNumbersInTime.java
@@ -48,6 +48,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 	private double collisionTime;
 	private double[] collisionPosition;
 	private double[] coneVelocity;
+	private boolean useGaussianWindow;
 
 	private String separator = ", ";
 	private String linebreak = "\n";
@@ -90,7 +91,8 @@ public class OccupationNumbersInTime implements Diagnostics {
 
 	public OccupationNumbersInTime(double timeInterval, String outputType, String filename, boolean colorful,
 								   boolean useMirroredGrid, int mirroredDirection,
-								   boolean useCone, double collisionTime, double[] collisionPosition, double[] coneVelocity) {
+								   boolean useCone, double collisionTime, double[] collisionPosition, double[] coneVelocity,
+								   boolean useGaussianWindow) {
 		this(timeInterval, outputType, filename, colorful);
 
 		this.useMirroredGrid = useMirroredGrid;
@@ -100,6 +102,7 @@ public class OccupationNumbersInTime implements Diagnostics {
 		this.collisionTime = collisionTime;
 		this.collisionPosition = collisionPosition;
 		this.coneVelocity = coneVelocity;
+		this.useGaussianWindow = useGaussianWindow;
 	}
 
 	public void initialize(Simulation s) {
@@ -145,7 +148,11 @@ public class OccupationNumbersInTime implements Diagnostics {
 			Grid grid = grid_reference;
 			// Create copy and cut cone into grid
 			if (useCone) {
-				grid = new ConeRestrictedGrid(grid, collisionTime, collisionPosition, coneVelocity);
+				if (useGaussianWindow) {
+					grid = new GaussianConeRestrictedGrid(grid, collisionTime, collisionPosition, coneVelocity);
+				} else {
+					grid = new ConeRestrictedGrid(grid, collisionTime, collisionPosition, coneVelocity);
+				}
 			}
 
 			// Apply Coulomb gauge.
@@ -493,6 +500,52 @@ public class OccupationNumbersInTime implements Diagnostics {
 				if (isWithinCone) {
 					cells[i] = grid.getCell(i).copy();
 				}
+			}
+		}
+	}
+
+	private class GaussianConeRestrictedGrid extends Grid {
+		public GaussianConeRestrictedGrid(Grid grid, double collisionTime, double[] collisionPosition, double[] coneVelocity) {
+			super(grid);
+			createGrid();
+			this.cellIterator.setNormalMode(numCells);
+
+			double two_sqrt_log_two = 2 * Math.sqrt(Math.log(2));
+
+			// Copy and mirror cells.
+			for (int i = 0; i < grid.getTotalNumberOfCells(); i++) {
+
+				int[] cellPos = grid.getCellPos(i);
+
+				// Check whether cellPos is within the cone
+				double suppressionFactor = 1;
+				for (int d = 0; d < coneVelocity.length; d++) {
+					if (coneVelocity[d] != 0) {
+						// Restriction on this axis!
+						double time = grid.getSimulationSteps() * grid.getTemporalSpacing();
+						double pos = cellPos[d] * grid.getLatticeSpacing(d);
+						double minTime = - Math.abs(time - collisionTime);
+						double maxTime = + Math.abs(time - collisionTime);
+						double minPos = minTime * coneVelocity[d] + collisionPosition[d];
+						double maxPos = maxTime * coneVelocity[d] + collisionPosition[d];
+
+						// Construct Gaussian with full width at half maximum:
+						double sigma = (maxPos - minPos) / two_sqrt_log_two;
+
+						suppressionFactor *= Math.exp(- Math.pow((pos - collisionPosition[d]) / sigma, 2));
+					}
+				}
+
+				cells[i] = grid.getCell(i).copy();
+
+				// Adjust all values by suppression factor
+				for(int j = 0; j < grid.getNumberOfDimensions(); j++) {
+					cells[i].getE(j).multAssign(suppressionFactor);
+					cells[i].getJ(j).multAssign(suppressionFactor);
+					cells[i].getU(j).multAssign(suppressionFactor);
+					cells[i].getUnext(j).multAssign(suppressionFactor);
+				}
+				cells[i].getRho().multAssign(suppressionFactor);
 			}
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/diagnostics/methods/ScreenshotInTime.java
@@ -136,6 +136,7 @@ public class ScreenshotInTime implements Diagnostics {
 		 * @param simulation  The simulation object.
 		 */
 		public SimulationAnimationDummy(Simulation simulation) {
+			super(null);  // TODO: Is this quickfix justified?
 			this.s = simulation;
 		}
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
+++ b/pixi/src/main/java/org/openpixi/pixi/physics/grid/Grid.java
@@ -504,6 +504,8 @@ public class Grid {
 
 		this.fsolver = grid.fsolver;
 		this.cellIterator = grid.cellIterator.copy();
+
+		this.simulationSteps = grid.simulationSteps;
 	}
 
 	/**

--- a/pixi/src/main/java/org/openpixi/pixi/ui/GridManager.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/GridManager.java
@@ -1,0 +1,41 @@
+package org.openpixi.pixi.ui;
+
+import org.openpixi.pixi.physics.grid.Grid;
+
+import java.util.ArrayList;
+
+/**
+ * Store list of grids
+ */
+public class GridManager {
+	ArrayList<LabeledGrid> labeledGridList = new ArrayList();
+
+	public LabeledGrid add(String label, Grid grid) {
+		LabeledGrid labeledGrid = new LabeledGrid();
+		labeledGrid.label = label;
+		labeledGrid.grid = grid;
+		labeledGridList.add(labeledGrid);
+		return labeledGrid;
+	}
+
+	public void remove(LabeledGrid labeledGrid) {
+		labeledGridList.remove(labeledGrid);
+	}
+
+	public String[] getLabelList() {
+		String[] list = new String[labeledGridList.size()];
+		for (int i = 0; i < labeledGridList.size(); i++) {
+			list[i] = labeledGridList.get(i).label;
+		}
+		return list;
+	}
+
+	public Grid getGrid(int index) {
+		return labeledGridList.get(index).grid;
+	}
+
+	public static class LabeledGrid {
+		public String label;
+		public Grid grid;
+	}
+}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/GridManager.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/GridManager.java
@@ -11,9 +11,14 @@ public class GridManager {
 	ArrayList<LabeledGrid> labeledGridList = new ArrayList();
 
 	public LabeledGrid add(String label, Grid grid) {
+		return add(label, grid, null);
+	}
+
+	public LabeledGrid add(String label, Grid grid, double[][] occupationNumbers) {
 		LabeledGrid labeledGrid = new LabeledGrid();
 		labeledGrid.label = label;
 		labeledGrid.grid = grid;
+		labeledGrid.occupationNumbers = occupationNumbers;
 		labeledGridList.add(labeledGrid);
 		return labeledGrid;
 	}
@@ -34,8 +39,13 @@ public class GridManager {
 		return labeledGridList.get(index).grid;
 	}
 
+	public double[][] getOccupationNumbers(int index) {
+		return labeledGridList.get(index).occupationNumbers;
+	}
+
 	public static class LabeledGrid {
 		public String label;
 		public Grid grid;
+		public double[][] occupationNumbers;
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
@@ -134,9 +134,7 @@ public class MainControlApplet extends JApplet
 
 		simulationAnimation = new SimulationAnimation(this);
 		panelManager = new PanelManager(this);
-		Simulation s = simulationAnimation.getSimulation();
-		gridManager = new GridManager();
-		defaultLabeledGrid = gridManager.add("Simulation", s.grid);
+		panelManager.resetGridManager();
 
 		startButton = new JButton("Start");
 		stopButton = new JButton("Stop");
@@ -209,6 +207,10 @@ public class MainControlApplet extends JApplet
 
 		panelManager.replaceMainPanel(mainPanel);
 
+	}
+
+	public void setGridManager(GridManager gridManager) {
+		this.gridManager = gridManager;
 	}
 
 	public GridManager getGridManager() {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/MainControlApplet.java
@@ -47,6 +47,8 @@ public class MainControlApplet extends JApplet
 
 	protected SimulationAnimation simulationAnimation;
 	private PanelManager panelManager;
+	private GridManager gridManager;
+	public GridManager.LabeledGrid defaultLabeledGrid;
 
 	protected PropertiesTab propertiesTab;
 	private FileTab fileTab;
@@ -130,9 +132,11 @@ public class MainControlApplet extends JApplet
 		// Set US locale for numeric output ("1.23"[US] instead of "1,23"[DE])
 		Locale.setDefault(Locale.US);
 
-		simulationAnimation = new SimulationAnimation();
+		simulationAnimation = new SimulationAnimation(this);
 		panelManager = new PanelManager(this);
 		Simulation s = simulationAnimation.getSimulation();
+		gridManager = new GridManager();
+		defaultLabeledGrid = gridManager.add("Simulation", s.grid);
 
 		startButton = new JButton("Start");
 		stopButton = new JButton("Stop");
@@ -205,6 +209,10 @@ public class MainControlApplet extends JApplet
 
 		panelManager.replaceMainPanel(mainPanel);
 
+	}
+
+	public GridManager getGridManager() {
+		return gridManager;
 	}
 
 	public void setText(JTextArea text, String str, boolean onoff)

--- a/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/PanelManager.java
@@ -13,6 +13,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
 import javax.swing.JSplitPane;
 
+import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.ui.panel.ElectricFieldPanel;
 import org.openpixi.pixi.ui.panel.EnergyDensity1DPanel;
 import org.openpixi.pixi.ui.panel.EnergyDensity2DPanel;
@@ -86,6 +87,15 @@ public class PanelManager {
 
 	public SimulationAnimation getSimulationAnimation() {
 		return mainControlApplet.simulationAnimation;
+	}
+
+	/**
+	 *
+	 */
+	public void resetGridManager() {
+		Simulation s = mainControlApplet.simulationAnimation.getSimulation();
+		mainControlApplet.setGridManager(new GridManager());
+		mainControlApplet.defaultLabeledGrid = mainControlApplet.getGridManager().add("Simulation", s.grid);
 	}
 
 	/**

--- a/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
@@ -115,7 +115,6 @@ public class SimulationAnimation {
 	private void doSimulationStep() {
 		try {
 			s.step();
-			mainControlApplet.defaultLabeledGrid.grid = s.grid;
 			if (s.totalSimulationSteps == s.getIterations()) {
 				// Stop simulation (the user can continue by hand)
 				stopAnimation();
@@ -138,6 +137,7 @@ public class SimulationAnimation {
 		// timer.restart();
 		timer.stop();
 		s = new Simulation(settings);
+		mainControlApplet.defaultLabeledGrid.grid = s.grid;
 		clear();
 		repaint();
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/SimulationAnimation.java
@@ -21,6 +21,7 @@ import org.openpixi.pixi.ui.util.FrameRateDetector;
 public class SimulationAnimation {
 
 	protected Simulation s;
+	private MainControlApplet mainControlApplet;
 
 	/** Milliseconds between updates */
 	private int interval = 30;
@@ -33,7 +34,8 @@ public class SimulationAnimation {
 	private ArrayList<SimulationAnimationListener> listeners = new ArrayList<SimulationAnimationListener>();
 
 	/** Constructor */
-	public SimulationAnimation() {
+	public SimulationAnimation(MainControlApplet mainControlApplet) {
+		this.mainControlApplet = mainControlApplet;
 		timer = new Timer(interval, new TimerListener());
 		frameratedetector = new FrameRateDetector(500);
 		Settings settings = new Settings();
@@ -69,6 +71,8 @@ public class SimulationAnimation {
 	public Simulation getSimulation() {
 		return s;
 	}
+
+	public MainControlApplet getMainControlApplet() { return mainControlApplet; }
 
 	public FrameRateDetector getFrameRateDetector() {
 		return frameratedetector;
@@ -111,6 +115,7 @@ public class SimulationAnimation {
 	private void doSimulationStep() {
 		try {
 			s.step();
+			mainControlApplet.defaultLabeledGrid.grid = s.grid;
 			if (s.totalSimulationSteps == s.getIterations()) {
 				// Stop simulation (the user can continue by hand)
 				stopAnimation();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -9,12 +9,9 @@ import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.gauge.CoulombGauge;
 import org.openpixi.pixi.physics.grid.Grid;
 import org.openpixi.pixi.physics.particles.IParticle;
+import org.openpixi.pixi.ui.GridManager;
 import org.openpixi.pixi.ui.SimulationAnimation;
-import org.openpixi.pixi.ui.panel.properties.BooleanArrayProperties;
-import org.openpixi.pixi.ui.panel.properties.BooleanProperties;
-import org.openpixi.pixi.ui.panel.properties.ColorProperties;
-import org.openpixi.pixi.ui.panel.properties.CoordinateProperties;
-import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
+import org.openpixi.pixi.ui.panel.properties.*;
 
 /**
  * This panel shows the one-dimensional electric field along the x-direction.
@@ -23,6 +20,7 @@ import org.openpixi.pixi.ui.panel.properties.ScaleProperties;
  */
 public class ElectricFieldPanel extends AnimationPanel {
 
+	public ComboBoxProperties sourceProperties;
 	public ColorProperties colorProperties;
 	public ScaleProperties scaleProperties;
 	public BooleanProperties gaugeProperties;
@@ -40,6 +38,8 @@ public class ElectricFieldPanel extends AnimationPanel {
 	public final int INDEX_ROT_E = 8;
 	public final int INDEX_ROT_B = 9;
 	public final int INDEX_ROT_B_NEXT = 10;
+
+	String[] sourceLabel = new String[] {};
 
 	String[] fieldLabel = new String[] {
 			"E",
@@ -83,14 +83,19 @@ public class ElectricFieldPanel extends AnimationPanel {
 			false
 	};
 
+	GridManager gridManager;
+
 	/** Constructor */
 	public ElectricFieldPanel(SimulationAnimation simulationAnimation) {
 		super(simulationAnimation);
+		sourceProperties = new ComboBoxProperties(simulationAnimation, "Source", sourceLabel, 0);
 		colorProperties = new ColorProperties(simulationAnimation);
 		scaleProperties = new ScaleProperties(simulationAnimation);
 		gaugeProperties = new BooleanProperties(simulationAnimation, "Coulomb gauge", false);
 		showFieldProperties = new BooleanArrayProperties(simulationAnimation, fieldLabel, fieldInit);
 		showCoordinateProperties = new CoordinateProperties(simulationAnimation, CoordinateProperties.Mode.MODE_1D_LOOP);
+
+		gridManager = simulationAnimation.getMainControlApplet().getGridManager();
 	}
 
 	/** Display the particles */
@@ -113,14 +118,19 @@ public class ElectricFieldPanel extends AnimationPanel {
 		colorProperties.checkConsistency();
 
 		Simulation s = getSimulationAnimation().getSimulation();
+
+		Grid drawGrid = s.grid;
+		int gridIndex = sourceProperties.getIndex();
+		drawGrid = gridManager.getGrid(gridIndex);
+
 		/** Scaling factor for the displayed panel in x-direction*/
-		double sx = getWidth() / s.getWidth();
+		//double sx = getWidth() / s.getWidth();
+		double sx = getWidth() / (drawGrid.getNumCells(0) * drawGrid.getLatticeSpacing(0));
 
 		double panelWidth = getWidth();
 		double panelHeight = getHeight();
 
 		boolean useCoulombGauge = gaugeProperties.getValue();
-		Grid drawGrid = s.grid;
 		if (useCoulombGauge) {
 			Grid gridCopy = new Grid(s.grid);
 			CoulombGauge coulombGauge = new CoulombGauge(gridCopy);
@@ -267,6 +277,8 @@ public class ElectricFieldPanel extends AnimationPanel {
 
 	public void addPropertyComponents(Box box) {
 		addLabel(box, "Electric field panel");
+		sourceProperties.updateEntries(gridManager.getLabelList());
+		sourceProperties.addComponents(box);
 		showFieldProperties.addComponents(box);
 		colorProperties.addComponents(box);
 		showCoordinateProperties.addComponents(box);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/ElectricFieldPanel.java
@@ -198,7 +198,8 @@ public class ElectricFieldPanel extends AnimationPanel {
 			kmin = 0;
 			kmax = drawGrid.getNumCells(loopIndex);
 		}
-		double sx = panelWidth / s.getSimulationBoxSize(abscissaIndex);
+		//double sx = panelWidth / s.getSimulationBoxSize(abscissaIndex);
+		double sx = panelWidth / (drawGrid.getNumCells(abscissaIndex) * drawGrid.getLatticeSpacing(abscissaIndex));
 		for(int k = kmin; k < kmax; k++)
 		{
 			int newPosition = 0;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -46,6 +46,7 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 	public DoubleProperties collisionTimeDoubleProperties;
 	public CoordinateProperties collisionCoordinateProperties;
 	public CoordinateProperties velocityCoordinateProperties;
+	public BooleanProperties useGaussianWindowProperties;
 
 	OccupationNumbersInTime diagnostic;
 	Simulation simulation;
@@ -58,6 +59,7 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 	private double oldCollisionTime;
 	private double[] oldCollisionPosition;
 	private double[] oldConeVelocity;
+	private boolean oldUseGaussianWindow;
 
 	/** Constructor */
 	public OccupationNumbers2DGLPanel(SimulationAnimation simulationAnimation) {
@@ -73,6 +75,7 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		collisionTimeDoubleProperties = new DoubleProperties(simulationAnimation, "Collision time:", 0.);
 		collisionCoordinateProperties = new CoordinateProperties(simulationAnimation, "Collision center:", "0, 0, 0");
 		velocityCoordinateProperties = new CoordinateProperties(simulationAnimation, "Cut cone velocity:", "0., 0., 0.");
+		useGaussianWindowProperties = new BooleanProperties(simulationAnimation, "Gaussian window", false);
 		frameCounter = 0;
 
 		simulation = this.simulationAnimation.getSimulation();
@@ -88,19 +91,22 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		double collisionTime = collisionTimeDoubleProperties.getValue();
 		double[] collisionPosition = collisionCoordinateProperties.getDoublePositions();
 		double[] coneVelocity = velocityCoordinateProperties.getDoublePositions();
+		boolean useGaussianWindow = useGaussianWindowProperties.getValue();
 
 		// Compute occupation numbers
 		if(mirrorProperties.getValue() != oldUseMirror || simulation != simulationAnimation.getSimulation()
 				|| useCone != oldUseCone
 				|| collisionTime != oldCollisionTime
 				|| ! collisionPosition.equals(oldCollisionPosition)
-				|| ! coneVelocity.equals(oldConeVelocity) ) {
+				|| ! coneVelocity.equals(oldConeVelocity)
+				|| useGaussianWindow != oldUseGaussianWindow) {
 			oldUseMirror = mirrorProperties.getValue();
 			simulation = simulationAnimation.getSimulation();
 			oldUseCone = useCone;
 			oldCollisionTime = collisionTime;
 			oldCollisionPosition = collisionPosition;
 			oldConeVelocity = coneVelocity;
+			oldUseGaussianWindow = useGaussianWindow;
 			updateDiagnostic();
 		}
 		frameSkip = (frameSkipProperties.getValue() > 1) ? frameSkipProperties.getValue() : 1;
@@ -193,12 +199,13 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		double collisionTime = collisionTimeDoubleProperties.getValue();
 		double[] collisionPosition = collisionCoordinateProperties.getDoublePositions();
 		double[] coneVelocity = velocityCoordinateProperties.getDoublePositions();
+		boolean useGaussianWindow = useGaussianWindowProperties.getValue();
 
 		boolean useMirroredGrid = mirrorProperties.getValue();
 
 		diagnostic = new OccupationNumbersInTime(1.0, "none", "", true,
 				useMirroredGrid, mirrorDirection,
-				useCone, collisionTime, collisionPosition, coneVelocity);
+				useCone, collisionTime, collisionPosition, coneVelocity, useGaussianWindow);
 		diagnostic.initialize(simulation);
 	}
 
@@ -229,5 +236,6 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		collisionTimeDoubleProperties.addComponents(box);
 		collisionCoordinateProperties.addComponents(box);
 		velocityCoordinateProperties.addComponents(box);
+		useGaussianWindowProperties.addComponents(box);
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -38,14 +38,14 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 
 	public ScaleProperties scaleProperties;
 	public BooleanProperties colorfulProperties;
-	BooleanProperties mirrorProperties;
+	public BooleanProperties mirrorProperties;
 	public IntegerProperties frameSkipProperties;
-	CoordinateProperties showCoordinateProperties;
+	public CoordinateProperties showCoordinateProperties;
 
-	BooleanProperties useConeProperties;
-	DoubleProperties collisionTimeDoubleProperties;
-	CoordinateProperties collisionCoordinateProperties;
-	CoordinateProperties velocityCoordinateProperties;
+	public BooleanProperties useConeProperties;
+	public DoubleProperties collisionTimeDoubleProperties;
+	public CoordinateProperties collisionCoordinateProperties;
+	public CoordinateProperties velocityCoordinateProperties;
 
 	OccupationNumbersInTime diagnostic;
 	Simulation simulation;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -47,6 +47,8 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 	public CoordinateProperties collisionCoordinateProperties;
 	public CoordinateProperties velocityCoordinateProperties;
 	public BooleanProperties useGaussianWindowProperties;
+	public BooleanProperties useTukeyWindowProperties;
+	public DoubleProperties tukeyWidthProperties;
 
 	OccupationNumbersInTime diagnostic;
 	Simulation simulation;
@@ -60,6 +62,8 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 	private double[] oldCollisionPosition;
 	private double[] oldConeVelocity;
 	private boolean oldUseGaussianWindow;
+	private boolean oldUseTukeyWindow;
+	private double oldTukeyWidth;
 
 	/** Constructor */
 	public OccupationNumbers2DGLPanel(SimulationAnimation simulationAnimation) {
@@ -76,6 +80,8 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		collisionCoordinateProperties = new CoordinateProperties(simulationAnimation, "Collision center:", "0, 0, 0");
 		velocityCoordinateProperties = new CoordinateProperties(simulationAnimation, "Cut cone velocity:", "0., 0., 0.");
 		useGaussianWindowProperties = new BooleanProperties(simulationAnimation, "Gaussian window", false);
+		useTukeyWindowProperties = new BooleanProperties(simulationAnimation, "Tukey window", false);
+		tukeyWidthProperties = new DoubleProperties(simulationAnimation, "Tukey width", 0.);
 		frameCounter = 0;
 
 		simulation = this.simulationAnimation.getSimulation();
@@ -92,6 +98,8 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		double[] collisionPosition = collisionCoordinateProperties.getDoublePositions();
 		double[] coneVelocity = velocityCoordinateProperties.getDoublePositions();
 		boolean useGaussianWindow = useGaussianWindowProperties.getValue();
+		boolean useTukeyWindow = useTukeyWindowProperties.getValue();
+		double tukeyWidth = tukeyWidthProperties.getValue();
 
 		// Compute occupation numbers
 		if(mirrorProperties.getValue() != oldUseMirror || simulation != simulationAnimation.getSimulation()
@@ -99,7 +107,9 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 				|| collisionTime != oldCollisionTime
 				|| ! collisionPosition.equals(oldCollisionPosition)
 				|| ! coneVelocity.equals(oldConeVelocity)
-				|| useGaussianWindow != oldUseGaussianWindow) {
+				|| useGaussianWindow != oldUseGaussianWindow
+				|| useTukeyWindow != oldUseTukeyWindow
+				|| tukeyWidth != oldTukeyWidth) {
 			oldUseMirror = mirrorProperties.getValue();
 			simulation = simulationAnimation.getSimulation();
 			oldUseCone = useCone;
@@ -107,6 +117,8 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 			oldCollisionPosition = collisionPosition;
 			oldConeVelocity = coneVelocity;
 			oldUseGaussianWindow = useGaussianWindow;
+			oldUseTukeyWindow = useTukeyWindow;
+			oldTukeyWidth = tukeyWidth;
 			updateDiagnostic();
 		}
 		frameSkip = (frameSkipProperties.getValue() > 1) ? frameSkipProperties.getValue() : 1;
@@ -200,12 +212,14 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		double[] collisionPosition = collisionCoordinateProperties.getDoublePositions();
 		double[] coneVelocity = velocityCoordinateProperties.getDoublePositions();
 		boolean useGaussianWindow = useGaussianWindowProperties.getValue();
+		boolean useTukeyWindow = useTukeyWindowProperties.getValue();
+		double tukeyWidth = tukeyWidthProperties.getValue();
 
 		boolean useMirroredGrid = mirrorProperties.getValue();
 
 		diagnostic = new OccupationNumbersInTime(1.0, "none", "", true,
 				useMirroredGrid, mirrorDirection,
-				useCone, collisionTime, collisionPosition, coneVelocity, useGaussianWindow);
+				useCone, collisionTime, collisionPosition, coneVelocity, useGaussianWindow, useTukeyWindow, tukeyWidth);
 		diagnostic.initialize(simulation);
 	}
 
@@ -237,5 +251,7 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		collisionCoordinateProperties.addComponents(box);
 		velocityCoordinateProperties.addComponents(box);
 		useGaussianWindowProperties.addComponents(box);
+		useTukeyWindowProperties.addComponents(box);
+		tukeyWidthProperties.addComponents(box);
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -140,6 +140,7 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 			gaugeMirrorLabeledGrid.grid = diagnostic.getGaugeMirrorGrid();
 			gaugeLabeledGrid.grid = diagnostic.getGaugeGrid();
 			finalLabeledGrid.grid = diagnostic.getFinalWindowGrid();
+			finalLabeledGrid.occupationNumbers = diagnostic.occupationNumbers;
 		}
 		frameCounter++;
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -29,7 +29,6 @@ import javax.media.opengl.GL;
 import javax.media.opengl.GL2;
 import javax.media.opengl.GLAutoDrawable;
 import javax.swing.*;
-import java.util.Arrays;
 
 
 /**
@@ -54,9 +53,9 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 	OccupationNumbersInTime diagnostic;
 	Simulation simulation;
 	GridManager gridManager;
-	GridManager.LabeledGrid windowLabeledGrid;
-	GridManager.LabeledGrid mirrorWindowLabeledGrid;
-	GridManager.LabeledGrid gaugeMirrorWindowLabeledGrid;
+	GridManager.LabeledGrid mirrorLabeledGrid;
+	GridManager.LabeledGrid gaugeMirrorLabeledGrid;
+	GridManager.LabeledGrid gaugeLabeledGrid;
 	GridManager.LabeledGrid finalLabeledGrid;
 
 	private int frameCounter;
@@ -95,9 +94,9 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		diagnostic.calculate(simulation.grid, simulation.particles, 0);
 
 		gridManager = simulationAnimation.getMainControlApplet().getGridManager();
-		windowLabeledGrid = gridManager.add("Occupation numbers (window)", simulation.grid);
-		mirrorWindowLabeledGrid = gridManager.add("Occupation numbers (mirror + window)", simulation.grid);
-		gaugeMirrorWindowLabeledGrid = gridManager.add("Occupation numbers (gauge + mirror + window)", simulation.grid);
+		mirrorLabeledGrid = gridManager.add("Occupation numbers (mirror)", simulation.grid);
+		gaugeMirrorLabeledGrid = gridManager.add("Occupation numbers (gauge + mirror)", simulation.grid);
+		gaugeLabeledGrid = gridManager.add("Occupation numbers (gauge)", simulation.grid);
 		finalLabeledGrid = gridManager.add("Occupation numbers (final)", simulation.grid);
 	}
 
@@ -137,9 +136,9 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		{
 			diagnostic.calculate(simulation.grid, simulation.particles, 0);
 
-			windowLabeledGrid.grid = diagnostic.getWindowGrid();
-			mirrorWindowLabeledGrid.grid = diagnostic.getMirrorWindowGrid();
-			gaugeMirrorWindowLabeledGrid.grid = diagnostic.getGaugeMirrorWindowGrid();
+			mirrorLabeledGrid.grid = diagnostic.getMirrorGrid();
+			gaugeMirrorLabeledGrid.grid = diagnostic.getGaugeMirrorGrid();
+			gaugeLabeledGrid.grid = diagnostic.getGaugeGrid();
 			finalLabeledGrid.grid = diagnostic.getFinalWindowGrid();
 		}
 		frameCounter++;
@@ -272,9 +271,9 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 
 	@Override
 	public void destruct() {
-		gridManager.remove(windowLabeledGrid);
-		gridManager.remove(mirrorWindowLabeledGrid);
-		gridManager.remove(gaugeMirrorWindowLabeledGrid);
+		gridManager.remove(gaugeLabeledGrid);
+		gridManager.remove(mirrorLabeledGrid);
+		gridManager.remove(gaugeMirrorLabeledGrid);
 		gridManager.remove(finalLabeledGrid);
 		super.destruct();
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -118,6 +118,7 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 				int xstart2 = (int)(s.grid.getLatticeSpacing() * i * sx);
 				int xstart3 = (int)(s.grid.getLatticeSpacing() * (i + 1) * sx);
 				int ystart2 = (int) (s.grid.getLatticeSpacing() * k * sy);
+				int ystart3 = (int) (s.grid.getLatticeSpacing() * (k + 1) * sy);
 
 				pos[xAxisIndex] = i;
 				pos[yAxisIndex] = k;
@@ -140,6 +141,8 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 					gl2.glColor3d( red, green, blue );
 					gl2.glVertex2f( xstart2, ystart2 );
 					gl2.glVertex2f( xstart3, ystart2 );
+					gl2.glVertex2f( xstart2, ystart3 );
+					gl2.glVertex2f( xstart3, ystart3 );
 				} else {
 					double occ = diagnostic.occupationNumbers[index][0]
 							+ diagnostic.occupationNumbers[index][1]
@@ -151,6 +154,8 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 					gl2.glColor3d( value, value, value );
 					gl2.glVertex2f( xstart2, ystart2 );
 					gl2.glVertex2f( xstart3, ystart2 );
+					gl2.glVertex2f( xstart2, ystart3 );
+					gl2.glVertex2f( xstart3, ystart3 );
 				}
 
 			}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/gl/OccupationNumbers2DGLPanel.java
@@ -21,6 +21,7 @@ package org.openpixi.pixi.ui.panel.gl;
 import org.openpixi.pixi.diagnostics.methods.OccupationNumbersInTime;
 import org.openpixi.pixi.physics.Simulation;
 import org.openpixi.pixi.physics.util.GridFunctions;
+import org.openpixi.pixi.ui.GridManager;
 import org.openpixi.pixi.ui.SimulationAnimation;
 import org.openpixi.pixi.ui.panel.properties.*;
 
@@ -52,6 +53,11 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 
 	OccupationNumbersInTime diagnostic;
 	Simulation simulation;
+	GridManager gridManager;
+	GridManager.LabeledGrid windowLabeledGrid;
+	GridManager.LabeledGrid mirrorWindowLabeledGrid;
+	GridManager.LabeledGrid gaugeMirrorWindowLabeledGrid;
+	GridManager.LabeledGrid finalLabeledGrid;
 
 	private int frameCounter;
 	private int frameSkip;
@@ -88,6 +94,11 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		updateDiagnostic();
 		diagnostic.calculate(simulation.grid, simulation.particles, 0);
 
+		gridManager = simulationAnimation.getMainControlApplet().getGridManager();
+		windowLabeledGrid = gridManager.add("Occupation numbers (window)", simulation.grid);
+		mirrorWindowLabeledGrid = gridManager.add("Occupation numbers (mirror + window)", simulation.grid);
+		gaugeMirrorWindowLabeledGrid = gridManager.add("Occupation numbers (gauge + mirror + window)", simulation.grid);
+		finalLabeledGrid = gridManager.add("Occupation numbers (final)", simulation.grid);
 	}
 
 	@Override
@@ -126,6 +137,10 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		{
 			diagnostic.calculate(simulation.grid, simulation.particles, 0);
 
+			windowLabeledGrid.grid = diagnostic.getWindowGrid();
+			mirrorWindowLabeledGrid.grid = diagnostic.getMirrorWindowGrid();
+			gaugeMirrorWindowLabeledGrid.grid = diagnostic.getGaugeMirrorWindowGrid();
+			finalLabeledGrid.grid = diagnostic.getFinalWindowGrid();
 		}
 		frameCounter++;
 
@@ -253,5 +268,14 @@ public class OccupationNumbers2DGLPanel extends AnimationGLPanel {
 		useGaussianWindowProperties.addComponents(box);
 		useTukeyWindowProperties.addComponents(box);
 		tukeyWidthProperties.addComponents(box);
+	}
+
+	@Override
+	public void destruct() {
+		gridManager.remove(windowLabeledGrid);
+		gridManager.remove(mirrorWindowLabeledGrid);
+		gridManager.remove(gaugeMirrorWindowLabeledGrid);
+		gridManager.remove(finalLabeledGrid);
+		super.destruct();
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ComboBoxProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ComboBoxProperties.java
@@ -81,6 +81,14 @@ public class ComboBoxProperties {
 		}
 	}
 
+	public void updateEntries(String[] entries) {
+		this.entries = entries;
+		if (index > entries.length) {
+			index = 0;
+		}
+
+	}
+
 	class MyListener implements ActionListener {
 		public void actionPerformed(ActionEvent eve) {
 			JComboBox cbox = (JComboBox) eve.getSource();

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ComboBoxProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/ComboBoxProperties.java
@@ -3,9 +3,6 @@ package org.openpixi.pixi.ui.panel.properties;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import javax.swing.Box;
 import javax.swing.JComboBox;
@@ -73,7 +70,7 @@ public class ComboBoxProperties {
 
 	/**
 	 * Set values according to string array provided.
-	 * @param names
+	 * @param entry
 	 */
 	public void setEntryFromString(String entry) {
 		for (int i = 0; i < entries.length; i++) {

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/CoordinateProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/CoordinateProperties.java
@@ -19,19 +19,29 @@ public class CoordinateProperties extends StringProperties {
 
 	public enum Mode {
 		MODE_1D_LOOP,
-		MODE_2D
+		MODE_2D,
+		MODE_COORDINATES
 	}
 
 	Mode mode;
 	int[] positions;
+	double[] double_positions;
 	int xAxisIndex;
 	int yAxisIndex;
 	int loopIndex;
 
 	public CoordinateProperties(SimulationAnimation simulationAnimation,
-			Mode mode) {
-		super(simulationAnimation, "Show coordinate", "");
+								String name, String initialValue) {
+		super(simulationAnimation, name, initialValue);
+		commonConstructor(Mode.MODE_COORDINATES);
+	}
 
+	public CoordinateProperties(SimulationAnimation simulationAnimation, Mode mode) {
+		super(simulationAnimation, "Show coordinate", "");
+		commonConstructor(mode);
+	}
+
+	private void commonConstructor(Mode mode) {
 		this.mode = mode;
 
 		// Construct default string:
@@ -50,6 +60,9 @@ public class CoordinateProperties extends StringProperties {
 			coordinates = "x, y, ";
 			wstart = 2;
 			break;
+		case MODE_COORDINATES:
+			// No special coordinates
+			break;
 		default:
 			break;
 		}
@@ -59,7 +72,9 @@ public class CoordinateProperties extends StringProperties {
 		}
 		coordinates = coordinates.substring(0, coordinates.length() - 2);
 
-		setValue(coordinates);
+		if (this.getValue().equals("")) {
+			setValue(coordinates);
+		}
 	}
 
 	@Override
@@ -89,8 +104,10 @@ public class CoordinateProperties extends StringProperties {
 		}
 
 		positions = new int[dimensions];
+		double_positions = new double[dimensions];
 		for(int i = 0; i < dimensions; i++) {
 			positions[i] = s.grid.getNumCells(i)/2;
+			double_positions[i] = 0;
 		}
 
 		// No loop index set
@@ -106,6 +123,11 @@ public class CoordinateProperties extends StringProperties {
 			} else {
 				try{
 					positions[i] = Integer.parseInt(indices[i].trim());
+				} catch (NumberFormatException e) {
+					// No error message - use default instead.
+				}
+				try{
+					double_positions[i] = Double.parseDouble(indices[i].trim());
 				} catch (NumberFormatException e) {
 					// No error message - use default instead.
 				}
@@ -128,4 +150,6 @@ public class CoordinateProperties extends StringProperties {
 	public int[] getPositions() {
 		return positions;
 	}
+
+	public double[] getDoublePositions() { return double_positions; }
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/DoubleProperties.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/panel/properties/DoubleProperties.java
@@ -9,7 +9,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
 /**
- * A generic text field for setting integer values.
+ * A generic text field for setting double values.
  */
 public class DoubleProperties {
 

--- a/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/tab/FileTab.java
@@ -212,6 +212,7 @@ public class FileTab extends Box {
 				parent.web.validate();
 			}
 			if (panels != null) {
+				panelManager.resetGridManager();
 				Component component = panels.inflate(panelManager);
 				if (component != null) {
 					panelManager.replaceMainPanel(component);

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlOccupationNumbersInTime.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/filegenerators/YamlOccupationNumbersInTime.java
@@ -1,5 +1,6 @@
 package org.openpixi.pixi.ui.util.yaml.filegenerators;
 import org.openpixi.pixi.diagnostics.methods.OccupationNumbersInTime;
+import java.util.List;
 
 /**
  * Yaml wrapper for the YamlParticlesInTime FileGenerator.
@@ -27,6 +28,16 @@ public class YamlOccupationNumbersInTime {
 	 */
 	public Boolean colorful = false;
 
+	public Boolean useMirroredGrid;
+	public Integer mirroredDirection;
+	public Boolean useRectangularWindow;
+	public Double collisionTime;
+	public List<Double> collisionPosition;
+	public List<Double> coneVelocity;
+	public Boolean useGaussianWindow;
+	public Boolean useTukeyWindow;
+	public Double tukeyWidth;
+
 	/**
 	 * Returns an instance of CoulombGaugeInTime according to the parameters in the YAML file.
 	 *
@@ -34,11 +45,29 @@ public class YamlOccupationNumbersInTime {
 	 */
 	public OccupationNumbersInTime getFileGenerator() {
 		OccupationNumbersInTime fileGen;
-		if(colorful != null) {
+		if (useMirroredGrid != null) {
+
+			double[] collisionPositionArray = getDoubleArray(collisionPosition);
+			double[] coneVelocityArray = getDoubleArray(coneVelocity);
+
+			fileGen = new OccupationNumbersInTime(interval, outputType, path, colorful,
+					useMirroredGrid, mirroredDirection,
+					useRectangularWindow, collisionTime, collisionPositionArray, coneVelocityArray,
+					useGaussianWindow,
+					useTukeyWindow, tukeyWidth);
+		} else if(colorful != null) {
 			fileGen = new OccupationNumbersInTime(interval, outputType, path, colorful);
 		} else {
 			fileGen = new OccupationNumbersInTime(interval, outputType, path, false);
 		}
 		return fileGen;
+	}
+
+	private double[] getDoubleArray(List<Double> list) {
+		double[] array = new double[list.size()];
+		for (int i = 0; i < list.size(); i++) {
+			array[i] = list.get(i);
+		}
+		return array;
 	}
 }

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlElectricFieldPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlElectricFieldPanel.java
@@ -21,6 +21,8 @@ public class YamlElectricFieldPanel {
 	// Coordinate properties
 	public String showCoordinates;
 
+	public Integer dataSource;
+
 	/** Empty constructor called by SnakeYaml */
 	public YamlElectricFieldPanel() {
 	}
@@ -34,6 +36,7 @@ public class YamlElectricFieldPanel {
 			scaleFactor = panel.scaleProperties.getScaleFactor();
 			automaticScaling = panel.scaleProperties.getAutomaticScaling();
 			showCoordinates = panel.showCoordinateProperties.getValue();
+			dataSource = panel.sourceProperties.getIndex();
 		}
 	}
 
@@ -63,6 +66,10 @@ public class YamlElectricFieldPanel {
 
 		if (showCoordinates != null) {
 			panel.showCoordinateProperties.setValue(showCoordinates);
+		}
+
+		if (dataSource != null) {
+			panel.sourceProperties.setIndex(dataSource);
 		}
 		return panel;
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlEnergyDensityVoxelGLPanel.java
@@ -34,6 +34,8 @@ public class YamlEnergyDensityVoxelGLPanel {
 	/** Distance of viewer */
 	public Double distanceFactor;
 
+	public Integer dataSource;
+
 	/** Empty constructor called by SnakeYaml */
 	public YamlEnergyDensityVoxelGLPanel() {
 	}
@@ -56,6 +58,7 @@ public class YamlEnergyDensityVoxelGLPanel {
 			centery = panel.centery;
 			centerz = panel.centerz;
 			distanceFactor = panel.distanceFactor;
+			dataSource = panel.sourceProperties.getIndex();
 		}
 	}
 
@@ -121,6 +124,10 @@ public class YamlEnergyDensityVoxelGLPanel {
 
 		if (distanceFactor != null) {
 			panel.distanceFactor = distanceFactor;
+		}
+
+		if (dataSource != null) {
+			panel.sourceProperties.setIndex(dataSource);
 		}
 
 		return panel;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlOccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlOccupationNumbers2DGLPanel.java
@@ -19,6 +19,13 @@ public class YamlOccupationNumbers2DGLPanel {
 	// Frame skip properties
 	public Integer frameSkip;
 
+	public String showCoordinates;
+	public Boolean mirrorX;
+	public Boolean coneRestriction;
+	public Double collisionTime;
+	public String collisionPosition;
+	public String cutConeVelocity;
+
 	/** Empty constructor called by SnakeYaml */
 	public YamlOccupationNumbers2DGLPanel() {
 	}
@@ -30,6 +37,12 @@ public class YamlOccupationNumbers2DGLPanel {
 			automaticScaling = panel.scaleProperties.getAutomaticScaling();
 			colorful = panel.colorfulProperties.getValue();
 			frameSkip = panel.frameSkipProperties.getValue();
+			showCoordinates = panel.showCoordinateProperties.getValue();
+			mirrorX = panel.mirrorProperties.getValue();
+			coneRestriction = panel.useConeProperties.getValue();
+			collisionTime = panel.collisionTimeDoubleProperties.getValue();
+			collisionPosition = panel.collisionCoordinateProperties.getValue();
+			cutConeVelocity = panel.velocityCoordinateProperties.getValue();
 		}
 	}
 
@@ -53,6 +66,29 @@ public class YamlOccupationNumbers2DGLPanel {
 			panel.frameSkipProperties.setValue(frameSkip);
 		}
 
+		if (showCoordinates != null) {
+			panel.showCoordinateProperties.setValue(showCoordinates);
+		}
+
+		if (mirrorX != null) {
+			panel.mirrorProperties.setValue(mirrorX);
+		}
+
+		if (coneRestriction != null) {
+			panel.useConeProperties.setValue(coneRestriction);
+		}
+
+		if (collisionTime != null) {
+			panel.collisionTimeDoubleProperties.setValue(collisionTime);
+		}
+
+		if (collisionPosition != null) {
+			panel.collisionCoordinateProperties.setValue(collisionPosition);
+		}
+
+		if (cutConeVelocity != null) {
+			panel.velocityCoordinateProperties.setValue(cutConeVelocity);
+		}
 
 		return panel;
 	}

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlOccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlOccupationNumbers2DGLPanel.java
@@ -26,6 +26,8 @@ public class YamlOccupationNumbers2DGLPanel {
 	public String collisionPosition;
 	public String cutConeVelocity;
 	public Boolean gaussianWindow;
+	public Boolean tukeyWindow;
+	public Double tukeyWidth;
 
 	/** Empty constructor called by SnakeYaml */
 	public YamlOccupationNumbers2DGLPanel() {
@@ -45,6 +47,8 @@ public class YamlOccupationNumbers2DGLPanel {
 			collisionPosition = panel.collisionCoordinateProperties.getValue();
 			cutConeVelocity = panel.velocityCoordinateProperties.getValue();
 			gaussianWindow = panel.useGaussianWindowProperties.getValue();
+			tukeyWindow = panel.useTukeyWindowProperties.getValue();
+			tukeyWidth = panel.tukeyWidthProperties.getValue();
 		}
 	}
 
@@ -94,6 +98,14 @@ public class YamlOccupationNumbers2DGLPanel {
 
 		if (gaussianWindow != null) {
 			panel.useGaussianWindowProperties.setValue(gaussianWindow);
+		}
+
+		if (tukeyWindow != null) {
+			panel.useTukeyWindowProperties.setValue(tukeyWindow);
+		}
+
+		if (tukeyWidth != null) {
+			panel.tukeyWidthProperties.setValue(tukeyWidth);
 		}
 
 		return panel;

--- a/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlOccupationNumbers2DGLPanel.java
+++ b/pixi/src/main/java/org/openpixi/pixi/ui/util/yaml/panels/YamlOccupationNumbers2DGLPanel.java
@@ -25,6 +25,7 @@ public class YamlOccupationNumbers2DGLPanel {
 	public Double collisionTime;
 	public String collisionPosition;
 	public String cutConeVelocity;
+	public Boolean gaussianWindow;
 
 	/** Empty constructor called by SnakeYaml */
 	public YamlOccupationNumbers2DGLPanel() {
@@ -43,6 +44,7 @@ public class YamlOccupationNumbers2DGLPanel {
 			collisionTime = panel.collisionTimeDoubleProperties.getValue();
 			collisionPosition = panel.collisionCoordinateProperties.getValue();
 			cutConeVelocity = panel.velocityCoordinateProperties.getValue();
+			gaussianWindow = panel.useGaussianWindowProperties.getValue();
 		}
 	}
 
@@ -88,6 +90,10 @@ public class YamlOccupationNumbers2DGLPanel {
 
 		if (cutConeVelocity != null) {
 			panel.velocityCoordinateProperties.setValue(cutConeVelocity);
+		}
+
+		if (gaussianWindow != null) {
+			panel.useGaussianWindowProperties.setValue(gaussianWindow);
 		}
 
 		return panel;


### PR DESCRIPTION
Add Window function for occupation numbers:

- A new sample yaml file can be found in `pixi/input/CGC/MV Model/MVModel_Occupation_numbers.yaml`
- In the occupation number panel, there are new uptions. You can choose one of the options "Use cone restriction", "Gaussian window", or "Tukey window".
- Further settings are "Collision time", "Collision center", "Cut cone velocity", and (for Tukey window) "Tukey width"
- In the electric field panel and in the energy density voxel panel, there is a new option "Source", which lets one select either "Simulation", or one of the stages of the calculation of occupation numbers, if an occupation number panel is present.
- Output to files is set by the new yaml settings in output / occupationNumbersInTime.
